### PR TITLE
Fix lint error from jest/prefer-hooks-on-top

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -347,6 +347,12 @@ test('query/get select by text with multiple options selected', () => {
 })
 
 describe('query by test id', () => {
+  afterEach(() => {
+    // Restore the default test id attribute
+    // even if these tests failed
+    configure({testIdAttribute: 'data-testid'})
+  })
+
   test('can get elements by test id', () => {
     const {queryByTestId} = render(`<div data-testid="firstName"></div>`)
     expect(queryByTestId('firstName')).toBeTruthy()
@@ -367,12 +373,6 @@ describe('query by test id', () => {
 
     configure({testIdAttribute: 'something-else'})
     expect(queryByTestId('theTestId')).toBeFalsy()
-  })
-
-  afterEach(() => {
-    // Restore the default test id attribute
-    // even if these tests failed
-    configure({testIdAttribute: 'data-testid'})
   })
 })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes a lint error.

**Why**:

Running `npm run validate` after pulling a fresh copy of the repo resulted in this error:

```
[lint] .../dom-testing-library/src/__tests__/element-queries.js
[lint]   372:3  error  Move all hooks before test cases  jest/prefer-hooks-on-top
```

It appears that it was triggered by [this commit](https://github.com/kentcdodds/eslint-config-kentcdodds/commit/0298d2e2d83868df2342afac0dcda4498a3c7de9#diff-b05a92a4bf52283f912cfbf2de67b458) in `eslint-config-kentcdodds`.

**How**:

Moves an `afterEach` call to the top of its enclosing block.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [ ] Tests N/A
- [x ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
