### PR TITLE
feat(config): add customGetElementError config option

### DIFF
--- a/src/__tests__/__snapshots__/get-by-errors.js.snap
+++ b/src/__tests__/__snapshots__/get-by-errors.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getByLabelText query will throw the custom error returned by config.customGetElementError 1`] = `"My custom error: Unable to find a label with the text of: TEST QUERY"`;
+
+exports[`getByText query will throw the custom error returned by config.customGetElementError 1`] = `"My custom error: Unable to find an element with the text: TEST QUERY. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`;

--- a/src/__tests__/__snapshots__/get-by-errors.js.snap
+++ b/src/__tests__/__snapshots__/get-by-errors.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getByLabelText query will throw the custom error returned by config.customGetElementError 1`] = `"My custom error: Unable to find a label with the text of: TEST QUERY"`;
+exports[`getByLabelText query will throw the custom error returned by config.getElementError 1`] = `"My custom error: Unable to find a label with the text of: TEST QUERY"`;
 
-exports[`getByText query will throw the custom error returned by config.customGetElementError 1`] = `"My custom error: Unable to find an element with the text: TEST QUERY. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`;
+exports[`getByText query will throw the custom error returned by config.getElementError 1`] = `"My custom error: Unable to find an element with the text: TEST QUERY. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`;

--- a/src/__tests__/get-by-errors.js
+++ b/src/__tests__/get-by-errors.js
@@ -47,15 +47,15 @@ cases(
 )
 
 test.each([['getByText'], ['getByLabelText']])(
-  '%s query will throw the custom error returned by config.customGetElementError',
+  '%s query will throw the custom error returned by config.getElementError',
   query => {
-    const customGetElementError = jest.fn(
+    const getElementError = jest.fn(
       (message, _container) => new Error(`My custom error: ${message}`),
     )
-    configure({customGetElementError})
+    configure({getElementError})
     document.body.innerHTML = '<div>Hello</div>'
     expect(() => screen[query]('TEST QUERY')).toThrowErrorMatchingSnapshot()
-    expect(customGetElementError).toBeCalledTimes(1)
+    expect(getElementError).toBeCalledTimes(1)
   },
 )
 

--- a/src/__tests__/get-by-errors.js
+++ b/src/__tests__/get-by-errors.js
@@ -1,5 +1,12 @@
 import cases from 'jest-in-case'
+import {screen} from '../'
+import {configure, getConfig} from '../config'
 import {render} from './helpers/test-utils'
+
+const originalConfig = getConfig()
+beforeEach(() => {
+  configure(originalConfig)
+})
 
 cases(
   'getBy* queries throw an error when there are multiple elements returned',
@@ -36,6 +43,19 @@ cases(
       query: /his/,
       html: `<div data-testid="his"></div><div data-testid="history"></div>`,
     },
+  },
+)
+
+test.each([['getByText'], ['getByLabelText']])(
+  '%s query will throw the custom error returned by config.customGetElementError',
+  query => {
+    const customGetElementError = jest.fn(
+      (message, _container) => new Error(`My custom error: ${message}`),
+    )
+    configure({customGetElementError})
+    document.body.innerHTML = '<div>Hello</div>'
+    expect(() => screen[query]('TEST QUERY')).toThrowErrorMatchingSnapshot()
+    expect(customGetElementError).toBeCalledTimes(1)
   },
 )
 

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,9 @@ let config = {
   asyncWrapper: cb => cb(),
   // default value for the `hidden` option in `ByRole` queries
   defaultHidden: false,
+
+  // called when getBy* queries fail. (message, container) => Error
+  customGetElementError: null,
 }
 
 export function configure(newConfig) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import {prettyDOM} from './pretty-dom'
+
 // It would be cleaner for this to live inside './queries', but
 // other parts of the code assume that all exports from
 // './queries' are query functions.
@@ -16,7 +18,11 @@ let config = {
   defaultHidden: false,
 
   // called when getBy* queries fail. (message, container) => Error
-  customGetElementError: null,
+  getElementError(message, container) {
+    return new Error(
+      [message, prettyDOM(container)].filter(Boolean).join('\n\n'),
+    )
+  },
 }
 
 export function configure(newConfig) {

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -1,8 +1,8 @@
+import {getConfig} from '../config'
 import {
   fuzzyMatches,
   matches,
   makeNormalizer,
-  getElementError,
   queryAllByAttribute,
   makeFindQuery,
   makeSingleQuery,
@@ -104,12 +104,12 @@ function getAllByLabelText(container, text, ...rest) {
   if (!els.length) {
     const labels = queryAllLabelsByText(container, text, ...rest)
     if (labels.length) {
-      throw getElementError(
+      throw getConfig().getElementError(
         `Found a label with the text of: ${text}, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.`,
         container,
       )
     } else {
-      throw getElementError(
+      throw getConfig().getElementError(
         `Unable to find a label with the text of: ${text}`,
         container,
       )

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -1,8 +1,13 @@
 import {prettyDOM} from './pretty-dom'
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
 import {waitForElement} from './wait-for-element'
+import {getConfig} from './config'
 
 function getElementError(message, container) {
+  const customGetElementError = getConfig().customGetElementError
+  if (customGetElementError) {
+    return customGetElementError(message, container)
+  }
   return new Error([message, prettyDOM(container)].filter(Boolean).join('\n\n'))
 }
 

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -1,18 +1,9 @@
-import {prettyDOM} from './pretty-dom'
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
 import {waitForElement} from './wait-for-element'
 import {getConfig} from './config'
 
-function getElementError(message, container) {
-  const customGetElementError = getConfig().customGetElementError
-  if (customGetElementError) {
-    return customGetElementError(message, container)
-  }
-  return new Error([message, prettyDOM(container)].filter(Boolean).join('\n\n'))
-}
-
 function getMultipleElementsFoundError(message, container) {
-  return getElementError(
+  return getConfig().getElementError(
     `${message}\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`,
     container,
   )
@@ -64,7 +55,10 @@ function makeGetAllQuery(allQuery, getMissingError) {
   return (container, ...args) => {
     const els = allQuery(container, ...args)
     if (!els.length) {
-      throw getElementError(getMissingError(container, ...args), container)
+      throw getConfig().getElementError(
+        getMissingError(container, ...args),
+        container,
+      )
     }
     return els
   }
@@ -91,7 +85,6 @@ function buildQueries(queryAllBy, getMultipleError, getMissingError) {
 }
 
 export {
-  getElementError,
   getMultipleElementsFoundError,
   queryAllByAttribute,
   queryByAttribute,


### PR DESCRIPTION
Closes #360

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Adding a showLogOnFail option to configure logging for getBy* and getAllBy* when the query fails. 
<!-- Why are these changes necessary? -->

**Why**:
Logging the entire document when working with larger components can obscure other error messages. I often find these explicit error messages are more helpful than scrolling through the output from prettyDom. If the DOM needs to be examined then debug() can be used. @benmonro also mentions that this makes working with Testcafe harder.

<!-- How were these changes implemented? -->

**How**:
`getElementError` looks at the config and determines what to output as an error:
```javascript
function getElementError(message, container) {
  const errorMessages = getConfig().showLogOnFail
    ? [message, prettyDOM(container)]
    : [message]
  return new Error(errorMessages.filter(Boolean).join('\n\n'))
}
```
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
