### PR TITLE
[fix] Allow any element as valid for aria-labelledby

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -197,6 +197,19 @@ test('can get elements labelled with aria-labelledby attribute', () => {
   expect(getByLabelText('Section One').id).toBe('section-one')
 })
 
+test('can get sibling elements with aria-labelledby attrib ute', () => {
+  const {getAllByLabelText} = render(`
+    <div>
+      <svg id="icon" aria-labelledby="icon-desc"></svg>
+      <span id="icon-desc">Tacos</span>
+    </div>
+  `)
+
+  const result = getAllByLabelText('Tacos')
+  expect(result).toHaveLength(1)
+  expect(result[0].id).toBe('icon')
+})
+
 test('get can get form controls by placeholder', () => {
   const {getByPlaceholderText} = render(`
     <input id="username-id" placeholder="username" />,

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -63,7 +63,7 @@ function queryAllByLabelText(
   const possibleAriaLabelElements = queryAllByText(container, text, {
     exact,
     normalizer: matchNormalizer,
-  }).filter(el => el.tagName !== 'LABEL') // don't reprocess labels
+  })
 
   const ariaLabelledElements = possibleAriaLabelElements.reduce(
     (allLabelledElements, nextLabelElement) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

See #271 for more context.

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->
It is valid to allow any element to be the label when using `aria-labelledby`, not just `<label>` elements. The current implementation in dom-testing-library restricts to `label` elements.


**How**:

<!-- Have you done all of these things?  -->
Removed a filter that restricted to `label` elements.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
