### PR TITLE
fix(allByLabelText): forEach on NodeList is not supported in edge

### DIFF
--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -64,17 +64,19 @@ function queryAllByLabelText(
       }
       if (label.getAttribute('id')) {
         // <label id="someId">text</label><input aria-labelledby="someId" />
-        container
-          .querySelectorAll(`[aria-labelledby~="${label.getAttribute('id')}"]`)
-          .forEach(element => elementsForLabel.push(element))
+        Array.from(
+          container.querySelectorAll(
+            `[aria-labelledby~="${label.getAttribute('id')}"]`,
+          ),
+        ).forEach(element => elementsForLabel.push(element))
       }
       if (label.childNodes.length) {
         // <label>text: <input /></label>
         const formControlSelector =
           'button, input, meter, output, progress, select, textarea'
-        label
-          .querySelectorAll(formControlSelector)
-          .forEach(element => elementsForLabel.push(element))
+        Array.from(
+          label.querySelectorAll(formControlSelector),
+        ).forEach(element => elementsForLabel.push(element))
       }
       return matchedElements.concat(elementsForLabel)
     }, [])


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

fixes crash in Edge when using `getAllByLabelText`

**Why**:

forEach is not implemented in NodeList in edge 15

**How**:

Convert NodeList to array before using forEach

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests (will run codesandbox canary on Material-UI
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
