### PR TITLE
Add asyncUtilTimeout to config to allow custom default async timeout

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@
 // './queries' are query functions.
 let config = {
   testIdAttribute: 'data-testid',
+  asyncUtilTimeout: 4500,
   // this is to support React's async `act` function.
   // forcing react-testing-library to wrap all async functions would've been
   // a total nightmare (consider wrapping every findBy* query and then also

--- a/src/wait-for-dom-change.js
+++ b/src/wait-for-dom-change.js
@@ -9,7 +9,7 @@ import {getConfig} from './config'
 
 function waitForDomChange({
   container = getDocument(),
-  timeout = 4500,
+  timeout = getConfig().asyncUtilTimeout,
   mutationObserverOptions = {
     subtree: true,
     childList: true,

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -11,7 +11,7 @@ function waitForElementToBeRemoved(
   callback,
   {
     container = getDocument(),
-    timeout = 4500,
+    timeout = getConfig().asyncUtilTimeout,
     mutationObserverOptions = {
       subtree: true,
       childList: true,

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -11,7 +11,7 @@ function waitForElement(
   callback,
   {
     container = getDocument(),
-    timeout = 4500,
+    timeout = getConfig().asyncUtilTimeout,
     mutationObserverOptions = {
       subtree: true,
       childList: true,

--- a/src/wait.js
+++ b/src/wait.js
@@ -1,7 +1,7 @@
 import waitForExpect from 'wait-for-expect'
 import {getConfig} from './config'
 
-function wait(callback = () => {}, {timeout = 4500, interval = 50} = {}) {
+function wait(callback = () => {}, {timeout = getConfig().asyncUtilTimeout, interval = 50} = {}) {
   return waitForExpect(callback, timeout, interval)
 }
 


### PR DESCRIPTION
**What**:

Add a new config value called `asyncUtilTimeout` to allow users to adjust the default timeout for the async utils. 

**Why**:

There doesn't seem to be a nice way to change all of the async utils to use something other than `4500` timeout by default. This is useful for those who have changed the default jest timeout that the `4500` value was intended to be used with.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged