### PR TITLE
chore: Bump jsdom to 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "jest-in-case": "^1.0.2",
     "jest-serializer-ansi": "^1.0.3",
     "jest-watch-select-projects": "^1.0.0",
-    "jsdom": "^15.1.1",
-    "kcd-scripts": "^1.7.0"
+    "jsdom": "^15.2.1",
+    "kcd-scripts": "^5.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/__tests__/__snapshots__/wait-for-dom-change.js.snap
+++ b/src/__tests__/__snapshots__/wait-for-dom-change.js.snap
@@ -2,12 +2,36 @@
 
 exports[`timers works with fake timers 1`] = `
 Array [
-  MutationRecord {},
+  Object {
+    "addedNodes": NodeList [],
+    "attributeName": "id",
+    "attributeNamespace": null,
+    "nextSibling": null,
+    "oldValue": null,
+    "previousSibling": null,
+    "removedNodes": NodeList [],
+    "target": <div
+      id="foo"
+    />,
+    "type": "attributes",
+  },
 ]
 `;
 
 exports[`timers works with real timers 1`] = `
 Array [
-  MutationRecord {},
+  Object {
+    "addedNodes": NodeList [],
+    "attributeName": "id",
+    "attributeNamespace": null,
+    "nextSibling": null,
+    "oldValue": null,
+    "previousSibling": null,
+    "removedNodes": NodeList [],
+    "target": <div
+      id="foo"
+    />,
+    "type": "attributes",
+  },
 ]
 `;

--- a/src/__tests__/__snapshots__/wait-for-dom-change.js.snap
+++ b/src/__tests__/__snapshots__/wait-for-dom-change.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timers works with fake timers 1`] = `
+Array [
+  MutationRecord {},
+]
+`;
+
+exports[`timers works with real timers 1`] = `
+Array [
+  MutationRecord {},
+]
+`;

--- a/src/__tests__/wait-for-dom-change.js
+++ b/src/__tests__/wait-for-dom-change.js
@@ -18,22 +18,10 @@ test('waits for the dom to change in the document', async () => {
   setTimeout(() => container.firstChild.setAttribute('id', 'foo'))
   const mutationResult = await promise
   expect(mutationResult).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "addedNodes": Array [],
-    "attributeName": "id",
-    "attributeNamespace": null,
-    "nextSibling": null,
-    "oldValue": null,
-    "previousSibling": null,
-    "removedNodes": Array [],
-    "target": <div
-      id="foo"
-    />,
-    "type": "attributes",
-  },
-]
-`)
+    Array [
+      MutationRecord {},
+    ]
+  `)
 })
 
 test('waits for the dom to change in a specified container', async () => {
@@ -42,22 +30,10 @@ test('waits for the dom to change in a specified container', async () => {
   setTimeout(() => container.firstChild.setAttribute('id', 'foo'))
   const mutationResult = await promise
   expect(mutationResult).toMatchInlineSnapshot(`
-Array [
-  Object {
-    "addedNodes": Array [],
-    "attributeName": "id",
-    "attributeNamespace": null,
-    "nextSibling": null,
-    "oldValue": null,
-    "previousSibling": null,
-    "removedNodes": Array [],
-    "target": <div
-      id="foo"
-    />,
-    "type": "attributes",
-  },
-]
-`)
+    Array [
+      MutationRecord {},
+    ]
+  `)
 })
 
 describe('timers', () => {
@@ -73,23 +49,7 @@ describe('timers', () => {
       jest.advanceTimersByTime(110)
     }
 
-    await expect(promise).resolves.toMatchInlineSnapshot(`
-  Array [
-    Object {
-      "addedNodes": Array [],
-      "attributeName": "id",
-      "attributeNamespace": null,
-      "nextSibling": null,
-      "oldValue": null,
-      "previousSibling": null,
-      "removedNodes": Array [],
-      "target": <div
-        id="foo"
-      />,
-      "type": "attributes",
-    },
-  ]
-  `)
+    await expect(promise).resolves.toMatchSnapshot()
   }
 
   it('works with real timers', async () => {

--- a/src/__tests__/wait-for-dom-change.js
+++ b/src/__tests__/wait-for-dom-change.js
@@ -19,7 +19,19 @@ test('waits for the dom to change in the document', async () => {
   const mutationResult = await promise
   expect(mutationResult).toMatchInlineSnapshot(`
     Array [
-      MutationRecord {},
+      Object {
+        "addedNodes": NodeList [],
+        "attributeName": "id",
+        "attributeNamespace": null,
+        "nextSibling": null,
+        "oldValue": null,
+        "previousSibling": null,
+        "removedNodes": NodeList [],
+        "target": <div
+          id="foo"
+        />,
+        "type": "attributes",
+      },
     ]
   `)
 })
@@ -31,7 +43,19 @@ test('waits for the dom to change in a specified container', async () => {
   const mutationResult = await promise
   expect(mutationResult).toMatchInlineSnapshot(`
     Array [
-      MutationRecord {},
+      Object {
+        "addedNodes": NodeList [],
+        "attributeName": "id",
+        "attributeNamespace": null,
+        "nextSibling": null,
+        "oldValue": null,
+        "previousSibling": null,
+        "removedNodes": NodeList [],
+        "target": <div
+          id="foo"
+        />,
+        "type": "attributes",
+      },
     ]
   `)
 })

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -2,3 +2,26 @@ import '@testing-library/jest-dom/extend-expect'
 import jestSerializerAnsi from 'jest-serializer-ansi'
 
 expect.addSnapshotSerializer(jestSerializerAnsi)
+// add serializer for MutationRecord
+expect.addSnapshotSerializer({
+  print: (record, serialize) => {
+    return serialize({
+      addedNodes: record.addedNodes,
+      attributeName: record.attributeName,
+      attributeNamespace: record.attributeNamespace,
+      nextSibling: record.nextSibling,
+      oldValue: record.oldValue,
+      previousSibling: record.previousSibling,
+      removedNodes: record.removedNodes,
+      target: record.target,
+      type: record.type,
+    })
+  },
+  test: value => {
+    // list of records will stringify to the same value
+    return (
+      Array.isArray(value) === false &&
+      String(value) === '[object MutationRecord]'
+    )
+  },
+})


### PR DESCRIPTION
Not sure which version we should use. While the latest is 16 it isn't the default version used in jest. Ideally we would test with jsdom 15 and 16 just to be aware of changes between those versions.

**What**:

Bump used jsdom version to 15.2.1

**Why**:

jsdom 15 has MutationObserver support as well as perf improvements. 

**How**:

- fixing breaking changes in jest and jsodm

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
