### PR TITLE
Fix misleading advice in waitForElement deprecation warning

### DIFF
--- a/src/__tests__/wait-for-element.js
+++ b/src/__tests__/wait-for-element.js
@@ -22,7 +22,7 @@ test('waits for element to appear in the document', async () => {
   expect(console.warn.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor",
+        "\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor",
       ],
     ]
   `)

--- a/src/wait-for-element.js
+++ b/src/wait-for-element.js
@@ -9,7 +9,7 @@ async function waitForElement(callback, options) {
   if (!hasWarned) {
     hasWarned = true
     console.warn(
-      `\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#waitfor`,
+      `\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor`,
     )
   }
   if (!callback) {


### PR DESCRIPTION
Fixes https://github.com/testing-library/react-testing-library/issues/677