### PR TITLE
fix: getByRole error message, when there are no available roles

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -88,7 +88,7 @@ test('get throws a useful error message', () => {
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an element with the role "LucyRicardo"
 
-Here are the available roles:
+There are no available roles.
 
 <div>
   <div />

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -20,3 +20,16 @@ Here are the available roles:
 </div>"
 `)
 })
+
+test('logs error when there are no available roles', () => {
+  const {getByRole} = render('<div />')
+  expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "article"
+
+There are no available roles.
+
+<div>
+  <div />
+</div>"
+`)
+})

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -26,16 +26,26 @@ function queryAllByRole(
 
 const getMultipleError = (c, role) =>
   `Found multiple elements with the role "${role}"`
-const getMissingError = (container, role) =>
-  `
-Unable to find an element with the role "${role}"
 
+const getMissingError = (container, role) => {
+  const roles = prettyRoles(container)
+  let roleMessage
+
+  if (roles.length === 0) {
+    roleMessage = 'There are no available roles.'
+  } else {
+    roleMessage = `
 Here are the available roles:
 
-  ${prettyRoles(container)
-    .replace(/\n/g, '\n  ')
-    .replace(/\n\s\s\n/g, '\n\n')}
+  ${roles.replace(/\n/g, '\n  ').replace(/\n\s\s\n/g, '\n\n')}
 `.trim()
+  }
+
+  return `
+Unable to find an element with the role "${role}"
+
+${roleMessage}`.trim()
+}
 
 const [
   queryByRole,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added an error message when there are no available roles.

<!-- Why are these changes necessary? -->

**Why**:

Solves #328.

When unable to locate a role, an error message prints listing the available roles. When there are no available roles, the same message would print without a list of roles. This behavior is confusing/misleading to users.
<!-- How were these changes implemented? -->

**How**:

When the length of the string returned by `prettyRoles` is 0, we know there are no roles to be listed. The error message then changes based on that condition.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
