### PR TITLE
chore: revert pretty-format dependency upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.9.6",
     "aria-query": "^4.0.2",
     "dom-accessibility-api": "^0.4.3",
-    "pretty-format": "^26.0.1"
+    "pretty-format": "^25.0.1"
   },
   "devDependencies": {
     "dtslint": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.9.6",
     "aria-query": "^4.0.2",
     "dom-accessibility-api": "^0.4.3",
-    "pretty-format": "^25.0.1"
+    "pretty-format": "^25.5.0"
   },
   "devDependencies": {
     "dtslint": "^3.4.2",


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Downgrade `pretty-format` to v25.

<!-- Why are these changes necessary? -->

**Why**: The newer v26 bumps the minimum required version of Node. See #563.

<!-- How were these changes implemented? -->

**How**: Update version in package.json

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) – N/A
- [ ] I've prepared a PR for types targeting [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom) – N/A
- [x] Tests – no new tests, but verified that they pass
- [x] Ready to be merged
