### PR TITLE
fix: fireEvent in IE11

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -392,7 +392,17 @@ Object.keys(eventMap).forEach(key => {
     Object.assign(node, targetProperties)
     const window = getWindowFromNode(node)
     const EventConstructor = window[EventType] || window.Event
-    return new EventConstructor(eventName, eventInit)
+    if (typeof EventConstructor === 'function') {
+      return new EventConstructor(eventName, eventInit)
+    }
+    // IE11 polyfill from https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+    const event = window.document.createEvent(EventType)
+    const {bubbles, cancelable, detail, ...otherInit} = eventInit
+    event.initEvent(eventName, bubbles, cancelable, detail)
+    Object.keys(otherInit).forEach(eventKey => {
+      event[eventKey] = otherInit[eventKey]
+    })
+    return event
   }
 
   fireEvent[key] = (node, init) => fireEvent(node, createEvent[key](node, init))

--- a/src/events.js
+++ b/src/events.js
@@ -392,17 +392,19 @@ Object.keys(eventMap).forEach(key => {
     Object.assign(node, targetProperties)
     const window = getWindowFromNode(node)
     const EventConstructor = window[EventType] || window.Event
+    /* istanbul ignore else  */
     if (typeof EventConstructor === 'function') {
       return new EventConstructor(eventName, eventInit)
+    } else {
+      // IE11 polyfill from https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+      const event = window.document.createEvent(EventType)
+      const {bubbles, cancelable, detail, ...otherInit} = eventInit
+      event.initEvent(eventName, bubbles, cancelable, detail)
+      Object.keys(otherInit).forEach(eventKey => {
+        event[eventKey] = otherInit[eventKey]
+      })
+      return event
     }
-    // IE11 polyfill from https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-    const event = window.document.createEvent(EventType)
-    const {bubbles, cancelable, detail, ...otherInit} = eventInit
-    event.initEvent(eventName, bubbles, cancelable, detail)
-    Object.keys(otherInit).forEach(eventKey => {
-      event[eventKey] = otherInit[eventKey]
-    })
-    return event
   }
 
   fireEvent[key] = (node, init) => fireEvent(node, createEvent[key](node, init))


### PR DESCRIPTION
Fixes #421
**What**:

Use `createEvent` instead of `new Event` if `Event` is not constructable

**Why**:

`new Event` is not supported in IE 11

**How**:

Use https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ] I've prepared a PR for types targeting~
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)~
- [x] Tests: Verified pass in https://github.com/eps1lon/ie-fire-event-repro/runs/421197374?check_suite_focus=true using the codesandbox build via https://github.com/ysgk/ie-fire-event-repro/compare/master...eps1lon:fix/ie11-events
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
