### PR TITLE
docs: corrects deprecation warning for waitForDomChange

### DIFF
--- a/src/__tests__/wait-for-dom-change.js
+++ b/src/__tests__/wait-for-dom-change.js
@@ -38,7 +38,7 @@ test('waits for the dom to change in the document', async () => {
   expect(console.warn.mock.calls).toMatchInlineSnapshot(`
 Array [
   Array [
-    "\`waitForDomChange\` has been deprecated. Use \`wait\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.",
+    "\`waitForDomChange\` has been deprecated. Use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.",
   ],
 ]
 `)

--- a/src/wait-for-dom-change.js
+++ b/src/wait-for-dom-change.js
@@ -26,7 +26,7 @@ function waitForDomChange({
   if (!hasWarned) {
     hasWarned = true
     console.warn(
-      `\`waitForDomChange\` has been deprecated. Use \`wait\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.`,
+      `\`waitForDomChange\` has been deprecated. Use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.`,
     )
   }
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

If you are migrating from `waitForDomChanges`, it suggests using `wait` instead, which is also deprecated and it suggests `waitFor`. The link in this particular warning is linked to `waitFor`.

```
`waitForElement` has been deprecated. Use a `find*` query ...
```

```
`waitForDomChange` has been deprecated. Use `wait` instead ...
```

but then it says `wait` is also deprecated:

```
`wait` has been deprecated and replaced by `waitFor` instead. In most cases you should be able to find/replace `wait` with `waitFor`.
```

<!-- Why are these changes necessary? -->

**Why**:

☝️ 

<!-- How were these changes implemented? -->

**How**:

Updated deprecation warning string with the correct suggestion

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
