### PR TITLE
fix: make sure setTimeout exists on global

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,7 +5,9 @@ const globalObj = typeof window === 'undefined' ? global : window
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
   const usingJestFakeTimers =
-    globalObj.setTimeout._isMockFunction && typeof jest !== 'undefined'
+    globalObj.setTimeout &&
+    globalObj.setTimeout._isMockFunction &&
+    typeof jest !== 'undefined'
 
   if (usingJestFakeTimers) {
     jest.useRealTimers()


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added a check to make sure globalObj.setTimeout exists before referencing the _isMockFunction parameter.
<!-- Why are these changes necessary? -->
**Why**:
I was getting the following error in my console when using ```@testing-library/react``` in my project.

```TypeError: Cannot read property '_isMockFunction' of undefined```

<!-- How were these changes implemented? -->

**How**:
Made sure ```globalObj.setTimeout``` existed before referencing the child property ```_isMockFunction```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped] (https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
