### PR TITLE
fix(prettyRoles): crash in older browsers

### DIFF
--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -149,8 +149,10 @@ function getRoles(container, {hidden = false} = {}) {
 function prettyRoles(dom, {hidden}) {
   const roles = getRoles(dom, {hidden})
 
-  return Object.entries(roles)
-    .map(([role, elements]) => {
+  // Object.entries is not supported in older browsers
+  return Object.keys(roles)
+    .map(role => {
+      const elements = roles[role]
       const delimiterBar = '-'.repeat(50)
       const elementsString = elements
         .map(el => {


### PR DESCRIPTION

**What**:

Fixes crash when logging roles in older browsers (namely IE11)

**Why**:

Objec.entries is not implemented in older browsers

**How**:

Use Object.keys

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests (Testing codesandbox canary on Material-UI)
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
