### PR TITLE
fix: various event defaults

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -23,7 +23,7 @@ const eventMap = {
   },
   compositionUpdate: {
     EventType: 'CompositionEvent',
-    defaultInit: {bubbles: true, cancelable: false},
+    defaultInit: {bubbles: true, cancelable: true},
   },
   // Keyboard Events
   keyDown: {

--- a/src/events.js
+++ b/src/events.js
@@ -57,8 +57,8 @@ const eventMap = {
   },
   // Form Events
   change: {
-    EventType: 'InputEvent',
-    defaultInit: {bubbles: true, cancelable: true},
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: false},
   },
   input: {
     EventType: 'InputEvent',

--- a/src/events.js
+++ b/src/events.js
@@ -123,7 +123,7 @@ const eventMap = {
   },
   mouseEnter: {
     EventType: 'MouseEvent',
-    defaultInit: {bubbles: true, cancelable: true},
+    defaultInit: {bubbles: false, cancelable: false},
   },
   mouseLeave: {
     EventType: 'MouseEvent',

--- a/src/events.js
+++ b/src/events.js
@@ -127,7 +127,7 @@ const eventMap = {
   },
   mouseLeave: {
     EventType: 'MouseEvent',
-    defaultInit: {bubbles: true, cancelable: true},
+    defaultInit: {bubbles: false, cancelable: false},
   },
   mouseMove: {
     EventType: 'MouseEvent',

--- a/src/events.js
+++ b/src/events.js
@@ -62,7 +62,7 @@ const eventMap = {
   },
   input: {
     EventType: 'InputEvent',
-    defaultInit: {bubbles: true, cancelable: true},
+    defaultInit: {bubbles: true, cancelable: false},
   },
   invalid: {
     EventType: 'Event',


### PR DESCRIPTION
**What**:

Fix defaults for various events following

**Why**:

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
- https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionupdate_event
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event
- https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event
- https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event

**How**:

Using https://developer.mozilla.org/en-US/docs/Web/Events

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- ~[ ] Typescript definitions updated~
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
