### PR TITLE
Provide humane error messages for missing fireEvent() params

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -223,6 +223,24 @@ test('fires shortcut events on Window', () => {
   window.removeEventListener('message', clickSpy)
 })
 
+test('throws a useful error message when firing events on non-existent nodes', () => {
+  expect(() => fireEvent(undefined, new MouseEvent('click'))).toThrow(
+    'Unable to fire a "click" event - please provide a DOM element.',
+  )
+})
+
+test('throws a useful error message when firing events on non-existent nodes (shortcut)', () => {
+  expect(() => fireEvent.click(undefined)).toThrow(
+    'Unable to fire a "click" event - please provide a DOM element.',
+  )
+})
+
+test('throws a useful error message when firing non-events', () => {
+  expect(() => fireEvent(document.createElement('div'), undefined)).toThrow(
+    'Unable to fire an event - please provide an event object.',
+  )
+})
+
 test('fires events on Document', () => {
   const keyDownSpy = jest.fn()
   document.addEventListener('keydown', keyDownSpy)

--- a/src/events.js
+++ b/src/events.js
@@ -345,6 +345,14 @@ const eventAliasMap = {
 }
 
 function fireEvent(element, event) {
+  if (!event) {
+    throw new Error(`Unable to fire an event - please provide an event object.`)
+  }
+  if (!element) {
+    throw new Error(
+      `Unable to fire a "${event.type}" event - please provide a DOM element.`,
+    )
+  }
   return element.dispatchEvent(event)
 }
 
@@ -355,6 +363,11 @@ Object.keys(eventMap).forEach(key => {
   const eventName = key.toLowerCase()
 
   createEvent[key] = (node, init) => {
+    if (!node) {
+      throw new Error(
+        `Unable to fire a "${key}" event - please provide a DOM element.`,
+      )
+    }
     const eventInit = {...defaultInit, ...init}
     const {target: {value, files, ...targetProperties} = {}} = eventInit
     if (value !== undefined) {


### PR DESCRIPTION
**What**:

Adds specific error message text when `element` / `node` / `event` params are missing for `fireEvent()`

**Why**:

In some cases you may be calling `fireEvent` without giving it an element, e.g.
while it is discouraged, in some cases it is necessary to use `querySelector` or similar or you might be accessing a `results[0]` in an empty array returned by `queryAllBy*`.

When you do that - `fireEvent()` will throw the good old `Cannot convert undefined or null to object`, which means you need to go and look for what exactly happened.

Providing a human readable, specific error message makes it easier to debug such failures.


**How**:

Throw a specific error after testing a condition.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
