### PR TITLE
fix(byRole): Don't assume window context

### DIFF
--- a/src/__node_tests__/index.js
+++ b/src/__node_tests__/index.js
@@ -76,3 +76,23 @@ test('works without a browser context on a dom node (JSDOM Fragment)', () => {
     />
   `)
 })
+
+test('byRole works without a global DOM', () => {
+  const {
+    window: {
+      document: {body: container},
+    },
+  } = new JSDOM(`
+    <html>
+      <body>
+        <button>Say "Hello, Dave!"</button>
+      </body>
+    </html>
+  `)
+
+  expect(dtl.getByRole(container, 'button')).toMatchInlineSnapshot(`
+    <button>
+      Say "Hello, Dave!"
+    </button>
+  `)
+})

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -15,6 +15,7 @@ const elementRoleList = buildElementRoleList(elementRoles)
  * @returns {boolean} true if excluded, otherwise false
  */
 function shouldExcludeFromA11yTree(element) {
+  const window = element.ownerDocument.defaultView
   const computedStyle = window.getComputedStyle(element)
   // since visibility is inherited we can exit early
   if (computedStyle.visibility === 'hidden') {


### PR DESCRIPTION

**What**:

Get window from passed element

**Why**:

element might be passed from another window/frame

**How**:

Use `element.ownerDocument.defaultView`. This is safe to evaluate since we expect an `Element`. `ownerDocument` is only `null` for `Document` (https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- ~[ ] I've prepared a PR for types targetting ~https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom
- [x] Tests: To be honest I wouldn't know if these can create different results. As far as I know getComputedStyle never reads from its window (`this`) but only from the window of the passed element (at least the `jsdom` implementation). So from my knowledge this is only useful if you run inside node without a global DOM.
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
