### PR TITLE
feat(typings): allow document to be used in fireEvent

### DIFF
--- a/typings/events.d.ts
+++ b/typings/events.d.ts
@@ -71,12 +71,21 @@ export type EventType =
   | 'transitionEnd'
   | 'doubleClick'
 
-export type FireFunction = (element: Element | Window, event: Event) => boolean
+export type FireFunction = (
+  element: Document | Element | Window,
+  event: Event,
+) => boolean
 export type FireObject = {
-  [K in EventType]: (element: Element | Window, options?: {}) => boolean
+  [K in EventType]: (
+    element: Document | Element | Window,
+    options?: {},
+  ) => boolean
 }
 export type CreateObject = {
-  [K in EventType]: (element: Element | Window, options?: {}) => Event
+  [K in EventType]: (
+    element: Document | Element | Window,
+    options?: {},
+  ) => Event
 }
 
 export const createEvent: CreateObject


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow Document type to be used in fireEvent

<!-- Why are these changes necessary? -->

**Why**:

Document is not a subtype of Element nor Window

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
