### PR TITLE
fix: update deprecation warning for waitForElement

### DIFF
--- a/src/__tests__/wait-for-element.js
+++ b/src/__tests__/wait-for-element.js
@@ -22,7 +22,7 @@ test('waits for element to appear in the document', async () => {
   expect(console.warn.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`wait\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor",
+        "\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor",
       ],
     ]
   `)

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -9,7 +9,7 @@ async function waitForElement(callback, options) {
   if (!hasWarned) {
     hasWarned = true
     console.warn(
-      `\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`wait\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor`,
+      `\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor`,
     )
   }
   if (!callback) {


### PR DESCRIPTION
**What**:

Same issue as https://github.com/testing-library/dom-testing-library/pull/478 but in the `waitForElement` deprecation warning. The warning when you use `waitForElement` currently says to use either `find*` or `wait` instead, but `wait` is deprecated as well.

**Why**:

Up-to-date deprecation warnings

**How**:

Updated warning to say `waitFor` instead of `wait`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) **N/A**
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) **N/A**
- [x] Tests
- [x] Ready to be merged

