### PR TITLE
feat(events): Add dataTransfer event property option

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -282,6 +282,27 @@ test('assigning the files property on an input', () => {
   expect(node.files).toEqual([file])
 })
 
+test('assigns dataTransfer properties', () => {
+  const node = document.createElement('div')
+  const spy = jest.fn()
+  node.addEventListener('dragover', spy)
+  fireEvent.dragOver(node, {dataTransfer: {dropEffect: 'move'}})
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy.mock.calls[0][0]).toHaveProperty('dataTransfer.dropEffect', 'move')
+})
+
+test('assigning the files property on dataTransfer', () => {
+  const node = document.createElement('div')
+  const file = new document.defaultView.File(['(⌐□_□)'], 'chucknorris.png', {
+    type: 'image/png',
+  })
+  const spy = jest.fn()
+  node.addEventListener('drop', spy)
+  fireEvent.drop(node, {dataTransfer: {files: [file]}})
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy.mock.calls[0][0]).toHaveProperty('dataTransfer.files', [file])
+})
+
 test('fires events on Window', () => {
   const messageSpy = jest.fn()
   window.addEventListener('message', messageSpy)

--- a/src/events.js
+++ b/src/events.js
@@ -60,6 +60,7 @@ Object.keys(eventMap).forEach(key => {
 
     const {dataTransfer} = eventInit
     if (typeof dataTransfer === 'object') {
+      // DataTransfer is not supported in jsdom: https://github.com/jsdom/jsdom/issues/1568
       /* istanbul ignore if  */
       if (typeof window.DataTransfer === 'function') {
         Object.defineProperty(event, 'dataTransfer', {

--- a/src/events.js
+++ b/src/events.js
@@ -58,12 +58,18 @@ Object.keys(eventMap).forEach(key => {
       })
     }
 
-    // Approximate dataTransfer on the event object
-    // jsdom does not support DataTransfer constructor
-    // https://github.com/testing-library/react-testing-library/issues/339#issuecomment-526310225
     const {dataTransfer} = eventInit
     if (typeof dataTransfer === 'object') {
-      Object.assign(event, {dataTransfer})
+      /* istanbul ignore if  */
+      if (typeof window.DataTransfer === 'function') {
+        Object.defineProperty(event, 'dataTransfer', {
+          value: Object.assign(new window.DataTransfer(), dataTransfer)
+        })
+      } else {
+        Object.defineProperty(event, 'dataTransfer', {
+          value: dataTransfer
+        })
+      }
     }
     return event
   }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Resolves #551

Adds a convenience option to approximate the `dataTransfer` event property when firing events

<!-- Why are these changes necessary? -->

**Why**:

Provides a consistent and convenient way to populate `dataTransfer` properties, much like populating `target` properties. This would help developers better simulate testing for drag and drop interactions.

There was previous discussion and feature validation over in https://github.com/testing-library/react-testing-library/issues/339

<!-- How were these changes implemented? -->

**How**:

Update the `fireEvent.*` functions to populate the `dataTransfer` property for events only when defined in the `eventProperties` (second argument).

The property is assigned to the event object in a simple way. It does not construct the `DataTransfer` object and for good reasons. `DataTransfer` is  privately handled and constructed by the browser and is [not supported by jsdom](https://github.com/jsdom/jsdom/issues/1272#issuecomment-486088445).

MDN also warns:
>  it is not possible to create a useful DataTransfer object from script, since DataTransfer objects have a processing and security model that is coordinated by the browser during drag-and-drops.
https://developer.mozilla.org/en-US/docs/Web/API/DragEvent

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/459
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
