### PR TITLE
fix: Fix setImmediate issue when using with Cypress.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,11 +9,9 @@ function setImmediatePolyfill(fn) {
 }
 
 // istanbul ignore next
-const {
-  setTimeout,
-  clearTimeout,
-  setImmediate = setImmediatePolyfill,
-} = globalObj
+const clearTimeoutFn = globalObj.clearTimeout
+const setImmediateFn = globalObj.setImmediate || setImmediatePolyfill
+const setTimeoutFn = globalObj.setTimeout
 
 function newMutationObserver(onMutation) {
   const MutationObserverConstructor =
@@ -36,7 +34,7 @@ function getDocument() {
 export {
   getDocument,
   newMutationObserver,
-  setImmediate,
-  setTimeout,
-  clearTimeout,
+  clearTimeoutFn as clearTimeout,
+  setImmediateFn as setImmediate,
+  setTimeoutFn as setTimeout,
 }


### PR DESCRIPTION
This is a fix for this issue - https://github.com/testing-library/dom-testing-library/issues/315.

**Checklist**:

- [x] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Typescript definitions updated N/A
- [x] Tests N/A? I'm not sure how to test this. I assume it's not caught in `@testing-library/cypress` because it's tested against an older version.
- [x] Ready to be merged
