### PR TITLE
fix: shouldExcludeFromA11yTree runs in IE11

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -385,6 +385,9 @@ test('queryAllByRole returns semantic html elements', () => {
       <h4>Heading 4</h4>
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
+      <svg role="img">
+        <rect width="100" height="100" />
+      </svg>
       <ol>
         <li></li>
         <li></li>
@@ -429,6 +432,7 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole('row')).toHaveLength(3)
   expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
   expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
+  expect(queryAllByRole(/img/i)).toHaveLength(1)
 })
 
 test('getAll* matchers return an array', () => {

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -26,7 +26,7 @@ function shouldExcludeFromA11yTree(element) {
   let visibility = computedStyle.visibility
 
   let currentElement = element
-  while (currentElement !== null) {
+  while (currentElement) {
     if (currentElement.hidden === true) {
       return true
     }


### PR DESCRIPTION
IE11 returns `undefined` for missing `parentElement`.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

fix: In IE11 when an element lacks `parentElement` it returns `undefined` instead of `null`.

<!-- Why are these changes necessary? -->

**Why**: Because otherwise you get these errors

```
TypeError: Unable to get property 'hidden' of undefined or null reference
	error properties: Object({ number: -2146823281 })
	    at <Jasmine>
	   at shouldExcludeFromA11yTree (eval code:824:5)
	   at Anonymous function (eval code:995:5)
	   at Anonymous function (eval code:28:7)
	   at filter (eval code:11:5)
	   at queryAllByRole (eval code:994:3)
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom N/A
- [ ] Tests N/A
- [x ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
