### PR TITLE
feat: add semantic html elements implicit role support to queryByRole…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@sheerun/mutationobserver-shim": "^0.3.2",
+    "aria-query": "3.0.0",
     "pretty-format": "^24.8.0",
     "wait-for-expect": "^1.2.0"
   },

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -374,6 +374,61 @@ describe('query by test id', () => {
   })
 })
 
+test('queryAllByRole returns semantic html elements', () => {
+  const {queryAllByRole} = render(`
+    <form>
+      <h1>Heading 1</h1>
+      <h2>Heading 2</h2>
+      <h3>Heading 3</h3>
+      <h4>Heading 4</h4>
+      <h5>Heading 5</h5>
+      <h6>Heading 6</h6>
+      <ol>
+        <li></li>
+        <li></li>
+      </ol>
+      <ul>
+        <li></li>
+      </ul>
+      <input>
+      <input type="text">
+      <input type="checkbox">
+      <input type="radio">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th scope="row"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr></tr>
+          <tr></tr>
+        </tbody>
+      </table>
+      <table role="grid"></table>
+      <button>Button</button>
+    </form>
+  `)
+
+  expect(queryAllByRole(/table/i)).toHaveLength(1)
+  expect(queryAllByRole(/tabl/i, {exact: false})).toHaveLength(1)
+  expect(queryAllByRole(/columnheader/i)).toHaveLength(1)
+  expect(queryAllByRole(/rowheader/i)).toHaveLength(1)
+  expect(queryAllByRole(/grid/i)).toHaveLength(1)
+  expect(queryAllByRole(/form/i)).toHaveLength(1)
+  expect(queryAllByRole(/button/i)).toHaveLength(1)
+  expect(queryAllByRole(/heading/i)).toHaveLength(6)
+  expect(queryAllByRole('list')).toHaveLength(2)
+  expect(queryAllByRole(/listitem/i)).toHaveLength(3)
+  expect(queryAllByRole(/textbox/i)).toHaveLength(2)
+  expect(queryAllByRole(/checkbox/i)).toHaveLength(1)
+  expect(queryAllByRole(/radio/i)).toHaveLength(1)
+  expect(queryAllByRole('row')).toHaveLength(3)
+  expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
+  expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
+})
+
 test('getAll* matchers return an array', () => {
   const {
     getAllByAltText,

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,6 +1,74 @@
-import {queryAllByAttribute, buildQueries} from './all-utils'
+import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
+import {elementRoles} from 'aria-query'
 
-const queryAllByRole = queryAllByAttribute.bind(null, 'role')
+function buildElementRoleList(elementRolesMap) {
+  function makeElementSelector({name, attributes = []}) {
+    return `${name}${attributes
+      .map(({name: attributeName, value}) => `[${attributeName}=${value}]`)
+      .join('')}`
+  }
+
+  function getSelectorSpecificity({attributes = []}) {
+    return attributes.length
+  }
+
+  function bySelectorSpecificity(
+    {specificity: leftSpecificity},
+    {specificity: rightSpecificity},
+  ) {
+    return rightSpecificity - leftSpecificity
+  }
+
+  let result = []
+
+  for (const [element, roles] of elementRolesMap.entries()) {
+    result = [
+      ...result,
+      {
+        selector: makeElementSelector(element),
+        roles: Array.from(roles),
+        specificity: getSelectorSpecificity(element),
+      },
+    ]
+  }
+
+  return result.sort(bySelectorSpecificity)
+}
+
+const elementRoleList = buildElementRoleList(elementRoles)
+
+function queryAllByRole(
+  container,
+  role,
+  {exact = true, collapseWhitespace, trim, normalizer} = {},
+) {
+  const matcher = exact ? matches : fuzzyMatches
+  const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
+
+  function getImplicitAriaRole(currentNode) {
+    for (const {selector, roles} of elementRoleList) {
+      if (currentNode.matches(selector)) {
+        return [...roles]
+      }
+    }
+
+    return []
+  }
+
+  return Array.from(container.querySelectorAll('*')).filter(node => {
+    const isRoleSpecifiedExplicitly = node.hasAttribute('role')
+
+    if (isRoleSpecifiedExplicitly) {
+      return matcher(node.getAttribute('role'), node, role, matchNormalizer)
+    }
+
+    const implicitRoles = getImplicitAriaRole(node)
+
+    return implicitRoles.some(implicitRole =>
+      matcher(implicitRole, node, role, matchNormalizer),
+    )
+  })
+}
 
 const getMultipleError = (c, id) => `Found multiple elements by [role=${id}]`
 const getMissingError = (c, id) => `Unable to find an element by [role=${id}]`


### PR DESCRIPTION
…/getByRole selectors (#262)

* Add aria-query library as a dependency

* Extend queryByRole to use aria-query ARIA roles to identify semantic HTML elements

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: `queryAllByRole` function has been extended to find semantic HTML elements by role. So users don't need to anymore explicitly specify `role` attributes to find elements.

<!-- Why are these changes necessary? -->

**Why**: It makes dom-testing-library more convenient to use.

<!-- How were these changes implemented? -->

**How**: `queryAllByRole` function has been extended to find HTML elements based on HTML element names and attributes. `aria-query` library has been used for get elements-role mapping. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Typescript definitions updated (there was no API change)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
