### PR TITLE
Fix getByRole('link') not returning anchor elements

### DIFF
--- a/src/__tests__/__snapshots__/role-helpers.js.snap
+++ b/src/__tests__/__snapshots__/role-helpers.js.snap
@@ -8,6 +8,14 @@ exports[`logRoles calls console.log with output from prettyRoles 1`] = `
 />
 
 --------------------------------------------------
+link:
+
+<a
+  data-testid="a-link"
+  href="http://whatever.com"
+/>
+
+--------------------------------------------------
 navigation:
 
 <nav

--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -6,6 +6,9 @@ afterEach(cleanup)
 function setup() {
   const {getByTestId} = render(`
 <section data-testid='a-section'>
+  <a href="http://whatever.com" data-testid="a-link">link</a>
+  <a>invalid link</a>
+
   <nav data-testid='a-nav' />
   
   <h1 data-testid='a-h1'>Main Heading</h1>
@@ -54,6 +57,7 @@ function setup() {
 
   return {
     section: getByTestId('a-section'),
+    anchor: getByTestId('a-link'),
     h1: getByTestId('a-h1'),
     h2: getByTestId('a-h2'),
     h3: getByTestId('a-h3'),
@@ -85,6 +89,7 @@ function setup() {
 test('getRoles returns expected roles for various dom nodes', () => {
   const {
     section,
+    anchor,
     h1,
     h2,
     h3,
@@ -113,6 +118,7 @@ test('getRoles returns expected roles for various dom nodes', () => {
   } = setup()
 
   expect(getRoles(section)).toEqual({
+    link: [anchor],
     region: [section],
     heading: [h1, h2, h3],
     navigation: [nav],

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -16,7 +16,9 @@ function getImplicitAriaRoles(currentNode) {
 function buildElementRoleList(elementRolesMap) {
   function makeElementSelector({name, attributes = []}) {
     return `${name}${attributes
-      .map(({name: attributeName, value}) => `[${attributeName}=${value}]`)
+      .map(({name: attributeName, value}) =>
+        value ? `[${attributeName}=${value}]` : `[${attributeName}]`,
+      )
       .join('')}`
   }
 


### PR DESCRIPTION
**What**:

This PR tries to close #313 😇 

**Why**:

`getByRole('link')` wasn't returning valid anchor elements (read: anchors with `href` attribute).

**How**:

I simply check if `value` is set, and change the return format accordingly. I kept it simple and readable, feel free to suggest some JavaScript calisthenics to improve the resulting function!

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged
   

I discovered that only `<a>` and `<area>` suffer from "value-less" attributes. Following is an output of elements provided by `aria-query` and their associated attribute array:

![imatge](https://user-images.githubusercontent.com/9197791/61145768-91f2a400-a4d8-11e9-9191-86408e706507.png)


Thanks! 👋 
