### PR TITLE
feat: update wait-for-expect which always uses real timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,20 +40,20 @@
     "dist"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.5.5",
+    "@babel/runtime": "^7.6.2",
     "@sheerun/mutationobserver-shim": "^0.3.2",
     "@types/testing-library__dom": "^6.0.0",
     "aria-query": "3.0.0",
-    "pretty-format": "^24.8.0",
-    "wait-for-expect": "^1.3.0"
+    "pretty-format": "^24.9.0",
+    "wait-for-expect": "^3.0.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.0.0",
+    "@testing-library/jest-dom": "^4.1.0",
     "jest-in-case": "^1.0.2",
     "jest-serializer-ansi": "^1.0.3",
-    "jest-watch-select-projects": "^0.1.1",
+    "jest-watch-select-projects": "^1.0.0",
     "jsdom": "^15.1.1",
-    "kcd-scripts": "^1.5.2"
+    "kcd-scripts": "^1.7.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -57,6 +57,8 @@ function shouldExcludeFromA11yTree(element) {
 }
 
 function getImplicitAriaRoles(currentNode) {
+  // eslint bug here:
+  // eslint-disable-next-line no-unused-vars
   for (const {selector, roles} of elementRoleList) {
     if (currentNode.matches(selector)) {
       return [...roles]
@@ -88,6 +90,8 @@ function buildElementRoleList(elementRolesMap) {
 
   let result = []
 
+  // eslint bug here:
+  // eslint-disable-next-line no-unused-vars
   for (const [element, roles] of elementRolesMap.entries()) {
     result = [
       ...result,


### PR DESCRIPTION
**What**: Upgrade all deps, but most notably `wait-for-expect` which always uses real timers

**Why**: Related: #342 

**How**: `yarn upgrade-interactive --latest'

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
