### PR TITLE
docs: Fix progressbar typo for queryFallbacks

### DIFF
--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -60,7 +60,7 @@ export interface ByRoleOptions extends MatcherOptions {
     selected?: boolean;
     /**
      * Includes every role used in the `role` attribute
-     * For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progresbar">`.
+     * For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progressbar">`.
      */
     queryFallbacks?: boolean;
     /**


### PR DESCRIPTION
**What**:

The TypeScript documentation for `ByRoleOptions.queryFallback` has a typo.

**Why** / **How**:

Fixed the typo.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) **N/A**
- [x] I've prepared a PR for types targeting [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests **N/A**
- [x] Ready to be merged

