### PR TITLE
feat(waitFor*): improve stacktrace for timeout errors

### DIFF
--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -141,6 +141,15 @@ test('rethrows non-testing-lib errors', () => {
   ).rejects.toBe(error)
 })
 
+test('logs timeout error when it times out', async () => {
+  const div = document.createElement('div')
+  await expect(
+    waitForElementToBeRemoved(() => div, {timeout: 1}),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"Timed out in waitForElementToBeRemoved."`,
+  )
+})
+
 test('accepts an element as an argument and waits for it to be removed from its top-most parent', async () => {
   const {queryByTestId} = renderIntoDocument(`
     <div data-testid="div"></div>

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -21,3 +21,14 @@ test('can timeout after the given timeout time', async () => {
   ).catch(e => e)
   expect(result).toBe(error)
 })
+
+test('uses generic error if there was no last error', async () => {
+  const result = await waitFor(
+    () => {
+      // eslint-disable-next-line no-throw-literal
+      throw undefined
+    },
+    {timeout: 8, interval: 5},
+  ).catch(e => e)
+  expect(result).toMatchInlineSnapshot(`[Error: Timed out in wait.]`)
+})

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -30,5 +30,5 @@ test('uses generic error if there was no last error', async () => {
     },
     {timeout: 8, interval: 5},
   ).catch(e => e)
-  expect(result).toMatchInlineSnapshot(`[Error: Timed out in wait.]`)
+  expect(result).toMatchInlineSnapshot(`[Error: Timed out in waitFor.]`)
 })

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -13,8 +13,9 @@ function initialCheck(elements) {
 }
 
 async function waitForElementToBeRemoved(callback, options) {
+  // created here so we get a nice stacktrace
+  const timeoutError = new Error('Timed out in waitForElementToBeRemoved.')
   if (typeof callback !== 'function') {
-    // await waitForElementToBeRemoved(getAllByText('Hello'))
     initialCheck(callback)
     const elements = Array.isArray(callback) ? callback : [callback]
     const getRemainingElements = elements.map(element => {
@@ -38,7 +39,7 @@ async function waitForElementToBeRemoved(callback, options) {
       throw error
     }
     if (!isRemoved(result)) {
-      throw new Error('Timed out in waitForElementToBeRemoved.')
+      throw timeoutError
     }
     return true
   }, options)

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -22,6 +22,8 @@ function waitFor(
     },
   } = {},
 ) {
+  // created here so we get a nice stacktrace
+  const timedOutError = new Error('Timed out in wait.')
   if (interval < 1) interval = 1
   return new Promise((resolve, reject) => {
     let lastError
@@ -57,7 +59,7 @@ function waitFor(
     }
 
     function onTimeout() {
-      onDone(lastError || new Error('Timed out in wait.'), null)
+      onDone(lastError || timedOutError, null)
     }
   })
 }

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -23,7 +23,7 @@ function waitFor(
   } = {},
 ) {
   // created here so we get a nice stacktrace
-  const timedOutError = new Error('Timed out in wait.')
+  const timedOutError = new Error('Timed out in waitFor.')
   if (interval < 1) interval = 1
   return new Promise((resolve, reject) => {
     let lastError


### PR DESCRIPTION
**What**: feat(waitFor*): improve stacktrace for timeout errors

**Why**: Closes #491

Way improved:

Before: 

```
  ● can create a list item for the book

    Timed out in waitForElementToBeRemoved.

      at node_modules/@testing-library/dom/dist/wait-for-element-to-be-removed.js:51:13
      at checkCallback (node_modules/@testing-library/dom/dist/wait-for.js:50:22)
```

After:

```
  ● can create a list item for the book

    Timed out in waitForElementToBeRemoved.

      34 | 
      35 |   const div = document.createElement('div')
    > 36 |   await waitForElementToBeRemoved(() => div)
         |         ^
      37 | 
      38 |   await waitForElementToBeRemoved(() =>
      39 |     utils.getByRole('heading', {name: 'Loading...'}),

      at waitForElementToBeRemoved (node_modules/@testing-library/dom/dist/wait-for-element-to-be-removed.js:22:24)
      at renderBookScreen (src/screens/__tests__/book.js:36:9)
      at Object.<anonymous> (src/screens/__tests__/book.js:76:13)
```

Right!?!?

Also...

Before:

```
  ● can create a list item for the book

    Timed out in wait.

      at onTimeout (node_modules/@testing-library/dom/dist/wait-for.js:58:27)
```

After:

```
  ● can create a list item for the book

    Timed out in wait.

      33 |   const utils = render(<BookScreen bookId={book ? book.id : bookId} />)
      34 | 
    > 35 |   await waitFor(() => {
         |         ^
      36 |     throw undefined
      37 |   })
      38 |   const div = document.createElement('div')

      at waitFor (node_modules/@testing-library/dom/dist/wait-for.js:24:25)
      at node_modules/@testing-library/dom/dist/wait-for.js:65:54
      at node_modules/@testing-library/react/dist/pure.js:51:22
      at node_modules/@testing-library/react/dist/act-compat.js:60:24
      at batchedUpdates$1 (node_modules/react-dom/cjs/react-dom.development.js:21856:12)
      at act (node_modules/react-dom/cjs/react-dom-test-utils.development.js:929:14)
      at node_modules/@testing-library/react/dist/act-compat.js:59:20
      at asyncAct (node_modules/@testing-library/react/dist/act-compat.js:38:14)
      at Object.asyncWrapper (node_modules/@testing-library/react/dist/pure.js:50:35)
      at waitForWrapper (node_modules/@testing-library/dom/dist/wait-for.js:65:35)
      at renderBookScreen (src/screens/__tests__/book.js:35:9)
      at Object.<anonymous> (src/screens/__tests__/book.js:79:13)
```

So much better!

**How**:

Create the timeout error right when the function is called so the stacktrace includes the code that called it.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
