### PR TITLE
Fix waitFor not waiting for an async element

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -55,6 +55,12 @@ test('waits and returns an async element', async () => {
     document.querySelector('div').appendChild(element)
   }, 0)
 
-  const newElement = await waitFor(() => document.querySelector('[id="test"]'))
+  const newElement = await waitFor(() => {
+    const element = document.querySelector('[id="test"]')
+    if (!element) {
+      throw new Error('element with id of "test" not found')
+    }
+    return element
+  })
   expect(newElement).toBeInTheDocument()
 })

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -43,3 +43,18 @@ test('throws nice error if provided callback is not a function', () => {
     'Received `callback` arg must be a function',
   )
 })
+
+test('waits and returns an async element', async () => {
+  renderIntoDocument(`
+    <div data-testid="div"></div>
+  `)
+
+  setTimeout(() => {
+    const element = document.createElement('div')
+    element.id = 'test'
+    document.querySelector('div').appendChild(element)
+  }, 0)
+
+  const newElement = await waitFor(() => document.querySelector('[id="test"]'))
+  expect(newElement).toBeInTheDocument()
+})


### PR DESCRIPTION
I don't know why yet, but the `waitFor` is not waiting for some elements on cases whereas `waitForElement` is.

I felt more comfortable to open a PR with a test case demonstrating the "situation". Feel free to close the PR for whatever.

Thanks.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
