### PR TITLE
fix(events): add selection-related properties to target

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -160,6 +160,19 @@ test('assigns target properties', () => {
   expect(node.value).toBe(value)
 })
 
+test('assigns selection-related target properties', () => {
+  const node = document.createElement('input')
+  const spy = jest.fn()
+  const value = 'ab'
+  const selectionStart = 1
+  const selectionEnd = 2
+  node.addEventListener('change', spy)
+  fireEvent.change(node, {target: {value, selectionStart, selectionEnd}})
+  expect(node.value).toBe(value)
+  expect(node.selectionStart).toBe(selectionStart)
+  expect(node.selectionEnd).toBe(selectionEnd)
+})
+
 test('assigning a value to a target that cannot have a value throws an error', () => {
   const node = document.createElement('div')
   expect(() =>

--- a/src/events.js
+++ b/src/events.js
@@ -316,7 +316,6 @@ Object.keys(eventMap).forEach(key => {
   createEvent[key] = (node, init) => {
     const eventInit = {...defaultInit, ...init}
     const {target: {value, files, ...targetProperties} = {}} = eventInit
-    Object.assign(node, targetProperties)
     if (value !== undefined) {
       setNativeValue(node, value)
     }
@@ -331,6 +330,7 @@ Object.keys(eventMap).forEach(key => {
         value: files,
       })
     }
+    Object.assign(node, targetProperties)
     const window = getWindowFromNode(node)
     const EventConstructor = window[EventType] || window.Event
     return new EventConstructor(eventName, eventInit)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
Resolves: #263 
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix that ensures that `selectionStart` and `selectionEnd` properties are added to event targets.

<!-- Why are these changes necessary? -->

**Why**: To fulfill the requirement that any property added to the `target` object when firing an event is actually added to the object

<!-- How were these changes implemented? -->

**How**: Re-ordering operations in the fire event function

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
