### PR TITLE
fix: Only return first child element in label query

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -229,7 +229,7 @@ test('can filter results of label query based on selector', () => {
   expect(result[0].id).toBe('input1')
 })
 
-test('can find any form control when label text is inside other elements', () => {
+test('can find any labelable element when label text is inside other elements', () => {
   const {getByLabelText} = render(`
     <label>
       <span>Test</span>
@@ -260,7 +260,9 @@ test('can find any form control when label text is inside other elements', () =>
   })
 })
 
-test('returns the first form control inside a label', () => {
+// According to the spec, the first descendant of a label that is a labelable element is the labeled control
+// https://html.spec.whatwg.org/multipage/forms.html#the-label-element
+test('returns the labelable element control inside a label', () => {
   const {getByLabelText} = render(`
     <label>
       <span>Test</span>

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -230,7 +230,7 @@ test('can filter results of label query based on selector', () => {
 })
 
 test('can find any form control when label text is inside other elements', () => {
-  const {getAllByLabelText} = render(`
+  const {getByLabelText} = render(`
     <label>
       <span>Test</span>
       <span>Label</span>
@@ -244,8 +244,38 @@ test('can find any form control when label text is inside other elements', () =>
     </label>
   `)
 
-  const result = getAllByLabelText('Test Label')
-  expect(result).toHaveLength(7)
+  const nodeTypes = [
+    'button',
+    'input',
+    'meter',
+    'output',
+    'progress',
+    'select',
+    'textarea',
+  ]
+  nodeTypes.forEach(nodeType => {
+    expect(getByLabelText('Test Label', {selector: nodeType}).nodeName).toEqual(
+      nodeType.toUpperCase(),
+    )
+  })
+})
+
+test('returns the first form control inside a label', () => {
+  const {getByLabelText} = render(`
+    <label>
+      <span>Test</span>
+      <span>Label</span>
+      <button />
+      <input />
+      <meter />
+      <output />
+      <progress />
+      <select />
+      <textarea />
+    </label>
+  `)
+
+  expect(getByLabelText('Test Label').nodeName).toEqual('BUTTON')
 })
 
 test('can find non-input elements when aria-labelledby a label', () => {

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -74,9 +74,10 @@ function queryAllByLabelText(
         // <label>text: <input /></label>
         const formControlSelector =
           'button, input, meter, output, progress, select, textarea'
-        Array.from(
+        const labelledFormControl = Array.from(
           label.querySelectorAll(formControlSelector),
-        ).forEach(element => elementsForLabel.push(element))
+        ).filter(element => element.matches(selector))[0]
+        if (labelledFormControl) elementsForLabel.push(labelledFormControl)
       }
       return matchedElements.concat(elementsForLabel)
     }, [])


### PR DESCRIPTION
**What**:

Bug-Fix: Changes the *ByLabelText queries so that, when finding form controls that are children of labels, only the first form control is returned.

**Why**:

Following up on the discussion in #373 that started with [this comment](https://github.com/testing-library/dom-testing-library/pull/373#issuecomment-609843685)

**How**:

When finding children of labels, I filtered the children down to only those that matched the selector and grabbed the first one.

**Checklist**:
- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [X] Tests
- [X] Ready to be merged
