### PR TITLE
feat: Include hidden elements by default

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -86,9 +86,9 @@ test('get throws a useful error message', () => {
 </div>"
 `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "LucyRicardo"
+"Unable to find an element with the role "LucyRicardo"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+There are no available roles.
 
 <div>
   <div />

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -132,7 +132,7 @@ There are no accessible roles. But there might be some inaccessible roles. If yo
 `)
 })
 
- test('can exclude excludes elements which have visibility hidden', () => {
+test('can exclude elements which have visibility hidden', () => {
   const {getByRole} = render('<div style="visibility: hidden;"><ul /></div>')
 
   expect(() => getByRole('list', {hidden: false}))

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -21,6 +21,28 @@ Here are the available roles:
 `)
 })
 
+test('when hidde: false logs accessible roles when it fails', () => {
+  const {getByRole} = render(`<h1>Hi</h1>`)
+  expect(() => getByRole('article', {hidden: false}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an accessible element with the role "article"
+
+Here are the accessible roles:
+
+  heading:
+
+  <h1 />
+
+  --------------------------------------------------
+
+<div>
+  <h1>
+    Hi
+  </h1>
+</div>"
+`)
+})
+
 test('when hidden: false logs accessible roles when it fails', () => {
   const {getByRole} = render(`<div hidden><h1>Hi</h1></div>`)
   expect(() => getByRole('article', {hidden: false}))

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -21,7 +21,7 @@ Here are the available roles:
 `)
 })
 
-test('when hidde: false logs accessible roles when it fails', () => {
+test('when hidden: false logs accessible roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article', {hidden: false}))
     .toThrowErrorMatchingInlineSnapshot(`
@@ -132,7 +132,7 @@ There are no accessible roles. But there might be some inaccessible roles. If yo
 `)
 })
 
-test('by default excludes elements which have visibility hidden', () => {
+ test('can exclude excludes elements which have visibility hidden', () => {
   const {getByRole} = render('<div style="visibility: hidden;"><ul /></div>')
 
   expect(() => getByRole('list', {hidden: false}))

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -21,7 +21,7 @@ Here are the available roles:
 `)
 })
 
-test('when hidden: false logs accessible roles when it fails', () => {
+test('when hidden: false logs only accessible roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article', {hidden: false}))
     .toThrowErrorMatchingInlineSnapshot(`
@@ -39,26 +39,6 @@ Here are the accessible roles:
   <h1>
     Hi
   </h1>
-</div>"
-`)
-})
-
-test('when hidden: false logs accessible roles when it fails', () => {
-  const {getByRole} = render(`<div hidden><h1>Hi</h1></div>`)
-  expect(() => getByRole('article', {hidden: false}))
-    .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "article"
-
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
-
-<div>
-  <div
-    hidden=""
-  >
-    <h1>
-      Hi
-    </h1>
-  </div>
 </div>"
 `)
 })

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,8 @@ let config = {
   // react-testing-library to use. For that reason, this feature will remain
   // undocumented.
   asyncWrapper: cb => cb(),
+  // don't check if the element is part of the a11y tree by default
+  defaultHidden: true,
 }
 
 export function configure(newConfig) {

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -3,12 +3,24 @@ import {
   prettyRoles,
   isInaccessible,
 } from '../role-helpers'
-import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
+import {
+  buildQueries,
+  fuzzyMatches,
+  getConfig,
+  makeNormalizer,
+  matches,
+} from './all-utils'
 
 function queryAllByRole(
   container,
   role,
-  {exact = true, collapseWhitespace, hidden = false, trim, normalizer} = {},
+  {
+    exact = true,
+    collapseWhitespace,
+    hidden = getConfig().defaultHidden,
+    trim,
+    normalizer,
+  } = {},
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
@@ -35,7 +47,11 @@ function queryAllByRole(
 const getMultipleError = (c, role) =>
   `Found multiple elements with the role "${role}"`
 
-const getMissingError = (container, role, {hidden = false} = {}) => {
+const getMissingError = (
+  container,
+  role,
+  {hidden = getConfig().defaultHidden} = {},
+) => {
   const roles = prettyRoles(container, {hidden})
   let roleMessage
 


### PR DESCRIPTION
**What**:

- default for `hidden` is now `true` meaning inaccessible roles are included by default
- make the default value configurable

**Why**:

- it was demanded

**How**:

- change default value (read from config)
- adjust test descriptions

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
