### PR TITLE
fix(pretty-dom): Ensure safe process.env access

### DIFF
--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -16,7 +16,9 @@ const inNode = () =>
   process.versions.node !== undefined
 
 const getMaxLength = dom =>
-  inCypress(dom) ? 0 : process.env.DEBUG_PRINT_LIMIT || 7000
+  inCypress(dom)
+    ? 0
+    : typeof process !== 'undefined' && process.env.DEBUG_PRINT_LIMIT || 7000
 
 const {DOMElement, DOMCollection} = prettyFormat.plugins
 


### PR DESCRIPTION
refs #413 
refs #161 


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Not all environments (particularly the browser, where testing via tools like Karma occurs) have access to the `process` variable. There is already checking to ensure that its member properties have fallbacks, and this ensures that if it is simply unavailable the same fallback occurs.

**Why**:

I'd like to begin the work of supporting Karma and web components.

**How**:

Extra test for `process`.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
