### PR TITLE
fix: Crash in IE 11 when using logging roles

### DIFF
--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -135,8 +135,9 @@ function getRoles(container, {hidden = false} = {}) {
 function prettyRoles(dom, {hidden}) {
   const roles = getRoles(dom, {hidden})
 
-  return Object.entries(roles)
-    .map(([role, elements]) => {
+  return Object.keys(roles)
+    .map(role => {
+      const elements = roles[role]
       const delimiterBar = '-'.repeat(50)
       const elementsString = elements
         .map(el => prettyDOM(el.cloneNode(false)))


### PR DESCRIPTION

**What**:

* Don't use [`Object.entries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)

**Why**:

* Crashes in IE 11 when logging roles 

**How**:

* Use `Object.keys` instead

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- ~[ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom~
- ~[ ] Tests~ Would require running tests in browsers. Since tests are still passing then it doesn't matter how it's implemented.
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
