### PR TITLE
fix(find*): waitForElement was still in use

### DIFF
--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -1,5 +1,5 @@
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
-import {waitForElement} from './wait-for-element'
+import {waitFor} from './wait-for'
 import {getConfig} from './config'
 
 function getMultipleElementsFoundError(message, container) {
@@ -65,13 +65,10 @@ function makeGetAllQuery(allQuery, getMissingError) {
 }
 
 // this accepts a getter query function and returns a function which calls
-// waitForElement and passing a function which invokes the getter.
+// waitFor and passing a function which invokes the getter.
 function makeFindQuery(getter) {
-  return (container, text, options, waitForElementOptions) =>
-    waitForElement(
-      () => getter(container, text, options),
-      waitForElementOptions,
-    )
+  return (container, text, options, waitForOptions) =>
+    waitFor(() => getter(container, text, options), waitForOptions)
 }
 
 function buildQueries(queryAllBy, getMultipleError, getMissingError) {


### PR DESCRIPTION
**What**: fix(find*): waitForElement was still in use 

**Why**: That method has been deprecated and should not be used (was showing a warning to people using `find*`

**How**: find/replace basically

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
