### PR TITLE
Chore/templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -22,7 +22,7 @@ https://github.com/testing-library/testing-library-docs
 
 Relevant code or config
 
-```javascript
+```js
 ```
 
 What you did:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@ learn how: http://kcd.im/pull-request
 
 
 If this is an issue with the documentation, please file an issue in the docs repo:
-https://github.com/alexkrolick/testing-library-docs
+https://github.com/testing-library/testing-library-docs
 
 -->
 
@@ -32,7 +32,7 @@ What happened:
 <!-- Please provide the full error message/screenshots/anything -->
 
 Reproduction repository:
-https://github.com/alexkrolick/dom-testing-library-template
+https://github.com/testing-library/dom-testing-library-template
 
 <!--
 If possible, please create a repository that reproduces the issue with the

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ understand what's going on and fix the issue.
 
 I'll probably ask you to submit the fix (after giving some direction). If you've
 never done that before, that's great! Check this free short video tutorial to
-learn how: http://kcd.im/pull-request
+learn how: https://kcd.im/pull-request
 
 
 If this is an issue with the documentation, please file an issue in the docs repo:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -14,7 +14,7 @@ about: Bugs, missing documentation, or unexpected behavior 🤔.
 
 We'll probably ask you to submit the fix (after giving some direction). If
 you've never done that before, that's great! Check this free short video
-tutorial to learn how: http://kcd.im/pull-request
+tutorial to learn how: https://kcd.im/pull-request
 
 If this is an issue with the documentation, please file an issue in the docs repo:
 https://github.com/testing-library/testing-library-docs

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -26,7 +26,7 @@ https://github.com/testing-library/testing-library-docs
 
 ### Relevant code or config:
 
-```js
+```javascript
 var your => (code) => here;
 ```
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -26,7 +26,7 @@ https://github.com/testing-library/testing-library-docs
 
 ### Relevant code or config:
 
-```javascript
+```js
 var your => (code) => here;
 ```
 

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -17,7 +17,7 @@ to work on.
 
 It'd be great if after the discussion you're the one who submits the PR that
 implements this feature. If you've never done that before, that's great! Check
-this free short video tutorial to learn how: http://kcd.im/pull-request
+this free short video tutorial to learn how: https://kcd.im/pull-request
 
 
 If this is an issue with the documentation, please file an issue in the docs repo:

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -21,7 +21,7 @@ this free short video tutorial to learn how: http://kcd.im/pull-request
 
 
 If this is an issue with the documentation, please file an issue in the docs repo:
-https://github.com/alexkrolick/testing-library-docs
+https://github.com/testing-library/testing-library-docs
 -->
 
 ### Describe the feature you'd like:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Also, please make sure you're familiar with and follow the instructions in the
 contributing guidelines (found in the CONTRIBUTING.md file).
 
 If you're new to contributing to open source projects, you might find this free
-video course helpful: http://kcd.im/pull-request
+video course helpful: https://kcd.im/pull-request
 
 Please fill out the information below to expedite the review and (hopefully)
 merge of your pull request!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,11 +34,15 @@ merge of your pull request!
 
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-- [ ] Documentation added to the
-      [docs site](https://github.com/alexkrolick/testing-library-docs)
-- [ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom
+- [ ] Documentation added to the [docs site][docs]
+- [ ] I've prepared a PR for types targeting [DefinitelyTyped][types]
 - [ ] Tests
 - [ ] Ready to be merged
-      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+
+<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 
 <!-- feel free to add additional comments -->
+
+[docs]: https://github.com/testing-library/testing-library-docs
+[types]:
+  https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,14 +34,12 @@ merge of your pull request!
 
 <!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
 
-- [ ] Documentation added to the [docs site][docs]
-- [ ] I've prepared a PR for types targeting [DefinitelyTyped][types]
+- [ ] Documentation added to the
+      [docs site](https://github.com/testing-library/testing-library-docs)
+- [ ] I've prepared a PR for types targeting
+      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
 - [ ] Tests
 - [ ] Ready to be merged
       <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 
 <!-- feel free to add additional comments -->
-
-[docs]: https://github.com/testing-library/testing-library-docs
-[types]:
-  https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,8 +38,7 @@ merge of your pull request!
 - [ ] I've prepared a PR for types targeting [DefinitelyTyped][types]
 - [ ] Tests
 - [ ] Ready to be merged
-
-<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
 
 <!-- feel free to add additional comments -->
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,7 +69,8 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+version 1.4, available at
+[https://contributor-covenant.org/version/1/4][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "end-to-end",
     "e2e"
   ],
-  "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
+  "author": "Kent C. Dodds <kent@doddsfamily.us> (https://kentcdodds.com/)",
   "license": "MIT",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
**What**:

* Update `http` to `https`
* Change docs repo links
* Fix a typo in `targetting`
* Align markdown syntax to `javascript` (there used to be both `js` and `javascript`)

**Why**:

Since GitHub templates are probably the most used documents by various people, I've decided to make small maintenance.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom N/A
- [ ] Tests N/A
- [x] Ready to be merged
