### PR TITLE
fix: explicitly mention `Matcher` type in `BoundFunction` TS type

### DIFF
--- a/typings/get-queries-for-element.d.ts
+++ b/typings/get-queries-for-element.d.ts
@@ -4,12 +4,12 @@ import * as queries from './queries'
 export type BoundFunction<T> = T extends (
   attribute: string,
   element: HTMLElement,
-  text: infer P,
+  text: Matcher,
   options: infer Q,
 ) => infer R
-  ? (text: P, options?: Q) => R
-  : T extends (a1: any, text: infer P, options: infer Q) => infer R
-  ? (text: P, options?: Q) => R
+  ? (text: Matcher, options?: Q) => R
+  : T extends (a1: any, text: Matcher, options: infer Q) => infer R
+  ? (text: Matcher, options?: Q) => R
   : never
 export type BoundFunctions<T> = {[P in keyof T]: BoundFunction<T[P]>}
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Changing typescript type definitions for `BoundFunction` to not infer the type of the `text` property anymore but explicitly reference the type `Matcher` instead.

<!-- Why are these changes necessary? -->

**Why**:

Using [testcafe-testing-library](https://github.com/testing-library/testcafe-testing-library) along with typescripts creates a typing error.

This seems to be due to wrongly inferred types.

<img width="919" alt="Screenshot 2019-08-06 at 16 30 16" src="https://user-images.githubusercontent.com/4592406/62550097-ee43ac00-b869-11e9-9f16-a456729637da.png">
<img width="696" alt="Screenshot 2019-08-06 at 16 29 52" src="https://user-images.githubusercontent.com/4592406/62548905-d79c5580-b867-11e9-9721-b00eb0cd628d.png">

In the image above you can see, that the `text` property should be of type `SelectorMatcherOptions | undefined` and the `options` type is unknown which is both wrong.

It should be
```typescript
(text: Matcher, options?: SelectorMatcherOptions | undefined) => Selector
```
I think this is a regression from #139 

<!-- How were these changes implemented? -->

**How**:

Removing type inference and use `Matcher` type explicitly. I did not find a case where text is not of type `Matcher`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Typescript definitions updated
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Additional Comment**
I tried to validate the types by using `npm run dtslint` but it fails for typescript 2.8. Also the master branch is failing for me. Can someone validate if this is true or if it is an issue on my machine.