### PR TITLE
feat(byRole): Improve performance

### DIFF
--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -14,9 +14,6 @@ function queryAllByRole(
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
 
   return Array.from(container.querySelectorAll('*'))
-    .filter(element => {
-      return hidden === false ? isInaccessible(element) === false : true
-    })
     .filter(node => {
       const isRoleSpecifiedExplicitly = node.hasAttribute('role')
 
@@ -29,6 +26,9 @@ function queryAllByRole(
       return implicitRoles.some(implicitRole =>
         matcher(implicitRole, node, role, matchNormalizer),
       )
+    })
+    .filter(element => {
+      return hidden === false ? isInaccessible(element) === false : true
     })
 }
 


### PR DESCRIPTION
**What**:

Addresses #379

**Why**:

Queries can be used when polling the DOM. If the query is slower than the polling rate we'll run into timeouts

**How**:

Since |elements| >> |elements with role| and getting the role is far less expensive than deciding if an element is part of the a11y tree it's far cheaper to query the elements for the role before checking if an element is part of the a11y tree.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- [ ] ~I've prepared a PR for types targetting https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom~
- [ ] Tests, testing in Codesandbox CI
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
