### PR TITLE
fix: Consider explicit role when pretty printing roles

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -343,6 +343,35 @@ Here are the accessible roles:
 `)
 })
 
+test('explicit role is most specific', () => {
+  const {getByRole} = renderIntoDocument(
+    `<button role="tab" aria-label="my-tab" />`,
+  )
+
+  expect(() => getByRole('button')).toThrowErrorMatchingInlineSnapshot(`
+"Unable to find an accessible element with the role "button"
+
+Here are the accessible roles:
+
+  tab:
+
+  Name "my-tab":
+  <button
+    aria-label="my-tab"
+    role="tab"
+  />
+
+  --------------------------------------------------
+
+<body>
+  <button
+    aria-label="my-tab"
+    role="tab"
+  />
+</body>"
+`)
+})
+
 describe('configuration', () => {
   let originalConfig
   beforeEach(() => {

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -134,7 +134,13 @@ function getRoles(container, {hidden = false} = {}) {
       return hidden === false ? isInaccessible(element) === false : true
     })
     .reduce((acc, node) => {
-      const roles = getImplicitAriaRoles(node)
+      let roles = []
+      // TODO: This violates html-aria which does not allow any role on every element
+      if (node.hasAttribute('role')) {
+        roles = node.getAttribute('role').split(' ').slice(0, 1)
+      } else {
+        roles = getImplicitAriaRoles(node)
+      }
 
       return roles.reduce(
         (rolesAcc, role) =>


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Consider explicit roles first when pretty printing roles.

**Why**:

`getRoles` printed a different role than what `queryAllByRole` could query. Closes #553

**How**:

Check for existence of `role` attribute first and use the first role from that list. I haven't put much thought into fallback roles but we can discuss it when it becomes an issue.

Technically this isn't correct. html-aria disallows (some) roles for certain HTML elements. But we didn't consider this for `queryAllByRole` either and it isn't clear if we should restrict it (e.g. chrome's a11y pane does not).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- ~[ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)~
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
