### PR TITLE
feat(waitForElementToBeRemoved): support passing an element directly

### DIFF
--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -49,7 +49,7 @@ test('requires an element to exist first', () => {
   return expect(
     waitForElementToBeRemoved(null),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+    `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
   )
 })
 
@@ -57,7 +57,7 @@ test('requires an unempty array of elements to exist first', () => {
   return expect(
     waitForElementToBeRemoved([]),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+    `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
   )
 })
 
@@ -65,7 +65,7 @@ test('requires an element to exist first (function form)', () => {
   return expect(
     waitForElementToBeRemoved(() => null),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+    `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
   )
 })
 
@@ -73,7 +73,7 @@ test('requires an unempty array of elements to exist first (function form)', () 
   return expect(
     waitForElementToBeRemoved(() => []),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+    `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
   )
 })
 

--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -45,15 +45,23 @@ test('resolves on mutation if callback throws an error', async () => {
   await waitForElementToBeRemoved(() => getByTestId('div'), {timeout: 100})
 })
 
-test('requires a function as the first parameter', () => {
+test('requires an element to exist first', () => {
   return expect(
-    waitForElementToBeRemoved(),
+    waitForElementToBeRemoved(null),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `"waitForElementToBeRemoved requires a callback as the first parameter"`,
+    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
   )
 })
 
-test('requires an element to exist first', () => {
+test('requires an unempty array of elements to exist first', () => {
+  return expect(
+    waitForElementToBeRemoved([]),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+  )
+})
+
+test('requires an element to exist first (function form)', () => {
   return expect(
     waitForElementToBeRemoved(() => null),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -61,7 +69,7 @@ test('requires an element to exist first', () => {
   )
 })
 
-test('requires an unempty array of elements to exist first', () => {
+test('requires an unempty array of elements to exist first (function form)', () => {
   return expect(
     waitForElementToBeRemoved(() => []),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -131,4 +139,38 @@ test('rethrows non-testing-lib errors', () => {
       return div
     }),
   ).rejects.toBe(error)
+})
+
+test('accepts an element as an argument and waits for it to be removed from its top-most parent', async () => {
+  const {queryByTestId} = renderIntoDocument(`
+    <div data-testid="div"></div>
+  `)
+  const div = queryByTestId('div')
+  setTimeout(() => {
+    div.parentElement.removeChild(div)
+  }, 20)
+
+  await waitForElementToBeRemoved(div, {timeout: 200})
+})
+
+test('accepts an array of elements as an argument and waits for those elements to be removed from their top-most parent', async () => {
+  const {queryAllByTestId} = renderIntoDocument(`
+    <div>
+      <div>
+        <div data-testid="div"></div>
+      </div>
+      <div>
+        <div data-testid="div"></div>
+      </div>
+    </div>
+  `)
+  const [div1, div2] = queryAllByTestId('div')
+  setTimeout(() => {
+    div1.parentElement.removeChild(div1)
+  }, 20)
+
+  setTimeout(() => {
+    div2.parentElement.removeChild(div2)
+  }, 50)
+  await waitForElementToBeRemoved([div1, div2], {timeout: 200})
 })

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -2,22 +2,30 @@ import {wait} from './wait'
 
 const isRemoved = result => !result || (Array.isArray(result) && !result.length)
 
-async function waitForElementToBeRemoved(callback, options) {
-  if (!callback) {
-    return Promise.reject(
-      new Error(
-        'waitForElementToBeRemoved requires a callback as the first parameter',
-      ),
-    )
-  }
-
-  // Check if the element is not present synchronously,
-  // As the name implies, waitForElementToBeRemoved should check `present` --> `removed`
-  if (isRemoved(callback())) {
+// Check if the element is not present.
+// As the name implies, waitForElementToBeRemoved should check `present` --> `removed`
+function initialCheck(elements) {
+  if (isRemoved(elements)) {
     throw new Error(
       'The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.',
     )
   }
+}
+
+async function waitForElementToBeRemoved(callback, options) {
+  if (typeof callback !== 'function') {
+    // await waitForElementToBeRemoved(getAllByText('Hello'))
+    initialCheck(callback)
+    const elements = Array.isArray(callback) ? callback : [callback]
+    const getRemainingElements = elements.map(element => {
+      let parent = element.parentElement
+      while (parent.parentElement) parent = parent.parentElement
+      return () => (parent.contains(element) ? element : null)
+    })
+    callback = () => getRemainingElements.map(c => c()).filter(Boolean)
+  }
+
+  initialCheck(callback())
 
   return wait(() => {
     let result

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -7,7 +7,7 @@ const isRemoved = result => !result || (Array.isArray(result) && !result.length)
 function initialCheck(elements) {
   if (isRemoved(elements)) {
     throw new Error(
-      'The callback function which was passed did not return an element or non-empty array of elements. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.',
+      'The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.',
     )
   }
 }


### PR DESCRIPTION
**What**: feat(waitForElementToBeRemoved): support passing an element directly

**Why**: Makes using this async utility simpler

**How**: Overload the argument for this so the callback can be a DOM node (or array of DOM nodes). In that case, we capture those and reassign the callback to a function that checks whether those are still contained in their original parent element

**Checklist**:

- [x] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/394
- [ ] I've prepared a PR for types targeting [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) (Sorry, won't get to this. Will hope the community can make this happen later)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Really excited about this one.