### PR TITLE
feat(byRole): Exclude inaccessible elements

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -86,7 +86,7 @@ test('get throws a useful error message', () => {
 </div>"
 `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "LucyRicardo"
+"Unable to find an accessible element with the role "LucyRicardo"
 
 There are no accessible roles.
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -88,7 +88,7 @@ test('get throws a useful error message', () => {
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "LucyRicardo"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div />

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -86,9 +86,9 @@ test('get throws a useful error message', () => {
 </div>"
 `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "LucyRicardo"
+"Unable to find an accessible  element with the role "LucyRicardo"
 
-There are no available roles.
+There are no accessible roles.
 
 <div>
   <div />

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -26,7 +26,7 @@ test('logs error when there are no available roles', () => {
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "article"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div />
@@ -40,7 +40,7 @@ test('by default excludes elements that have the html hidden attribute or any of
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "list"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div
@@ -60,7 +60,7 @@ test('by default excludes elements which have display: none or any of their pare
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "list"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div
@@ -80,7 +80,7 @@ test('by default excludes elements which have visibility hidden', () => {
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "list"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div
@@ -104,7 +104,7 @@ test('by default excludes elements which have aria-hidden="true" or any of their
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "list"
 
-There are no accessible roles.
+There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
 <div>
   <div

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -3,9 +3,9 @@ import {render} from './helpers/test-utils'
 test('logs available roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "article"
+"Unable to find an accessible  element with the role "article"
 
-Here are the available roles:
+Here are the accessible roles:
 
   heading:
 
@@ -24,9 +24,9 @@ Here are the available roles:
 test('logs error when there are no available roles', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "article"
+"Unable to find an accessible  element with the role "article"
 
-There are no available roles.
+There are no accessible roles.
 
 <div>
   <div />
@@ -38,15 +38,9 @@ test('by default excludes elements that have the html hidden attribute or any of
   const {getByRole} = render('<div hidden><ul /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "list"
+"Unable to find an accessible  element with the role "list"
 
-Here are the available roles:
-
-  list:
-
-  <ul />
-
-  --------------------------------------------------
+There are no accessible roles.
 
 <div>
   <div
@@ -64,17 +58,9 @@ test('by default excludes elements which have display: none or any of their pare
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "list"
+"Unable to find an accessible  element with the role "list"
 
-Here are the available roles:
-
-  list:
-
-  <ul
-    style="display: block;"
-  />
-
-  --------------------------------------------------
+There are no accessible roles.
 
 <div>
   <div
@@ -92,15 +78,9 @@ test('by default excludes elements which have visibility hidden', () => {
   const {getByRole} = render('<div style="visibility: hidden;"><ul /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "list"
+"Unable to find an accessible  element with the role "list"
 
-Here are the available roles:
-
-  list:
-
-  <ul />
-
-  --------------------------------------------------
+There are no accessible roles.
 
 <div>
   <div
@@ -122,17 +102,9 @@ test('by default excludes elements which have aria-hidden="true" or any of their
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "list"
+"Unable to find an accessible  element with the role "list"
 
-Here are the available roles:
-
-  list:
-
-  <ul
-    aria-hidden="false"
-  />
-
-  --------------------------------------------------
+There are no accessible roles.
 
 <div>
   <div

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -3,7 +3,7 @@ import {render} from './helpers/test-utils'
 test('logs available roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "article"
+"Unable to find an accessible element with the role "article"
 
 Here are the accessible roles:
 
@@ -24,7 +24,7 @@ Here are the accessible roles:
 test('logs error when there are no available roles', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "article"
+"Unable to find an accessible element with the role "article"
 
 There are no accessible roles.
 
@@ -38,7 +38,7 @@ test('by default excludes elements that have the html hidden attribute or any of
   const {getByRole} = render('<div hidden><ul /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "list"
+"Unable to find an accessible element with the role "list"
 
 There are no accessible roles.
 
@@ -58,7 +58,7 @@ test('by default excludes elements which have display: none or any of their pare
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "list"
+"Unable to find an accessible element with the role "list"
 
 There are no accessible roles.
 
@@ -78,7 +78,7 @@ test('by default excludes elements which have visibility hidden', () => {
   const {getByRole} = render('<div style="visibility: hidden;"><ul /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "list"
+"Unable to find an accessible element with the role "list"
 
 There are no accessible roles.
 
@@ -102,7 +102,7 @@ test('by default excludes elements which have aria-hidden="true" or any of their
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible  element with the role "list"
+"Unable to find an accessible element with the role "list"
 
 There are no accessible roles.
 

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -164,7 +164,7 @@ test('considers the computed visibility style not the parent', () => {
   // the following markup. This behavior might change depending on how
   // https://github.com/w3c/aria/issues/1055 is resolved.
   const {getByRole} = render(
-    '<div style="visibility: hidden;"><ul style="visibility: visible;" /></div>',
+    '<div style="visibility: hidden;"><main style="visibility: visible;"><ul /></main></div>',
   )
 
   expect(getByRole('list')).not.toBeNull()

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -33,3 +33,127 @@ There are no available roles.
 </div>"
 `)
 })
+
+test('by default excludes elements that have the html hidden attribute or any of their parents', () => {
+  const {getByRole} = render('<div hidden><ul /></div>')
+
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "list"
+
+Here are the available roles:
+
+  list:
+
+  <ul />
+
+  --------------------------------------------------
+
+<div>
+  <div
+    hidden=""
+  >
+    <ul />
+  </div>
+</div>"
+`)
+})
+
+test('by default excludes elements which have display: none or any of their parents', () => {
+  const {getByRole} = render(
+    '<div style="display: none;"><ul style="display: block;" /></div>',
+  )
+
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "list"
+
+Here are the available roles:
+
+  list:
+
+  <ul
+    style="display: block;"
+  />
+
+  --------------------------------------------------
+
+<div>
+  <div
+    style="display: none;"
+  >
+    <ul
+      style="display: block;"
+    />
+  </div>
+</div>"
+`)
+})
+
+test('by default excludes elements which have visibility hidden', () => {
+  const {getByRole} = render('<div style="visibility: hidden;"><ul /></div>')
+
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "list"
+
+Here are the available roles:
+
+  list:
+
+  <ul />
+
+  --------------------------------------------------
+
+<div>
+  <div
+    style="visibility: hidden;"
+  >
+    <ul />
+  </div>
+</div>"
+`)
+})
+
+test('by default excludes elements which have aria-hidden="true" or any of their parents', () => {
+  // > if it, or any of its ancestors [...] have their aria-hidden attribute value set to true.
+  // -- https://www.w3.org/TR/wai-aria/#aria-hidden
+  // > In other words, aria-hidden="true" on a parent overrides aria-hidden="false" on descendants.
+  // -- https://www.w3.org/TR/core-aam-1.1/#exclude_elements2
+  const {getByRole} = render(
+    '<div aria-hidden="true"><ul aria-hidden="false" /></div>',
+  )
+
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "list"
+
+Here are the available roles:
+
+  list:
+
+  <ul
+    aria-hidden="false"
+  />
+
+  --------------------------------------------------
+
+<div>
+  <div
+    aria-hidden="true"
+  >
+    <ul
+      aria-hidden="false"
+    />
+  </div>
+</div>"
+`)
+})
+
+test('considers the computed visibility style not the parent', () => {
+  // this behavior deviates from the spec which includes "any descendant"
+  // if visibility is hidden. However, chrome a11y tree and nvda will include
+  // the following markup. This behavior might change depending on how
+  // https://github.com/w3c/aria/issues/1055 is resolved.
+  const {getByRole} = render(
+    '<div style="visibility: hidden;"><ul style="visibility: visible;" /></div>',
+  )
+
+  expect(getByRole('list')).not.toBeNull()
+})

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -1,6 +1,6 @@
 import {render} from './helpers/test-utils'
 
-test('logs available roles when it fails', () => {
+test('by default logs accessible roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "article"
@@ -21,12 +21,52 @@ Here are the accessible roles:
 `)
 })
 
-test('logs error when there are no available roles', () => {
+test('when hidden: true logs available roles when it fails', () => {
+  const {getByRole} = render(`<div hidden><h1>Hi</h1></div>`)
+  expect(() => getByRole('article', {hidden: true}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "article"
+
+Here are the available roles:
+
+  heading:
+
+  <h1 />
+
+  --------------------------------------------------
+
+<div>
+  <div
+    hidden=""
+  >
+    <h1>
+      Hi
+    </h1>
+  </div>
+</div>"
+`)
+})
+
+test('logs error when there are no accessible roles', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "article"
 
 There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+
+<div>
+  <div />
+</div>"
+`)
+})
+
+test('logs a different error if inaccessible roles should be included', () => {
+  const {getByRole} = render('<div />')
+  expect(() => getByRole('article', {hidden: true}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an element with the role "article"
+
+There are no available roles.
 
 <div>
   <div />
@@ -128,4 +168,14 @@ test('considers the computed visibility style not the parent', () => {
   )
 
   expect(getByRole('list')).not.toBeNull()
+})
+
+test('can include inaccessible roles', () => {
+  // this behavior deviates from the spec which includes "any descendant"
+  // if visibility is hidden. However, chrome a11y tree and nvda will include
+  // the following markup. This behavior might change depending on how
+  // https://github.com/w3c/aria/issues/1055 is resolved.
+  const {getByRole} = render('<div hidden><ul  /></div>')
+
+  expect(getByRole('list', {hidden: true})).not.toBeNull()
 })

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -43,7 +43,10 @@ const getMissingError = (container, role, {hidden = false} = {}) => {
 
   if (roles.length === 0) {
     if (hidden === false) {
-      roleMessage = 'There are no accessible roles.'
+      roleMessage =
+        'There are no accessible roles. But there might be some inaccessible roles. ' +
+        'If you wish to access them, then set the `hidden` option to `true`. ' +
+        'Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole'
     } else {
       roleMessage = 'There are no available roles.'
     }

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -58,7 +58,7 @@ Here are the ${hidden === false ? 'accessible' : 'available'} roles:
   return `
 Unable to find an ${
     hidden === false ? 'accessible ' : ''
-  } element with the role "${role}"
+  }element with the role "${role}"
 
 ${roleMessage}`.trim()
 }

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,27 +1,86 @@
 import {getImplicitAriaRoles, prettyRoles} from '../role-helpers'
 import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
 
+/**
+ * Partial implementation https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
+ * which should only be used for elements with a non-presentational role i.e.
+ * `role="none"` and `role="presentation"` will not be excluded.
+ *
+ * Implements aria-hidden semantics (i.e. parent overrides child)
+ * Ignores "Child Presentational: True" characteristics
+ *
+ * @param {Element} element -
+ * @returns {boolean} true if excluded, otherwise false
+ */
+function shouldExcludeFromA11yTree(element) {
+  const computedStyle = window.getComputedStyle(element)
+  // since visibility is inherited we can exit early
+  if (computedStyle.visibility === 'hidden') {
+    return true
+  }
+
+  // Remove once https://github.com/jsdom/jsdom/issues/2616 is fixed
+  const supportsStyleInheritance = computedStyle.visibility !== ''
+  let visibility = computedStyle.visibility
+
+  let currentElement = element
+  while (currentElement !== null) {
+    if (currentElement.hasAttribute('hidden')) {
+      return true
+    }
+
+    if (currentElement.getAttribute('aria-hidden') === 'true') {
+      return true
+    }
+
+    const currentComputedStyle = window.getComputedStyle(currentElement)
+
+    if (currentComputedStyle.display === 'none') {
+      return true
+    }
+
+    if (supportsStyleInheritance === false) {
+      // we go bottom-up for an inheritable property so we can only set it
+      // if it wasn't set already i.e. the parent can't overwrite the child
+      if (visibility === '') visibility = currentComputedStyle.visibility
+      if (visibility === 'hidden') {
+        return true
+      }
+    }
+
+    currentElement = currentElement.parentElement
+  }
+
+  return false
+}
+
 function queryAllByRole(
   container,
   role,
-  {exact = true, collapseWhitespace, trim, normalizer} = {},
+  {exact = true, collapseWhitespace, hidden = false, trim, normalizer} = {},
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
 
-  return Array.from(container.querySelectorAll('*')).filter(node => {
-    const isRoleSpecifiedExplicitly = node.hasAttribute('role')
+  return Array.from(container.querySelectorAll('*'))
+    .filter(element => {
+      return hidden === false
+        ? shouldExcludeFromA11yTree(element) === false
+        : true
+    })
+    .filter(node => {
+      const isRoleSpecifiedExplicitly = node.hasAttribute('role')
 
-    if (isRoleSpecifiedExplicitly) {
-      return matcher(node.getAttribute('role'), node, role, matchNormalizer)
-    }
+      if (isRoleSpecifiedExplicitly) {
+        return matcher(node.getAttribute('role'), node, role, matchNormalizer)
+      }
 
-    const implicitRoles = getImplicitAriaRoles(node)
+      const implicitRoles = getImplicitAriaRoles(node)
 
-    return implicitRoles.some(implicitRole =>
-      matcher(implicitRole, node, role, matchNormalizer),
-    )
-  })
+      return implicitRoles.some(implicitRole =>
+        matcher(implicitRole, node, role, matchNormalizer),
+      )
+    })
 }
 
 const getMultipleError = (c, role) =>

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,58 +1,9 @@
-import {getImplicitAriaRoles, prettyRoles} from '../role-helpers'
+import {
+  getImplicitAriaRoles,
+  prettyRoles,
+  shouldExcludeFromA11yTree,
+} from '../role-helpers'
 import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
-
-/**
- * Partial implementation https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
- * which should only be used for elements with a non-presentational role i.e.
- * `role="none"` and `role="presentation"` will not be excluded.
- *
- * Implements aria-hidden semantics (i.e. parent overrides child)
- * Ignores "Child Presentational: True" characteristics
- *
- * @param {Element} element -
- * @returns {boolean} true if excluded, otherwise false
- */
-function shouldExcludeFromA11yTree(element) {
-  const computedStyle = window.getComputedStyle(element)
-  // since visibility is inherited we can exit early
-  if (computedStyle.visibility === 'hidden') {
-    return true
-  }
-
-  // Remove once https://github.com/jsdom/jsdom/issues/2616 is fixed
-  const supportsStyleInheritance = computedStyle.visibility !== ''
-  let visibility = computedStyle.visibility
-
-  let currentElement = element
-  while (currentElement !== null) {
-    if (currentElement.hasAttribute('hidden')) {
-      return true
-    }
-
-    if (currentElement.getAttribute('aria-hidden') === 'true') {
-      return true
-    }
-
-    const currentComputedStyle = window.getComputedStyle(currentElement)
-
-    if (currentComputedStyle.display === 'none') {
-      return true
-    }
-
-    if (supportsStyleInheritance === false) {
-      // we go bottom-up for an inheritable property so we can only set it
-      // if it wasn't set already i.e. the parent can't overwrite the child
-      if (visibility === '') visibility = currentComputedStyle.visibility
-      if (visibility === 'hidden') {
-        return true
-      }
-    }
-
-    currentElement = currentElement.parentElement
-  }
-
-  return false
-}
 
 function queryAllByRole(
   container,
@@ -86,22 +37,28 @@ function queryAllByRole(
 const getMultipleError = (c, role) =>
   `Found multiple elements with the role "${role}"`
 
-const getMissingError = (container, role) => {
-  const roles = prettyRoles(container)
+const getMissingError = (container, role, {hidden = false} = {}) => {
+  const roles = prettyRoles(container, {hidden})
   let roleMessage
 
   if (roles.length === 0) {
-    roleMessage = 'There are no available roles.'
+    if (hidden === false) {
+      roleMessage = 'There are no accessible roles.'
+    } else {
+      roleMessage = 'There are no available roles.'
+    }
   } else {
     roleMessage = `
-Here are the available roles:
+Here are the ${hidden === false ? 'accessible' : 'available'} roles:
 
   ${roles.replace(/\n/g, '\n  ').replace(/\n\s\s\n/g, '\n\n')}
 `.trim()
   }
 
   return `
-Unable to find an element with the role "${role}"
+Unable to find an ${
+    hidden === false ? 'accessible ' : ''
+  } element with the role "${role}"
 
 ${roleMessage}`.trim()
 }

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -27,7 +27,7 @@ function shouldExcludeFromA11yTree(element) {
 
   let currentElement = element
   while (currentElement !== null) {
-    if (currentElement.hasAttribute('hidden')) {
+    if (currentElement.hidden === true) {
       return true
     }
 

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -132,7 +132,7 @@ function getRoles(container, {hidden = false} = {}) {
     }, {})
 }
 
-function prettyRoles(dom, {hidden = false} = {}) {
+function prettyRoles(dom, {hidden}) {
   const roles = getRoles(dom, {hidden})
 
   return Object.entries(roles)

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -3,6 +3,59 @@ import {prettyDOM} from './pretty-dom'
 
 const elementRoleList = buildElementRoleList(elementRoles)
 
+/**
+ * Partial implementation https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
+ * which should only be used for elements with a non-presentational role i.e.
+ * `role="none"` and `role="presentation"` will not be excluded.
+ *
+ * Implements aria-hidden semantics (i.e. parent overrides child)
+ * Ignores "Child Presentational: True" characteristics
+ *
+ * @param {Element} element -
+ * @returns {boolean} true if excluded, otherwise false
+ */
+function shouldExcludeFromA11yTree(element) {
+  const computedStyle = window.getComputedStyle(element)
+  // since visibility is inherited we can exit early
+  if (computedStyle.visibility === 'hidden') {
+    return true
+  }
+
+  // Remove once https://github.com/jsdom/jsdom/issues/2616 is fixed
+  const supportsStyleInheritance = computedStyle.visibility !== ''
+  let visibility = computedStyle.visibility
+
+  let currentElement = element
+  while (currentElement !== null) {
+    if (currentElement.hasAttribute('hidden')) {
+      return true
+    }
+
+    if (currentElement.getAttribute('aria-hidden') === 'true') {
+      return true
+    }
+
+    const currentComputedStyle = window.getComputedStyle(currentElement)
+
+    if (currentComputedStyle.display === 'none') {
+      return true
+    }
+
+    if (supportsStyleInheritance === false) {
+      // we go bottom-up for an inheritable property so we can only set it
+      // if it wasn't set already i.e. the parent can't overwrite the child
+      if (visibility === '') visibility = currentComputedStyle.visibility
+      if (visibility === 'hidden') {
+        return true
+      }
+    }
+
+    currentElement = currentElement.parentElement
+  }
+
+  return false
+}
+
 function getImplicitAriaRoles(currentNode) {
   for (const {selector, roles} of elementRoleList) {
     if (currentNode.matches(selector)) {
@@ -49,7 +102,7 @@ function buildElementRoleList(elementRolesMap) {
   return result.sort(bySelectorSpecificity)
 }
 
-function getRoles(container) {
+function getRoles(container, {hidden = false} = {}) {
   function flattenDOM(node) {
     return [
       node,
@@ -60,21 +113,27 @@ function getRoles(container) {
     ]
   }
 
-  return flattenDOM(container).reduce((acc, node) => {
-    const roles = getImplicitAriaRoles(node)
+  return flattenDOM(container)
+    .filter(element => {
+      return hidden === false
+        ? shouldExcludeFromA11yTree(element) === false
+        : true
+    })
+    .reduce((acc, node) => {
+      const roles = getImplicitAriaRoles(node)
 
-    return roles.reduce(
-      (rolesAcc, role) =>
-        Array.isArray(rolesAcc[role])
-          ? {...rolesAcc, [role]: [...rolesAcc[role], node]}
-          : {...rolesAcc, [role]: [node]},
-      acc,
-    )
-  }, {})
+      return roles.reduce(
+        (rolesAcc, role) =>
+          Array.isArray(rolesAcc[role])
+            ? {...rolesAcc, [role]: [...rolesAcc[role], node]}
+            : {...rolesAcc, [role]: [node]},
+        acc,
+      )
+    }, {})
 }
 
-function prettyRoles(dom) {
-  const roles = getRoles(dom)
+function prettyRoles(dom, {hidden = false} = {}) {
+  const roles = getRoles(dom, {hidden})
 
   return Object.entries(roles)
     .map(([role, elements]) => {
@@ -88,8 +147,15 @@ function prettyRoles(dom) {
     .join('\n')
 }
 
-const logRoles = dom => console.log(prettyRoles(dom))
+const logRoles = (dom, {hidden = false} = {}) =>
+  console.log(prettyRoles(dom, {hidden}))
 
-export {getRoles, logRoles, getImplicitAriaRoles, prettyRoles}
+export {
+  getRoles,
+  logRoles,
+  getImplicitAriaRoles,
+  prettyRoles,
+  shouldExcludeFromA11yTree,
+}
 
 /* eslint no-console:0 */


### PR DESCRIPTION
BREAKING
Certain<sup>1</sup> elements will no longer be included in `byRole` queries.
Examples:
* `<ul hidden />` will no longer by included in `*byRole('list')`
* `<main aria-hidden="true"><ul /><main>` will no longer return an element in `*byRole('list')` or `getByRole('main')`


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Implement https://www.w3.org/TR/core-aam-1.1/#exclude_elements2 with the following deviation:

* `role="none"` and `role="presentation"` is included (not following `MUST` criteria)
  I feel like this is more of a concern for an actual a11y tree implementation. `getByRole('presentation')` not returning anything even if the element is visible is probably confusing but I could see us throwing an error here. We could argue that one should use `getByTestId` instead since this makes it obvious you're not querying the a11y tree.
* descendants of "Children Presentational: True" are included (not following `SHOULD` criteria)

**Why**:

Closes #350

**How**:

Implementation is kept simple and mirrors the spec. Faster implementation is considered for a future PR.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) Will do once this is approved
- ~[ ] Typescript definitions updated~ Separate type PR is prepared
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I'm open to removing the option and making it default. In any case it should be released in a breaking change since it is potentially breaking.

<sup>1</sup> excluded are elements that
* have `aria-hidden=true` or any of its ancestors
* have the `hidden` attribute or any of its ancestors
* have `display: none` or any of its ancestors
* have `hidden` as their computed `visibility`

