### PR TITLE
feat(wait): remove default no-op callback

### DIFF
--- a/src/__tests__/wait.js
+++ b/src/__tests__/wait.js
@@ -12,10 +12,9 @@ test('it waits for the data to be loaded', async () => {
 })
 
 test('wait defaults to a noop callback', async () => {
-  const handler = jest.fn()
-  Promise.resolve().then(handler)
-  await wait()
-  expect(handler).toHaveBeenCalledTimes(1)
+  await expect(wait()).rejects.toMatchInlineSnapshot(
+    `[Error: wait callback is required]`,
+  )
 })
 
 test('can timeout after the given timeout time', async () => {

--- a/src/wait.js
+++ b/src/wait.js
@@ -9,7 +9,7 @@ import {
 import {getConfig} from './config'
 
 function wait(
-  callback = () => {},
+  callback,
   {
     container = getDocument(),
     timeout = getConfig().asyncUtilTimeout,
@@ -22,6 +22,9 @@ function wait(
     },
   } = {},
 ) {
+  if (!callback) {
+    return Promise.reject(new Error('wait callback is required'))
+  }
   if (interval < 1) interval = 1
   return new Promise((resolve, reject) => {
     let lastError


### PR DESCRIPTION
**What**: Removes the default no-op callback from `wait`

**Why**: That encourages relying on the implementation detail of waiting for the "next tick" and explicit expectations should be used instead.

**How**: Removed the default and added a test to check for the rejected response

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) https://github.com/testing-library/testing-library-docs/pull/394
- [ ] I've prepared a PR for types targeting [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) (still in beta...)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

BREAKING CHANGE: If you used `wait()` in the past, you now have to supply a callback. Relying on the "next tick" is an implementation detail and should be avoided in favor of explicit expectations within your wait callback.
