### PR TITLE
fix: apply spread syntax to container.querySelectorAll() in alt-text.js

### DIFF
--- a/src/queries/alt-text.js
+++ b/src/queries/alt-text.js
@@ -7,14 +7,14 @@ function queryAllByAltText(
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  return Array.from(container.querySelectorAll('img,input,area')).filter(node =>
+  return [...container.querySelectorAll('img,input,area')].filter(node =>
     matcher(node.getAttribute('alt'), node, alt, matchNormalizer),
   )
 }
 
-const getMultipleError = (c, alt) =>
+const getMultipleError = (_, alt) =>
   `Found multiple elements with the alt text: ${alt}`
-const getMissingError = (c, alt) =>
+const getMissingError = (_, alt) =>
   `Unable to find an element with the alt text: ${alt}`
 const [
   queryByAltText,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Improving code in queries/alt-text.js
<!-- Why are these changes necessary? -->

**Why**:
I changed it because spread syntax can replace Array.from() in the code.

Parameter 'c' was not used within those functions, so I replaced it to '_' to make code more clear and intuitive.
<!-- How were these changes implemented? -->

**How**:
I applied spread syntax to container.querySelectorAll().
And, I also changed first parameter of getMultipleError and getMissingError, 'c' to '_'.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
