### PR TITLE
Add createEvent that returns the created Event

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "test:update": "npm test -- --updateSnapshot --coverage",
     "validate": "kcd-scripts validate",
     "setup": "npm install && npm run validate -s",
-    "dtslint": "dtslint typings",
-    "precommit": "kcd-scripts pre-commit"
+    "dtslint": "dtslint typings"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:update": "npm test -- --updateSnapshot --coverage",
     "validate": "kcd-scripts validate",
     "setup": "npm install && npm run validate -s",
-    "dtslint": "dtslint typings"
+    "dtslint": "dtslint typings",
+    "precommit": "kcd-scripts pre-commit"
   },
   "husky": {
     "hooks": {

--- a/src/events.js
+++ b/src/events.js
@@ -307,11 +307,13 @@ function fireEvent(element, event) {
   return element.dispatchEvent(event)
 }
 
+const createEvent = {}
+
 Object.keys(eventMap).forEach(key => {
   const {EventType, defaultInit} = eventMap[key]
   const eventName = key.toLowerCase()
 
-  fireEvent[key] = (node, init) => {
+  createEvent[key] = (node, init) => {
     const eventInit = {...defaultInit, ...init}
     const {target: {value, files, ...targetProperties} = {}} = eventInit
     Object.assign(node, targetProperties)
@@ -331,9 +333,10 @@ Object.keys(eventMap).forEach(key => {
     }
     const window = getWindowFromNode(node)
     const EventConstructor = window[EventType] || window.Event
-    const event = new EventConstructor(eventName, eventInit)
-    return fireEvent(node, event)
+    return new EventConstructor(eventName, eventInit)
   }
+
+  fireEvent[key] = (node, init) => fireEvent(node, createEvent[key](node, init))
 })
 
 function getWindowFromNode(node) {
@@ -377,6 +380,6 @@ Object.keys(eventAliasMap).forEach(aliasKey => {
   fireEvent[aliasKey] = (...args) => fireEvent[key](...args)
 })
 
-export {fireEvent}
+export {fireEvent, createEvent}
 
 /* eslint complexity:["error", 9] */

--- a/typings/events.d.ts
+++ b/typings/events.d.ts
@@ -75,5 +75,9 @@ export type FireFunction = (element: Element | Window, event: Event) => boolean
 export type FireObject = {
   [K in EventType]: (element: Element | Window, options?: {}) => boolean
 }
+export type CreateObject = {
+  [K in EventType]: (element: Element | Window, options?: {}) => Event
+}
 
+export const createEvent: CreateObject
 export const fireEvent: FireFunction & FireObject


### PR DESCRIPTION
**What**:

Exposes a utility to create events that can be thrown by `fireEvent`. This is useful in order to have access to the source event attributes see #257

**Why**:

Some components might rely on event attributes created when the event object is created (i.e. `new Event({...eventAttributes})`).

**How**:

As suggested by @kentcdodds in #257:

```js
import {createEvent} from 'dom-testing-library'

const myEvent = createEvent.click(node, eventAttributes)
fireEvent(node, myEvent)
```

However since the event constructor depends on `window` which itself depends on the node, `createEvent` also requires the node to be passed as an argument (not very elegant I admit).

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Typescript definitions updated
- [ ] Tests: since `fireEvent` now uses `createEvent` I believe successful tests on `fireEvent` cover `createEvent`
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Pre-commit hook threw an error on Typescript definitions but I'm really not sure what's wrong, so I committed with the `--no-verify` flag.