### PR TITLE
feat: Export isInaccessible

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -166,6 +166,9 @@ test('getImplicitAriaRoles returns expected roles for various dom nodes', () => 
 })
 
 test.each([
+  ['<div />', false],
+  ['<div aria-hidden="false" />', false],
+  ['<div style="visibility: visible" />', false],
   ['<div hidden />', true],
   ['<div style="display: none;"/>', true],
   ['<div style="visibility: hidden;"/>', true],

--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -1,4 +1,9 @@
-import {getRoles, logRoles, getImplicitAriaRoles} from '../role-helpers'
+import {
+  getRoles,
+  logRoles,
+  getImplicitAriaRoles,
+  shouldExcludeFromA11yTree,
+} from '../role-helpers'
 import {render} from './helpers/test-utils'
 
 beforeEach(() => {
@@ -158,6 +163,20 @@ test('getImplicitAriaRoles returns expected roles for various dom nodes', () => 
   expect(getImplicitAriaRoles(form)).toEqual(['form'])
   expect(getImplicitAriaRoles(radio)).toEqual(['radio'])
   expect(getImplicitAriaRoles(input)).toEqual(['textbox'])
+})
+
+test.each([
+  ['<div hidden />', true],
+  ['<div style="display: none;"/>', true],
+  ['<div style="visibility: hidden;"/>', true],
+  ['<div aria-hidden="true" />', true],
+])('shouldExcludeFromA11yTree for %s returns %p', (html, expected) => {
+  const {container} = render(html)
+  container.firstChild.appendChild(document.createElement('button'))
+
+  expect(shouldExcludeFromA11yTree(container.querySelector('button'))).toBe(
+    expected,
+  )
 })
 
 /* eslint no-console:0 */

--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -2,7 +2,7 @@ import {
   getRoles,
   logRoles,
   getImplicitAriaRoles,
-  shouldExcludeFromA11yTree,
+  isInaccessible,
 } from '../role-helpers'
 import {render} from './helpers/test-utils'
 
@@ -177,9 +177,7 @@ test.each([
   const {container} = render(html)
   container.firstChild.appendChild(document.createElement('button'))
 
-  expect(shouldExcludeFromA11yTree(container.querySelector('button'))).toBe(
-    expected,
-  )
+  expect(isInaccessible(container.querySelector('button'))).toBe(expected)
 })
 
 /* eslint no-console:0 */

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export * from './get-node-text'
 export * from './events'
 export * from './get-queries-for-element'
 export * from './query-helpers'
-export {getRoles, logRoles, shouldExcludeFromA11yTree} from './role-helpers'
+export {getRoles, logRoles, isInaccessible} from './role-helpers'
 export * from './pretty-dom'
 export {configure} from './config'
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export * from './get-node-text'
 export * from './events'
 export * from './get-queries-for-element'
 export * from './query-helpers'
-export {getRoles, logRoles} from './role-helpers'
+export {getRoles, logRoles, shouldExcludeFromA11yTree} from './role-helpers'
 export * from './pretty-dom'
 export {configure} from './config'
 

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,7 +1,7 @@
 import {
   getImplicitAriaRoles,
   prettyRoles,
-  shouldExcludeFromA11yTree,
+  isInaccessible,
 } from '../role-helpers'
 import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
 
@@ -15,9 +15,7 @@ function queryAllByRole(
 
   return Array.from(container.querySelectorAll('*'))
     .filter(element => {
-      return hidden === false
-        ? shouldExcludeFromA11yTree(element) === false
-        : true
+      return hidden === false ? isInaccessible(element) === false : true
     })
     .filter(node => {
       const isRoleSpecifiedExplicitly = node.hasAttribute('role')

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -14,7 +14,7 @@ const elementRoleList = buildElementRoleList(elementRoles)
  * @param {Element} element -
  * @returns {boolean} true if excluded, otherwise false
  */
-function shouldExcludeFromA11yTree(element) {
+function isInaccessible(element) {
   const window = element.ownerDocument.defaultView
   const computedStyle = window.getComputedStyle(element)
   // since visibility is inherited we can exit early
@@ -120,9 +120,7 @@ function getRoles(container, {hidden = false} = {}) {
 
   return flattenDOM(container)
     .filter(element => {
-      return hidden === false
-        ? shouldExcludeFromA11yTree(element) === false
-        : true
+      return hidden === false ? isInaccessible(element) === false : true
     })
     .reduce((acc, node) => {
       const roles = getImplicitAriaRoles(node)
@@ -155,12 +153,6 @@ function prettyRoles(dom, {hidden}) {
 const logRoles = (dom, {hidden = false} = {}) =>
   console.log(prettyRoles(dom, {hidden}))
 
-export {
-  getRoles,
-  logRoles,
-  getImplicitAriaRoles,
-  prettyRoles,
-  shouldExcludeFromA11yTree,
-}
+export {getRoles, logRoles, getImplicitAriaRoles, prettyRoles, isInaccessible}
 
 /* eslint no-console:0 */


### PR DESCRIPTION
Looking for better names of this function.


**What**:

* Export helper method that is used in `byRoles` queries to exclude inaccessible elements

**Why**:

* To implement a custom test matcher like `expect(element).toBeInaccessible()`
  This is useful if you want to test relationships between elements which are established via `aria-controls`. We want to test that the value of `aria-controls` is valid by checking that `expect(document.getElementById(control.getAttribute('aria-controls'))).toBeInTheDocument()` but we want to make sure that at that point the element is still excluded from the a11y tree.

  Another use case might be if you queried the element with something other than `byRole` and you want to make sure the element is (in)accessible.

**How**:

* "just" export it

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
