### PR TITLE
fix: globalObj.setTimeout possibly undefined

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,8 +4,12 @@ const globalObj = typeof window === 'undefined' ? global : window
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
-  const usingJestFakeTimers =
-    globalObj.setTimeout._isMockFunction && typeof jest !== 'undefined'
+  let usingJestFakeTimers
+
+  if (globalObj.setTimeout) {
+    usingJestFakeTimers =
+      globalObj.setTimeout._isMockFunction && typeof jest !== 'undefined'
+  }
 
   if (usingJestFakeTimers) {
     jest.useRealTimers()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Check whether `globalObj.setTimeout` is `undefined` before attributing a value for `usingJestFakeTimers`.

<!-- Why are these changes necessary? -->

**Why**:  To prevent the following error from being raised whenever a user have mocked the `window` object on `jest.config.js` but did not set a `setTimeOut` method: `TypeError: Cannot read property '_isMockFunction' of undefined`

<!-- How were these changes implemented? -->

**How**: Conditionally attribute a value for `usingJestFakeTimers`, depending whether `globalObj.setTimeOut` exists or not. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
