### PR TITLE
fix: use wait in findBy queries

### DIFF
--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -1,5 +1,5 @@
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
-import {waitForElement} from './wait-for-element'
+import {wait} from './wait'
 import {getConfig} from './config'
 
 function getMultipleElementsFoundError(message, container) {
@@ -65,13 +65,10 @@ function makeGetAllQuery(allQuery, getMissingError) {
 }
 
 // this accepts a getter query function and returns a function which calls
-// waitForElement and passing a function which invokes the getter.
+// wait and passing a function which invokes the getter.
 function makeFindQuery(getter) {
-  return (container, text, options, waitForElementOptions) =>
-    waitForElement(
-      () => getter(container, text, options),
-      waitForElementOptions,
-    )
+  return (container, text, options, waitOptions) =>
+    wait(() => getter(container, text, options), waitOptions)
 }
 
 function buildQueries(queryAllBy, getMultipleError, getMissingError) {


### PR DESCRIPTION
**What**: Using the `wait` method instead of `waitForElement` for the `findBy` queries

**Why**: To prevent that deprecations are logged

 Closes #468

**How**: Replace `waitForElement` with `wait` (and by renaming `waitForElementOptions` to `waitOptions`)

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Something else that I've encountered, is that the changes made in #461 didn't make it into the [beta branch](https://github.com/testing-library/dom-testing-library/blob/beta/src/wait.js#L12). 
