### PR TITLE
upgrade dom-accessibility-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.8.4",
     "@types/testing-library__dom": "^6.12.1",
     "aria-query": "^4.0.2",
-    "dom-accessibility-api": "^0.3.0",
+    "dom-accessibility-api": "^0.4.1",
     "pretty-format": "^25.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**What**: Upgraded dom-accessibility-api to ^0.4.1

**Why**: To support es5 environment. dom-accessibility-api supports es5 from 0.4.1.

PR: https://github.com/eps1lon/dom-accessibility-api/pull/141