### PR TITLE
feat(event): add new history popstate event

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -327,6 +327,17 @@ test('fires events on Window', () => {
   window.removeEventListener('message', messageSpy)
 })
 
+test('fires history popstate event on Window', () => {
+  const popStateSpy = jest.fn()
+  window.addEventListener('popstate', popStateSpy)
+  fireEvent.popState(window, {
+    location: 'http://www.example.com/?page=1',
+    state: {page: 1},
+  })
+  expect(popStateSpy).toHaveBeenCalledTimes(1)
+  window.removeEventListener('popstate', popStateSpy)
+})
+
 test('fires shortcut events on Window', () => {
   const clickSpy = jest.fn()
   window.addEventListener('click', clickSpy)

--- a/src/events.js
+++ b/src/events.js
@@ -338,6 +338,11 @@ const eventMap = {
     EventType: 'PointerEvent',
     defaultInit: {bubbles: false, cancelable: false},
   },
+  // history events
+  popState: {
+    EventType: 'PopStateEvent',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
 }
 
 const eventAliasMap = {


### PR DESCRIPTION
Added popstate to events map with respective tests #427

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
popstate history event is not supported.

<!-- Why are these changes necessary? -->

**Why**:
Adding this event will allow the testing of custom router implementations

<!-- How were these changes implemented? -->

**How**:
Added new popstate event applicable on window.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
