### PR TITLE
fix: queryHelpers.getElementError is not a function

### DIFF
--- a/src/__tests__/query-helper.js
+++ b/src/__tests__/query-helper.js
@@ -1,0 +1,18 @@
+import * as queryHelpers from '../query-helpers'
+import {configure, getConfig} from '../config'
+
+const originalConfig = getConfig()
+beforeEach(() => {
+  configure(originalConfig)
+})
+
+test('should delegate to config.getElementError', () => {
+  const getElementError = jest.fn()
+  configure({getElementError})
+
+  const message = 'test Message'
+  const container = {} // dummy
+
+  queryHelpers.getElementError(message, container)
+  expect(getElementError.mock.calls[0]).toEqual([message, container])
+})

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -2,6 +2,10 @@ import {fuzzyMatches, matches, makeNormalizer} from './matches'
 import {waitFor} from './wait-for'
 import {getConfig} from './config'
 
+function getElementError(message, container) {
+  return getConfig().getElementError(message, container)
+}
+
 function getMultipleElementsFoundError(message, container) {
   return getConfig().getElementError(
     `${message}\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`,
@@ -82,6 +86,7 @@ function buildQueries(queryAllBy, getMultipleError, getMissingError) {
 }
 
 export {
+  getElementError,
   getMultipleElementsFoundError,
   queryAllByAttribute,
   queryByAttribute,

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -7,7 +7,7 @@ function getElementError(message, container) {
 }
 
 function getMultipleElementsFoundError(message, container) {
-  return getConfig().getElementError(
+  return getElementError(
     `${message}\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`,
     container,
   )


### PR DESCRIPTION
**What**:
If you try to call getElementError in a custom query according to the documentation, you will get an error.

<!-- Why are these changes necessary? -->

**Why**:
getElementError was removed in #452.

<!-- How were these changes implemented? -->

**How**:
redefine to queryHelpers

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->



NOTE: 
I asked a question about this issue. #508 
This can be done by require of `@testing-library/dom/dist/config`, but I'm wondering if that's the official way to do it (It was a question I wanted to ask on that `issue` ).

Please close this PR if that is official way.

Thanks!
