### PR TITLE
fix: support jsdom detached fragments

### DIFF
--- a/src/__node_tests__/index.js
+++ b/src/__node_tests__/index.js
@@ -47,3 +47,32 @@ test('works without a global dom', async () => {
   const data = JSON.parse(submittedDataPre.textContent)
   expect(data).toEqual(fakeUser)
 })
+
+test('works without a browser context on a dom node (JSDOM Fragment)', () => {
+  const container = JSDOM.fragment(`
+    <html>
+      <body>
+        <form id="login-form">
+          <label for="username">Username</label>
+          <input id="username" />
+          <label for="password">Password</label>
+          <input id="password" type="password" />
+          <button type="submit">Submit</button>
+          <div id="data-container"></div>
+        </form>
+      </body>
+    </html>
+  `)
+
+  expect(dtl.getByLabelText(container, /username/i)).toMatchInlineSnapshot(`
+    <input
+      id="username"
+    />
+  `)
+  expect(dtl.getByLabelText(container, /password/i)).toMatchInlineSnapshot(`
+    <input
+      id="password"
+      type="password"
+    />
+  `)
+})

--- a/src/events.js
+++ b/src/events.js
@@ -344,7 +344,7 @@ function getWindowFromNode(node) {
   if (node.defaultView) {
     // node is document
     return node.defaultView
-  } else if (node.ownerDocument) {
+  } else if (node.ownerDocument && node.ownerDocument.defaultView) {
     // node is a DOM node
     return node.ownerDocument.defaultView
   } else if (node.window) {

--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -1,4 +1,7 @@
+// Constant node.nodeType for text nodes, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
 const TEXT_NODE = 3
+
 function getNodeText(node) {
   if (node.matches('input[type=submit], input[type=button]')) {
     return node.value

--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -1,15 +1,11 @@
+const TEXT_NODE = 3
 function getNodeText(node) {
-  const window = node.ownerDocument.defaultView
-
   if (node.matches('input[type=submit], input[type=button]')) {
     return node.value
   }
 
   return Array.from(node.childNodes)
-    .filter(
-      child =>
-        child.nodeType === window.Node.TEXT_NODE && Boolean(child.textContent),
-    )
+    .filter(child => child.nodeType === TEXT_NODE && Boolean(child.textContent))
     .map(c => c.textContent)
     .join('')
 }


### PR DESCRIPTION
**What**:
This PR builds on top of https://github.com/testing-library/dom-testing-library/commit/c4b4efffb19233e1cca9799544e7ab016b3bd916 and adds support for using the [`JSDOM.fragment`](https://github.com/jsdom/jsdom#fragment) API for server side tests.

**Why**:

I think using the JSDOM.fragment API makes sense for SSR only tests. In theory if there was client side logic you would instead be running these tests in a browser context.

With this fragment API there is no `window`, which caused the existing jsdom test to break.
My current thinking is that for SSR tests you really shouldn't be testing events and what not, instead use a browser test for that. Using the fragment API outputs a sane error if you try to do so, while still supporting the same API for everything else.

**How**:

I've made a couple small changes that account for the scenario when the DOM is not in a browser context.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged

