### PR TITLE
fix: byLabel crashing in IE 11

### DIFF
--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -21,7 +21,7 @@ function queryAllLabelsByText(
 
     // The children of a textarea are part of `textContent` as well. We
     // need to remove them from the string so we can match it afterwards.
-    label.querySelectorAll('textarea').forEach(textarea => {
+    Array.from(label.querySelectorAll('textarea')).forEach(textarea => {
       textToMatch = textToMatch.replace(textarea.value, '')
     })
 


### PR DESCRIPTION
**What**:

* Don't use [`NodeList.prototype.forEach()
`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Browser_Compatibility)

**Why**:

* Crashes in IE 11 when using `byRoles`

**How**:

* Wrap in `Array.from`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- ~[ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom~
- ~[ ] Tests~ Would require running tests in browsers. Since tests are still passing then it doesn't matter how it's implemented.
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
