### PR TITLE
Fixed ByLabel queries to work with selects

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -830,3 +830,16 @@ test('can get a textarea with children', () => {
   `)
   getByLabelText('Label')
 })
+
+test('can get a select with options', () => {
+  const {getByLabelText} = renderIntoDocument(`
+    <label>
+      Label
+      <select>
+        <option>Some</option>
+        <option>Options</option>
+      </select>
+    </label>
+  `)
+  getByLabelText('Label')
+})

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -25,6 +25,12 @@ function queryAllLabelsByText(
       textToMatch = textToMatch.replace(textarea.value, '')
     })
 
+    // The children of a select are also part of `textContent`, so we
+    // need also to remove their text.
+    Array.from(label.querySelectorAll('select')).forEach(select => {
+      textToMatch = textToMatch.replace(select.textContent, '')
+    })
+
     return matcher(textToMatch, label, text, matchNormalizer)
   })
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Updating the ByLabel queries to work with `<select>` components. It didn't work properly with `<select>` components because the text from the options is part of the label's `textContent` property.

<!-- Why are these changes necessary? -->

**Why**:

It seems super counter-intuitive that it works really well for other inputs (even `<textarea>`), but not for `<select>`. I think having this working properly will make this library an even greater joy to use :heart:

<!-- How were these changes implemented? -->

**How**:

I used the same strategy used for `<textarea>` components, but instead removing the `textContent` value from the `<select>` components from the label's `textContent`. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the (_I'm not sure it's needed in this case_)
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting (_I'm not sure either_)
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ x] Tests
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

If anyone is having this same issue and this fix is not available, you can use this workaround:

```js
getByLabelText(/^Label/)
// instead of
getByLabelText('Label')
```

I would also like to add that you rule for making front-end testing such a pleasant experience! :heart: 