### PR TITLE
fix: Bump types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/testing-library__dom": "^6.14.0",
+    "@types/testing-library__dom": "^7.0.0",
     "aria-query": "^4.0.2",
     "dom-accessibility-api": "^0.4.2",
     "pretty-format": "^25.1.0"


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes outdated types being used

<!-- Why are these changes necessary? -->

**Why**:

Types are outdated

**How**:

Bump `@types/testing-library__dom`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- ~[ ]~ Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
