### PR TITLE
Add strict check for `dom` type

### DIFF
--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -26,14 +26,16 @@ test('prettyDOM supports truncating the output length', () => {
 })
 
 test('prettyDOM defaults to document.body', () => {
+  const defaultInlineSnapshot = `
+  "<body>
+    <div>
+      Hello World!
+    </div>
+  </body>"
+`
   renderIntoDocument('<div>Hello World!</div>')
-  expect(prettyDOM()).toMatchInlineSnapshot(`
-    "<body>
-      <div>
-        Hello World!
-      </div>
-    </body>"
-  `)
+  expect(prettyDOM()).toMatchInlineSnapshot(defaultInlineSnapshot)
+  expect(prettyDOM(null)).toMatchInlineSnapshot(defaultInlineSnapshot)
 })
 
 test('prettyDOM supports receiving the document element', () => {
@@ -56,6 +58,24 @@ test('logDOM logs prettyDOM to the console', () => {
       </div>
     </div>"
   `)
+})
+
+describe('prettyDOM fails with first parameter without outerHTML field', () => {
+  test('with array', () => {
+    expect(() => prettyDOM(['outerHTML'])).toThrowErrorMatchingInlineSnapshot(
+      `"Expected an element or document but got Array"`,
+    )
+  })
+  test('with number', () => {
+    expect(() => prettyDOM(1)).toThrowErrorMatchingInlineSnapshot(
+      `"Expected an element or document but got number"`,
+    )
+  })
+  test('with object', () => {
+    expect(() => prettyDOM({})).toThrowErrorMatchingInlineSnapshot(
+      `"Expected an element or document but got Object"`,
+    )
+  })
 })
 
 /* eslint no-console:0 */

--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -20,16 +20,32 @@ const getMaxLength = dom =>
 
 const {DOMElement, DOMCollection} = prettyFormat.plugins
 
-function prettyDOM(
-  dom = getDocument().body,
-  maxLength = getMaxLength(dom),
-  options,
-) {
+function prettyDOM(dom, maxLength, options) {
+  if (!dom) {
+    dom = getDocument().body
+  }
+  if (typeof maxLength !== 'number') {
+    maxLength = getMaxLength(dom)
+  }
+
   if (maxLength === 0) {
     return ''
   }
   if (dom.documentElement) {
     dom = dom.documentElement
+  }
+
+  let domTypeName = typeof dom
+  if (domTypeName === 'object') {
+    domTypeName = dom.constructor.name
+  } else {
+    // To don't fall with `in` operator
+    dom = {}
+  }
+  if (!('outerHTML' in dom)) {
+    throw new TypeError(
+      `Expected an element or document but got ${domTypeName}`,
+    )
   }
 
   const debugContent = prettyFormat(dom, {


### PR DESCRIPTION
Hey,

I face an issue and come with this pr :)

**What**:

Add strict check for `dom`'s `outerHTML` field

**Why**:

To improve DX. 

As a new user I've called `debug(x)` where `x` was a result of `queryAll*`. I've missed that `queryAll*` returns an array and got `TypeError: Cannot read property 'length' of undefined` in my terminal.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] I've prepared [a PR for types](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38901)
- [x] Tests
- [x] Ready to be merged
