### PR TITLE
feat: Make default of hidden in ByRole configurable

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -1,3 +1,4 @@
+import {configure, getConfig} from '../config'
 import {render} from './helpers/test-utils'
 
 test('by default logs accessible roles when it fails', () => {
@@ -180,4 +181,22 @@ test('can include inaccessible roles', () => {
   const {getByRole} = render('<div hidden><ul  /></div>')
 
   expect(getByRole('list', {hidden: true})).not.toBeNull()
+})
+
+describe('configuration', () => {
+  let originalConfig
+  beforeEach(() => {
+    originalConfig = getConfig()
+  })
+
+  afterEach(() => {
+    configure(originalConfig)
+  })
+
+  test('the default value for `hidden` can be configured', () => {
+    configure({defaultHidden: true})
+
+    const {getByRole} = render('<div hidden><ul  /></div>')
+    expect(getByRole('list')).not.toBeNull()
+  })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,8 @@ let config = {
   // react-testing-library to use. For that reason, this feature will remain
   // undocumented.
   asyncWrapper: cb => cb(),
+  // default value for the `hidden` option in `ByRole` queries
+  defaultHidden: false,
 }
 
 export function configure(newConfig) {

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -4,12 +4,24 @@ import {
   isInaccessible,
   isSubtreeInaccessible,
 } from '../role-helpers'
-import {buildQueries, fuzzyMatches, makeNormalizer, matches} from './all-utils'
+import {
+  buildQueries,
+  fuzzyMatches,
+  getConfig,
+  makeNormalizer,
+  matches,
+} from './all-utils'
 
 function queryAllByRole(
   container,
   role,
-  {exact = true, collapseWhitespace, hidden = false, trim, normalizer} = {},
+  {
+    exact = true,
+    collapseWhitespace,
+    hidden = getConfig().defaultHidden,
+    trim,
+    normalizer,
+  } = {},
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
@@ -49,7 +61,11 @@ function queryAllByRole(
 const getMultipleError = (c, role) =>
   `Found multiple elements with the role "${role}"`
 
-const getMissingError = (container, role, {hidden = false} = {}) => {
+const getMissingError = (
+  container,
+  role,
+  {hidden = getConfig().defaultHidden} = {},
+) => {
   const roles = prettyRoles(container, {hidden})
   let roleMessage
 


### PR DESCRIPTION

**What**:

Make default value of `hidden` in `ByRole` configurable via `configure({ defaultHidden: true })`

**Why**:

For people who experienced a measureable non-tolerable performance hit from #352 or mostly deactivate this feature.

**How**:

Extracted from #392 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
