### PR TITLE
feat(byRole): Add `name` filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@sheerun/mutationobserver-shim": "^0.3.2",
     "@types/testing-library__dom": "^6.0.0",
     "aria-query": "3.0.0",
+    "dom-accessibility-api": "^0.2.0",
     "pretty-format": "^24.9.0",
     "wait-for-expect": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sheerun/mutationobserver-shim": "^0.3.2",
     "@types/testing-library__dom": "^6.0.0",
     "aria-query": "3.0.0",
-    "dom-accessibility-api": "^0.2.0",
+    "dom-accessibility-api": "^0.3.0",
     "pretty-format": "^24.9.0",
     "wait-for-expect": "^3.0.0"
   },

--- a/src/__tests__/__snapshots__/role-helpers.js.snap
+++ b/src/__tests__/__snapshots__/role-helpers.js.snap
@@ -3,6 +3,7 @@
 exports[`logRoles calls console.log with output from prettyRoles 1`] = `
 "region:
 
+Name "":
 <section
   data-testid="a-section"
 />
@@ -10,6 +11,7 @@ exports[`logRoles calls console.log with output from prettyRoles 1`] = `
 --------------------------------------------------
 link:
 
+Name "link":
 <a
   data-testid="a-link"
   href="http://whatever.com"
@@ -18,6 +20,7 @@ link:
 --------------------------------------------------
 navigation:
 
+Name "":
 <nav
   data-testid="a-nav"
 />
@@ -25,14 +28,17 @@ navigation:
 --------------------------------------------------
 heading:
 
+Name "Main Heading":
 <h1
   data-testid="a-h1"
 />
 
+Name "Sub Heading":
 <h2
   data-testid="a-h2"
 />
 
+Name "Tertiary Heading":
 <h3
   data-testid="a-h3"
 />
@@ -40,6 +46,7 @@ heading:
 --------------------------------------------------
 article:
 
+Name "":
 <article
   data-testid="a-article"
 />
@@ -47,10 +54,12 @@ article:
 --------------------------------------------------
 command:
 
+Name "":
 <menuitem
   data-testid="a-menuitem-1"
 />
 
+Name "":
 <menuitem
   data-testid="a-menuitem-2"
 />
@@ -58,10 +67,12 @@ command:
 --------------------------------------------------
 menuitem:
 
+Name "":
 <menuitem
   data-testid="a-menuitem-1"
 />
 
+Name "":
 <menuitem
   data-testid="a-menuitem-2"
 />
@@ -69,10 +80,12 @@ menuitem:
 --------------------------------------------------
 list:
 
+Name "":
 <ul
   data-testid="a-list"
 />
 
+Name "":
 <ul
   data-testid="b-list"
 />
@@ -80,18 +93,22 @@ list:
 --------------------------------------------------
 listitem:
 
+Name "":
 <li
   data-testid="a-list-item-1"
 />
 
+Name "":
 <li
   data-testid="a-list-item-2"
 />
 
+Name "":
 <li
   data-testid="b-list-item-1"
 />
 
+Name "":
 <li
   data-testid="b-list-item-2"
 />
@@ -99,6 +116,7 @@ listitem:
 --------------------------------------------------
 table:
 
+Name "":
 <table
   data-testid="a-table"
 />
@@ -106,6 +124,7 @@ table:
 --------------------------------------------------
 rowgroup:
 
+Name "":
 <tbody
   data-testid="a-tbody"
 />
@@ -113,6 +132,7 @@ rowgroup:
 --------------------------------------------------
 row:
 
+Name "Cell 1 Cell 2 Cell 3":
 <tr
   data-testid="a-row"
 />
@@ -120,14 +140,17 @@ row:
 --------------------------------------------------
 cell:
 
+Name "Cell 1":
 <td
   data-testid="a-cell-1"
 />
 
+Name "Cell 2":
 <td
   data-testid="a-cell-2"
 />
 
+Name "Cell 3":
 <td
   data-testid="a-cell-3"
 />
@@ -135,6 +158,7 @@ cell:
 --------------------------------------------------
 form:
 
+Name "":
 <form
   data-testid="a-form"
 />
@@ -142,11 +166,13 @@ form:
 --------------------------------------------------
 radio:
 
+Name "":
 <input
   data-testid="a-radio-1"
   type="radio"
 />
 
+Name "":
 <input
   data-testid="a-radio-2"
   type="radio"
@@ -155,16 +181,19 @@ radio:
 --------------------------------------------------
 textbox:
 
+Name "":
 <input
   data-testid="a-input-1"
   type="text"
 />
 
+Name "":
 <input
   data-testid="a-input-2"
   type="text"
 />
 
+Name "":
 <textarea
   data-testid="a-textarea"
 />

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -11,6 +11,7 @@ Here are the accessible roles:
 
   heading:
 
+  Name "Hi":
   <h1 />
 
   --------------------------------------------------
@@ -33,6 +34,7 @@ Here are the available roles:
 
   heading:
 
+  Name "Hi":
   <h1 />
 
   --------------------------------------------------
@@ -227,7 +229,7 @@ test('can be filtered by accessible name', () => {
 test('accessible name comparison is case sensitive', () => {
   const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)
 
-  // actual:  "Sign up", 
+  // actual:  "Sign up",
   // queried: "Sign Up"
   expect(() => getByRole('heading', {name: 'Sign Up'}))
     .toThrowErrorMatchingInlineSnapshot(`

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -1,6 +1,6 @@
 import {configure, getConfig} from '../config'
-import {render, renderIntoDocument} from './helpers/test-utils'
 import {getQueriesForElement} from '../get-queries-for-element'
+import {render, renderIntoDocument} from './helpers/test-utils'
 
 test('by default logs accessible roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -224,28 +224,11 @@ test('can be filtered by accessible name', () => {
   ).not.toBeNull()
 })
 
-test('accessible name filter implements TextMatch', () => {
-  const {getByRole} = render(
-    `<h1>Sign <em>up</em></h1><h2>Details</h2><h2>Your Signature</h2>`,
-  )
-
-  // subset via regex
-  expect(getByRole('heading', {name: /gn u/})).not.toBeNull()
-  // regex
-  expect(getByRole('heading', {name: /^sign/i})).not.toBeNull()
-  // function
-  expect(
-    getByRole('heading', {
-      name: (name, element) => {
-        return element.nodeName === 'H2' && name === 'Your Signature'
-      },
-    }),
-  ).not.toBeNull()
-})
-
-test('includes accesible names in error message', () => {
+test('accessible name comparison is case sensitive', () => {
   const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)
 
+  // actual:  "Sign up", 
+  // queried: "Sign Up"
   expect(() => getByRole('heading', {name: 'Sign Up'}))
     .toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "heading" and name "Sign Up"
@@ -268,6 +251,29 @@ Here are the accessible roles:
   </h1>
 </div>"
 `)
+})
+
+test('accessible name filter implements TextMatch', () => {
+  const {getByRole} = render(
+    `<h1>Sign <em>up</em></h1><h2>Details</h2><h2>Your Signature</h2>`,
+  )
+
+  // subset via regex
+  expect(getByRole('heading', {name: /gn u/})).not.toBeNull()
+  // regex
+  expect(getByRole('heading', {name: /^sign/i})).not.toBeNull()
+  // function
+  expect(
+    getByRole('heading', {
+      name: (name, element) => {
+        return element.nodeName === 'H2' && name === 'Your Signature'
+      },
+    }),
+  ).not.toBeNull()
+})
+
+test('TextMatch serialization in error message', () => {
+  const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)
 
   expect(() => getByRole('heading', {name: /Login/}))
     .toThrowErrorMatchingInlineSnapshot(`

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -224,12 +224,77 @@ test('can be filtered by accessible name', () => {
   ).not.toBeNull()
 })
 
+test('accessible name filter implements TextMatch', () => {
+  const {getByRole} = render(
+    `<h1>Sign <em>up</em></h1><h2>Details</h2><h2>Your Signature</h2>`,
+  )
+
+  // subset via regex
+  expect(getByRole('heading', {name: /gn u/})).not.toBeNull()
+  // regex
+  expect(getByRole('heading', {name: /^sign/i})).not.toBeNull()
+  // function
+  expect(
+    getByRole('heading', {
+      name: (name, element) => {
+        return element.nodeName === 'H2' && name === 'Your Signature'
+      },
+    }),
+  ).not.toBeNull()
+})
+
 test('includes accesible names in error message', () => {
   const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)
 
   expect(() => getByRole('heading', {name: 'Sign Up'}))
     .toThrowErrorMatchingInlineSnapshot(`
 "Unable to find an accessible element with the role "heading" and name "Sign Up"
+
+Here are the accessible roles:
+
+  heading:
+
+  Name "Sign up":
+  <h1 />
+
+  --------------------------------------------------
+
+<div>
+  <h1>
+    Sign 
+    <em>
+      up
+    </em>
+  </h1>
+</div>"
+`)
+
+  expect(() => getByRole('heading', {name: /Login/}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an accessible element with the role "heading" and name \`/Login/\`
+
+Here are the accessible roles:
+
+  heading:
+
+  Name "Sign up":
+  <h1 />
+
+  --------------------------------------------------
+
+<div>
+  <h1>
+    Sign 
+    <em>
+      up
+    </em>
+  </h1>
+</div>"
+`)
+
+  expect(() => getByRole('heading', {name: () => false}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an accessible element with the role "heading" and name \`() => false\`
 
 Here are the accessible roles:
 

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,3 +1,4 @@
+import {computeAccessibleName} from 'dom-accessibility-api'
 import {
   getImplicitAriaRoles,
   prettyRoles,
@@ -19,6 +20,7 @@ function queryAllByRole(
     exact = true,
     collapseWhitespace,
     hidden = getConfig().defaultHidden,
+    name,
     trim,
     normalizer,
     queryFallbacks = false,
@@ -70,6 +72,11 @@ function queryAllByRole(
           }) === false
         : true
     })
+    .filter(element => {
+      return typeof name === 'string'
+        ? computeAccessibleName(element) === name
+        : true
+    })
 }
 
 const getMultipleError = (c, role) =>
@@ -78,9 +85,12 @@ const getMultipleError = (c, role) =>
 const getMissingError = (
   container,
   role,
-  {hidden = getConfig().defaultHidden} = {},
+  {hidden = getConfig().defaultHidden, name} = {},
 ) => {
-  const roles = prettyRoles(container, {hidden})
+  const roles = prettyRoles(container, {
+    hidden,
+    includeName: typeof name === 'string',
+  })
   let roleMessage
 
   if (roles.length === 0) {
@@ -103,7 +113,9 @@ Here are the ${hidden === false ? 'accessible' : 'available'} roles:
   return `
 Unable to find an ${
     hidden === false ? 'accessible ' : ''
-  }element with the role "${role}"
+  }element with the role "${role}"${
+    typeof name === 'string' ? ` and name "${name}"` : ''
+  }
 
 ${roleMessage}`.trim()
 }

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -73,9 +73,19 @@ function queryAllByRole(
         : true
     })
     .filter(element => {
-      return typeof name === 'string'
-        ? computeAccessibleName(element) === name
-        : true
+      if (name === undefined) {
+        // Don't care
+        return true
+      }
+
+      const accessibleName = computeAccessibleName(element)
+      if (typeof name === 'string') {
+        return name === accessibleName
+      }
+      if (typeof name === 'function') {
+        return name(accessibleName, element)
+      }
+      return name.test(accessibleName)
     })
 }
 
@@ -89,7 +99,7 @@ const getMissingError = (
 ) => {
   const roles = prettyRoles(container, {
     hidden,
-    includeName: typeof name === 'string',
+    includeName: name !== undefined,
   })
   let roleMessage
 
@@ -110,12 +120,19 @@ Here are the ${hidden === false ? 'accessible' : 'available'} roles:
 `.trim()
   }
 
+  let nameHint = ''
+  if (name === undefined) {
+    nameHint = ''
+  } else if (typeof name === 'string') {
+    nameHint = ` and name "${name}"`
+  } else {
+    nameHint = ` and name \`${name}\``
+  }
+
   return `
 Unable to find an ${
     hidden === false ? 'accessible ' : ''
-  }element with the role "${role}"${
-    typeof name === 'string' ? ` and name "${name}"` : ''
-  }
+  }element with the role "${role}"${nameHint}
 
 ${roleMessage}`.trim()
 }

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -78,14 +78,12 @@ function queryAllByRole(
         return true
       }
 
-      const accessibleName = computeAccessibleName(element)
-      if (typeof name === 'string') {
-        return name === accessibleName
-      }
-      if (typeof name === 'function') {
-        return name(accessibleName, element)
-      }
-      return name.test(accessibleName)
+      return matches(
+        computeAccessibleName(element),
+        element,
+        name,
+        text => text,
+      )
     })
 }
 

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -139,7 +139,7 @@ function getRoles(container, {hidden = false} = {}) {
     }, {})
 }
 
-function prettyRoles(dom, {hidden, includeName}) {
+function prettyRoles(dom, {hidden}) {
   const roles = getRoles(dom, {hidden})
 
   return Object.entries(roles)
@@ -147,8 +147,7 @@ function prettyRoles(dom, {hidden, includeName}) {
       const delimiterBar = '-'.repeat(50)
       const elementsString = elements
         .map(el => {
-          const nameString =
-            includeName === true ? `Name "${computeAccessibleName(el)}":\n` : ''
+          const nameString = `Name "${computeAccessibleName(el)}":\n`
           const domString = prettyDOM(el.cloneNode(false))
           return `${nameString}${domString}`
         })
@@ -159,8 +158,8 @@ function prettyRoles(dom, {hidden, includeName}) {
     .join('\n')
 }
 
-const logRoles = (dom, {hidden = false, includeName = true} = {}) =>
-  console.log(prettyRoles(dom, {hidden, includeName}))
+const logRoles = (dom, {hidden = false} = {}) =>
+  console.log(prettyRoles(dom, {hidden}))
 
 export {
   getRoles,

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -1,5 +1,6 @@
 import {elementRoles} from 'aria-query'
 import {prettyDOM} from './pretty-dom'
+import {computeAccessibleName} from 'dom-accessibility-api'
 
 const elementRoleList = buildElementRoleList(elementRoles)
 
@@ -138,14 +139,19 @@ function getRoles(container, {hidden = false} = {}) {
     }, {})
 }
 
-function prettyRoles(dom, {hidden}) {
+function prettyRoles(dom, {hidden, includeName = false}) {
   const roles = getRoles(dom, {hidden})
 
   return Object.entries(roles)
     .map(([role, elements]) => {
       const delimiterBar = '-'.repeat(50)
       const elementsString = elements
-        .map(el => prettyDOM(el.cloneNode(false)))
+        .map(
+          el =>
+            `${
+              includeName === true ? `Name "${computeAccessibleName(el)}":\n` : ''
+            }${prettyDOM(el.cloneNode(false))}`,
+        )
         .join('\n\n')
 
       return `${role}:\n\n${elementsString}\n\n${delimiterBar}`

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -139,7 +139,7 @@ function getRoles(container, {hidden = false} = {}) {
     }, {})
 }
 
-function prettyRoles(dom, {hidden, includeName = false}) {
+function prettyRoles(dom, {hidden, includeName}) {
   const roles = getRoles(dom, {hidden})
 
   return Object.entries(roles)
@@ -149,7 +149,9 @@ function prettyRoles(dom, {hidden, includeName = false}) {
         .map(
           el =>
             `${
-              includeName === true ? `Name "${computeAccessibleName(el)}":\n` : ''
+              includeName === true
+                ? `Name "${computeAccessibleName(el)}":\n`
+                : ''
             }${prettyDOM(el.cloneNode(false))}`,
         )
         .join('\n\n')
@@ -159,8 +161,8 @@ function prettyRoles(dom, {hidden, includeName = false}) {
     .join('\n')
 }
 
-const logRoles = (dom, {hidden = false} = {}) =>
-  console.log(prettyRoles(dom, {hidden}))
+const logRoles = (dom, {hidden = false, includeName = false} = {}) =>
+  console.log(prettyRoles(dom, {hidden, includeName}))
 
 export {
   getRoles,

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -161,7 +161,7 @@ function prettyRoles(dom, {hidden, includeName}) {
     .join('\n')
 }
 
-const logRoles = (dom, {hidden = false, includeName = false} = {}) =>
+const logRoles = (dom, {hidden = false, includeName = true} = {}) =>
   console.log(prettyRoles(dom, {hidden, includeName}))
 
 export {

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -1,6 +1,6 @@
 import {elementRoles} from 'aria-query'
-import {prettyDOM} from './pretty-dom'
 import {computeAccessibleName} from 'dom-accessibility-api'
+import {prettyDOM} from './pretty-dom'
 
 const elementRoleList = buildElementRoleList(elementRoles)
 

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -146,14 +146,12 @@ function prettyRoles(dom, {hidden, includeName}) {
     .map(([role, elements]) => {
       const delimiterBar = '-'.repeat(50)
       const elementsString = elements
-        .map(
-          el =>
-            `${
-              includeName === true
-                ? `Name "${computeAccessibleName(el)}":\n`
-                : ''
-            }${prettyDOM(el.cloneNode(false))}`,
-        )
+        .map(el => {
+          const nameString =
+            includeName === true ? `Name "${computeAccessibleName(el)}":\n` : ''
+          const domString = prettyDOM(el.cloneNode(false))
+          return `${nameString}${domString}`
+        })
         .join('\n\n')
 
       return `${role}:\n\n${elementsString}\n\n${delimiterBar}`


### PR DESCRIPTION
**What**:
Add a `name` option to `ByRole` queries. If a `name` is provided then the error messages will include the accessible name of each element with a role.

**Why**:

Better alternative to `byText` (especially for buttons) or `byLabelText` when `aria-label` or `aria-labelledby` is used (e.g. for custom Select implementations) or `byTestId` for "semantic" elements e.g. menuitem. 

There's a bit more to write in https://testing-library.com/docs/guide-which-query to explain why you still might want to use byLabelText('street') instead of `byRole('textbox', { name: 'street' })`.

**How**:

Using https://github.com/eps1lon/dom-accessibility-api#readme which implements https://www.w3.org/TR/accname-1.2/ and is tested against web-platform-tests

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs). See https://github.com/testing-library/testing-library-docs/pull/368 ([Preview](https://deploy-preview-368--testing-library.netlify.com/docs/dom-testing-library/api-queries#byrole))
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I would hope that (after review and testing phase) we can move that package under the testing-library umbrella and move isInaccessible into dom-accessibility-api. In the end I'd like to add a single configuration that allows mocking `window.getComputedStyle` for the a11y context. That operation is quite expensive and I think allowing to pretend that every element is visible is sufficient for unit testing. The rationale being that we don't exclude certain groups of people by (accidentally) implementing inaccessible component but instead exclude everyone if we assert on elements that are actually visually hidden.