### PR TITLE
 fix: Exclude container in the list of queryable roles

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -321,6 +321,34 @@ Here are the accessible roles:
 `)
 })
 
+test('does not include the container in the queryable roles', () => {
+  const {getByRole} = render(`<li />`, {
+    container: document.createElement('ul'),
+  })
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an accessible element with the role "list"
+
+Here are the accessible roles:
+
+  list:
+
+  Name "":
+  <ul />
+
+  --------------------------------------------------
+  listitem:
+
+  Name "":
+  <li />
+
+  --------------------------------------------------
+
+<ul>
+  <li />
+</ul>"
+`)
+})
+
 describe('configuration', () => {
   let originalConfig
   beforeEach(() => {

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -330,12 +330,6 @@ test('does not include the container in the queryable roles', () => {
 
 Here are the accessible roles:
 
-  list:
-
-  Name "":
-  <ul />
-
-  --------------------------------------------------
   listitem:
 
   Name "":

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -95,9 +95,12 @@ const getMissingError = (
   role,
   {hidden = getConfig().defaultHidden, name} = {},
 ) => {
-  const roles = prettyRoles(container, {
-    hidden,
-    includeName: name !== undefined,
+  let roles = ''
+  Array.from(container.children).forEach(childElement => {
+    roles += prettyRoles(childElement, {
+      hidden,
+      includeName: name !== undefined,
+    })
   })
   let roleMessage
 


### PR DESCRIPTION
To better understand, review commits individually. The first commit describes the current behavior and the second commit applies the expected behavior.

**What**:
- Closes #549
- Exclude `container` when displaying the available roles for a bound `ByRole`

**Why**:

- The `container` was never part of the considered elements due to how `.querySelectorAll` works.

**How**:

Start with `container.children`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- ~[ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)~
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
