### PR TITLE
test: Run in node

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: require.resolve('kcd-scripts/dist/config/eslintrc.js'),
+  env: {
+    browser: false,
+  },
+}

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1,5 +1,6 @@
 import {configure} from '../config'
 import {render, renderIntoDocument} from './helpers/test-utils'
+import document from './helpers/document'
 
 beforeEach(() => {
   document.defaultView.Cypress = null

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,4 +1,6 @@
+import document from './helpers/document'
 import {fireEvent} from '..'
+const window = document.defaultView
 
 const eventTypes = [
   {
@@ -219,7 +221,7 @@ test('fires shortcut events on Window', () => {
 })
 
 test('throws a useful error message when firing events on non-existent nodes', () => {
-  expect(() => fireEvent(undefined, new MouseEvent('click'))).toThrow(
+  expect(() => fireEvent(undefined, new window.MouseEvent('click'))).toThrow(
     'Unable to fire a "click" event - please provide a DOM element.',
   )
 })

--- a/src/__tests__/example.js
+++ b/src/__tests__/example.js
@@ -7,6 +7,7 @@ import {
   wait,
   fireEvent,
 } from '../'
+import document from './helpers/document'
 
 function getExampleDOM() {
   // This is just a raw example of setting up some DOM

--- a/src/__tests__/get-queries-for-element.js
+++ b/src/__tests__/get-queries-for-element.js
@@ -1,4 +1,5 @@
 import {getQueriesForElement} from '../get-queries-for-element'
+import document from './helpers/document'
 import {queries} from '..'
 
 test('uses default queries', () => {

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -1,4 +1,6 @@
 import {getDocument, newMutationObserver} from '../helpers'
+import document from './helpers/document'
+const window = document.defaultView
 
 test('returns global document if exists', () => {
   expect(getDocument()).toBe(document)

--- a/src/__tests__/helpers/document.js
+++ b/src/__tests__/helpers/document.js
@@ -1,0 +1,9 @@
+// https://github.com/testing-library/jest-dom/blob/v4.1.2/src/__tests__/helpers/document.js
+if (global.document) {
+  module.exports = global.document
+} else {
+  const {JSDOM} = require('jsdom')
+  const {window} = new JSDOM()
+
+  module.exports = window.document
+}

--- a/src/__tests__/helpers/test-utils.js
+++ b/src/__tests__/helpers/test-utils.js
@@ -1,4 +1,5 @@
 import {getQueriesForElement} from '../../get-queries-for-element'
+import document from './document'
 
 function render(html, {container = document.createElement('div')} = {}) {
   container.innerHTML = html

--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -1,5 +1,6 @@
 import {prettyDOM, logDOM} from '../pretty-dom'
 import {render, renderIntoDocument} from './helpers/test-utils'
+import document from './helpers/document'
 
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {})

--- a/src/__tests__/wait-for-dom-change.js
+++ b/src/__tests__/wait-for-dom-change.js
@@ -1,4 +1,6 @@
 import {renderIntoDocument} from './helpers/test-utils'
+import document from './helpers/document'
+const window = document.defaultView
 
 function importModule() {
   return require('../').waitForDomChange

--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -1,4 +1,7 @@
 import {renderIntoDocument} from './helpers/test-utils'
+import document from './helpers/document'
+
+const window = document.defaultView
 
 function importModule() {
   return require('../').waitForElementToBeRemoved

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -4,6 +4,17 @@ import {prettyDOM} from './pretty-dom'
 const elementRoleList = buildElementRoleList(elementRoles)
 
 /**
+ * @param {Node} node -
+ * @returns {Window} -
+ */
+function defaultViewOf(node) {
+  // is null when node is already the document
+  return node.ownerDocument === null
+    ? node.defaultView
+    : node.ownerDocument.defaultView
+}
+
+/**
  * Partial implementation https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
  * which should only be used for elements with a non-presentational role i.e.
  * `role="none"` and `role="presentation"` will not be excluded.
@@ -15,7 +26,7 @@ const elementRoleList = buildElementRoleList(elementRoles)
  * @returns {boolean} true if excluded, otherwise false
  */
 function isInaccessible(element) {
-  const window = element.ownerDocument.defaultView
+  const window = defaultViewOf(element)
   const computedStyle = window.getComputedStyle(element)
   // since visibility is inherited we can exit early
   if (computedStyle.visibility === 'hidden') {

--- a/tests/jest.config.node.js
+++ b/tests/jest.config.node.js
@@ -11,5 +11,4 @@ module.exports = {
     '/__tests__/',
     '/__node_tests__/',
   ],
-  testMatch: ['**/__node_tests__/**.js'],
 }


### PR DESCRIPTION
I have to ask again: Is the purpose of this to be importable/evaluateable in node or useable without a global DOM? 

This will require some work and before deep diving I want to be sure I'm not just implementing someones "I like".

If we don't care about this requirement here why do we care for it in `jest-dom`? It lowers interop with other dom related libraries since everybody is assuming that at least window or document are globally defined.

I traced the requirement back to https://github.com/testing-library/jest-dom/issues/58 which is quite a different thing to ask. Yes instanceof checks need special treatment for cross-realm elements but those are fixable (though difficult to test properly).

But asking for no global DOM available was not part of the question, It was explicitly not asked by providing the quote from jsdom

> Note that we strongly advise against trying to "execute scripts" by mashing together the jsdom and Node global environments (e.g. by doing global.window = dom.window), and then executing scripts or test code inside the Node global environment. Instead, you should treat jsdom like you would a browser, and run all scripts and tests that need access to a DOM inside the jsdom environment, using window.eval or runScripts: "dangerously". This might require, for example, creating a browserify bundle to execute as a <script> element—just like you would in a browser.

This doesn't mean you shouldn't expose a global window. Just that you don't mix these environments but rather execute your scripts **inside** jsdom which would result in a global `window`.

You can't just cherry-pick this quote and not expose a global window but still run in the node environment. 

/cc @kentcdodds 