### PR TITLE
feat(ByRole): Add support for fallback roles

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -434,6 +434,8 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
   expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
   expect(queryAllByRole(/img/i)).toHaveLength(1)
+  expect(queryAllByRole('meter')).toHaveLength(1)
+  expect(queryAllByRole('progressbar')).toHaveLength(0)
   expect(queryAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
 })
 
@@ -485,6 +487,7 @@ test('getAll* matchers return an array', () => {
   expect(getAllByDisplayValue(/cars$/)).toHaveLength(2)
   expect(getAllByText(/^where/i)).toHaveLength(1)
   expect(getAllByRole(/container/i)).toHaveLength(1)
+  expect(getAllByRole('meter')).toHaveLength(1)
   expect(getAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
 })
 

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -412,6 +412,7 @@ test('queryAllByRole returns semantic html elements', () => {
         </tbody>
       </table>
       <table role="grid"></table>
+      <div role="meter progressbar" />
       <button>Button</button>
     </form>
   `)
@@ -433,6 +434,7 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
   expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
   expect(queryAllByRole(/img/i)).toHaveLength(1)
+  expect(queryAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
 })
 
 test('getAll* matchers return an array', () => {
@@ -471,6 +473,7 @@ test('getAll* matchers return an array', () => {
         <option value="volvo">Toyota</option>
         <option value="audi">Honda</option>
       </select>
+      <div role="meter progressbar" />
     </div>,
   `)
   expect(getAllByAltText(/finding.*poster$/i)).toHaveLength(2)
@@ -482,6 +485,7 @@ test('getAll* matchers return an array', () => {
   expect(getAllByDisplayValue(/cars$/)).toHaveLength(2)
   expect(getAllByText(/^where/i)).toHaveLength(1)
   expect(getAllByRole(/container/i)).toHaveLength(1)
+  expect(getAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
 })
 
 test('getAll* matchers throw for 0 matches', () => {
@@ -656,6 +660,18 @@ test('using jest helpers to check element role', () => {
   `)
 
   expect(getByRole('dialog')).toHaveTextContent('Contents')
+})
+
+test('using jest helpers to check element fallback roles', () => {
+  const {getByRole} = render(`
+    <div role="meter progressbar">
+      <span>Contents</span>
+    </div>
+  `)
+
+  expect(getByRole('progressbar', {queryFallbacks: true})).toHaveTextContent(
+    'Contents',
+  )
 })
 
 test('test the debug helper prints the dom state here', () => {

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -33,6 +33,7 @@ test('find asynchronously finds elements', async () => {
       <img alt="test alt text" src="/lucy-ricardo.png" />
       <span title="test title" />
       <div role="dialog"></div>
+      <div role="meter progressbar"></div>
     </div>
   `)
   await expect(findByLabelText('test-label')).resolves.toBeTruthy()
@@ -55,6 +56,13 @@ test('find asynchronously finds elements', async () => {
 
   await expect(findByRole('dialog')).resolves.toBeTruthy()
   await expect(findAllByRole('dialog')).resolves.toHaveLength(1)
+
+  await expect(
+    findByRole('progressbar', {queryFallbacks: true}),
+  ).resolves.toBeTruthy()
+  await expect(
+    findAllByRole('progressbar', {queryFallbacks: true}),
+  ).resolves.toHaveLength(1)
 
   await expect(findByTestId('test-id')).resolves.toBeTruthy()
   await expect(findAllByTestId('test-id')).resolves.toHaveLength(1)

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -57,6 +57,8 @@ test('find asynchronously finds elements', async () => {
   await expect(findByRole('dialog')).resolves.toBeTruthy()
   await expect(findAllByRole('dialog')).resolves.toHaveLength(1)
 
+  await expect(findByRole('meter')).resolves.toBeTruthy()
+  await expect(findAllByRole('meter')).resolves.toHaveLength(1)
   await expect(
     findByRole('progressbar', {queryFallbacks: true}),
   ).resolves.toBeTruthy()

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -41,14 +41,20 @@ function queryAllByRole(
       const isRoleSpecifiedExplicitly = node.hasAttribute('role')
 
       if (isRoleSpecifiedExplicitly) {
+        const roleValue = node.getAttribute('role')
         if (queryFallbacks) {
-          return node
-            .getAttribute('role')
+          return roleValue
             .split(' ')
             .filter(Boolean)
             .some(text => matcher(text, node, role, matchNormalizer))
         }
-        return matcher(node.getAttribute('role'), node, role, matchNormalizer)
+        // if a custom normalizer is passed then let normalizer handle the role value
+        if (normalizer) {
+          return matcher(roleValue, node, role, matchNormalizer)
+        }
+        // other wise only send the first word to match
+        const [firstWord] = roleValue.split(' ')
+        return matcher(firstWord, node, role, matchNormalizer)
       }
 
       const implicitRoles = getImplicitAriaRoles(node)

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -21,6 +21,7 @@ function queryAllByRole(
     hidden = getConfig().defaultHidden,
     trim,
     normalizer,
+    queryFallbacks = false,
   } = {},
 ) {
   const matcher = exact ? matches : fuzzyMatches
@@ -40,6 +41,13 @@ function queryAllByRole(
       const isRoleSpecifiedExplicitly = node.hasAttribute('role')
 
       if (isRoleSpecifiedExplicitly) {
+        if (queryFallbacks) {
+          return node
+            .getAttribute('role')
+            .split(' ')
+            .filter(Boolean)
+            .some(text => matcher(text, node, role, matchNormalizer))
+        }
         return matcher(node.getAttribute('role'), node, role, matchNormalizer)
       }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding support for `*ByRole` query to query multiple roles.

<!-- Why are these changes necessary? -->

**Why**:
> The *ByRole query should support querying elements that have multiple role values defined. the ARIA spec defines the role attribute as a whitespace delimited list of values, of which the engine will choose the first supported value. See w3.org/TR/wai-aria-1.2/#introroles. Querying by role when testing should take this into account and find roles matching any of the items in the list rather than only the entire role attribute.

Closes: #411 

<!-- How were these changes implemented? -->

**How**: With the help of a flag named `queryFallbacks`, `*ByRole` queries can query multiple roles. If the flag is missing and you're trying to query a role that is located on the right side, then this will throw an error. The working is same as mentioned in (https://github.com/testing-library/dom-testing-library/issues/411#issuecomment-563799459)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) (I'm not sure whether it's needed or not)
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->