### PR TITLE
test: add tests for get-node-text

### DIFF
--- a/src/__tests__/get-node-text.js
+++ b/src/__tests__/get-node-text.js
@@ -1,0 +1,17 @@
+import {getNodeText} from '../get-node-text'
+import {render} from './helpers/test-utils'
+
+test('it prints out the text content of a container', () => {
+  const {container} = render('Hello <!--skipped-->World!')
+  expect(getNodeText(container)).toMatchInlineSnapshot(`"Hello World!"`)
+})
+
+test('it prints the value for submit and button inputs', () => {
+  const {container} = render(
+    '<input type="submit" value="save"><input type="button" value="reset">',
+  )
+
+  expect(getNodeText(container.firstChild)).toMatchInlineSnapshot(`"save"`)
+
+  expect(getNodeText(container.lastChild)).toMatchInlineSnapshot(`"reset"`)
+})


### PR DESCRIPTION
**What**:

Currently looks like the `getNodeText` helper is only tested indirectly.

**How**:

I created a new test file for `getNodeText` with the expected behavior.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated "N/A"
- [x] Tests
- [x] Ready to be merged
