### PR TITLE
chore: Add codesandbox ci config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["github/kentcdodds/dom-testing-library-with-anything"]
+  "sandboxes": ["github/kentcdodds/react-testing-library-examples"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,3 @@
+{
+  "sandboxes": ["vanilla", "github/kentcdodds/react-testing-library-examples"]
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["vanilla", "github/kentcdodds/react-testing-library-examples"]
+  "sandboxes": ["vanilla"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["vanilla"]
+  "sandboxes": ["github/kentcdodds/dom-testing-library-with-anything"]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,3 @@ export {
   queries,
   queryHelpers,
 }
-
-export function csb() {
-  return 'yay!'
-}

--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,7 @@ export {
   queries,
   queryHelpers,
 }
+
+export function csb() {
+  return 'yay!'
+}


### PR DESCRIPTION
Please don't merge this yet

Testing:
* [x] if codesandbox CI runs
* [x] how it works with transitive dependencies (the codesandbox from kent only has a direct dependency on `@testing-library/react` but we would like to resolve its dependency on `@testing-library/dom` to the canary from this PR as well)

  Edit: It doesn't at the moment so we use https://github.com/kentcdodds/dom-testing-library-with-anything