### PR TITLE
feat(events): add form reset event

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -33,7 +33,7 @@ const eventTypes = [
   },
   {
     type: 'Focus',
-    events: ['submit'],
+    events: ['submit', 'reset'],
     elementType: 'form',
   },
   {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -22,17 +22,12 @@ const eventTypes = [
     elementType: 'input',
   },
   {
-    type: 'Form',
-    events: ['focus', 'blur'],
-    elementType: 'input',
-  },
-  {
-    type: 'Focus',
+    type: 'Input',
     events: ['change', 'input', 'invalid'],
     elementType: 'input',
   },
   {
-    type: 'Focus',
+    type: 'Form',
     events: ['submit', 'reset'],
     elementType: 'form',
   },

--- a/src/events.js
+++ b/src/events.js
@@ -72,6 +72,10 @@ const eventMap = {
     EventType: 'Event',
     defaultInit: {bubbles: true, cancelable: true},
   },
+  reset: {
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: true},
+  },
   // Mouse Events
   click: {
     EventType: 'MouseEvent',


### PR DESCRIPTION
Hi all!
This is my first PR to a popular OSS project.

**What**:

Forms have ```submit```, but lack ```reset``` event.

**Why**:

Using form events instead of direct button callbacks comes handy sometimes, when using form templates with variable content.

**How**:

Events were extended to contain ```reset``` event applicable on ```<form />``` tags.

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) N/A (see below)
- [ ] I've prepared a PR for types targeting
https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom
- [x] Tests
- [x] Ready to be merged

**Comments**:

1. I think updating docs is not necessary since the following line covers everything.

```
Convenience methods for firing DOM events. Check out src/events.js for a full list as well as default eventProperties.
```

2. I can prepare a types PR if this one will be accepted.