### PR TITLE
fix: handle ignores for ByText in suggestions

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -10,13 +10,20 @@ afterAll(() => {
   configure({throwSuggestions: false})
 })
 
-test('dost not suggest for inline script, style', () => {
+test('does not suggest for inline script, style', () => {
   renderIntoDocument(
     `<script data-testid="script">alert('hello')</script><style data-testid="style">.hsuHs{margin:auto}.wFncld{margin-top:3px;color:#9AA0A6;height:20px;width:20px}</style>`,
   )
 
   expect(() => screen.getByTestId('script')).not.toThrow()
   expect(() => screen.getByTestId('style')).not.toThrow()
+})
+it('respects ignores', () => {
+  renderIntoDocument(`<my-thing>foo</my-thing>`)
+
+  expect(() =>
+    screen.queryByText('foo', {ignore: 'my-thing'}),
+  ).not.toThrowError()
 })
 
 test('does not suggest when using getByRole', () => {

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -10,6 +10,16 @@ afterAll(() => {
   configure({throwSuggestions: false})
 })
 
+test('does not suggest for nested inline style', () => {
+  renderIntoDocument(
+    `<div data-testid="style"><style>.hsuHs{margin:auto}.wFncld{margin-top:3px;color:#9AA0A6;height:20px;width:20px}</style></div>`,
+  )
+
+  // screen.debug(screen.getByText(/hsus/))
+
+  expect(() => screen.getByTestId('style')).not.toThrow()
+})
+
 test('does not suggest for inline script, style', () => {
   renderIntoDocument(
     `<script data-testid="script">alert('hello')</script><style data-testid="style">.hsuHs{margin:auto}.wFncld{margin-top:3px;color:#9AA0A6;height:20px;width:20px}</style>`,

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -10,6 +10,15 @@ afterAll(() => {
   configure({throwSuggestions: false})
 })
 
+test('dost not suggest for inline script, style', () => {
+  renderIntoDocument(
+    `<script data-testid="script">alert('hello')</script><style data-testid="style">.hsuHs{margin:auto}.wFncld{margin-top:3px;color:#9AA0A6;height:20px;width:20px}</style>`,
+  )
+
+  expect(() => screen.getByTestId('script')).not.toThrow()
+  expect(() => screen.getByTestId('style')).not.toThrow()
+})
+
 test('does not suggest when using getByRole', () => {
   renderIntoDocument(`<button data-testid="foo">submit</button>`)
 

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -15,8 +15,6 @@ test('does not suggest for nested inline style', () => {
     `<div data-testid="style"><style>.hsuHs{margin:auto}.wFncld{margin-top:3px;color:#9AA0A6;height:20px;width:20px}</style></div>`,
   )
 
-  // screen.debug(screen.getByText(/hsus/))
-
   expect(() => screen.getByTestId('style')).not.toThrow()
 })
 

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ let config = {
   _disableExpensiveErrorDiagnostics: false,
 }
 
+export const DEFAULT_IGNORE_TAGS = 'script, style'
 export function runWithExpensiveErrorDiagnosticsDisabled(callback) {
   try {
     config._disableExpensiveErrorDiagnostics = true

--- a/src/queries/text.js
+++ b/src/queries/text.js
@@ -1,4 +1,5 @@
 import {wrapAllByQueryWithSuggestion} from '../query-helpers'
+import {DEFAULT_IGNORE_TAGS} from '../config'
 import {
   fuzzyMatches,
   matches,
@@ -15,7 +16,7 @@ function queryAllByText(
     exact = true,
     collapseWhitespace,
     trim,
-    ignore = 'script, style',
+    ignore = DEFAULT_IGNORE_TAGS,
     normalizer,
   } = {},
 ) {

--- a/src/queries/text.js
+++ b/src/queries/text.js
@@ -1,3 +1,4 @@
+import {wrapAllByQueryWithSuggestion} from '../query-helpers'
 import {
   fuzzyMatches,
   matches,
@@ -5,7 +6,6 @@ import {
   getNodeText,
   buildQueries,
 } from './all-utils'
-import {wrapAllByQueryWithSuggestion} from '../query-helpers'
 
 function queryAllByText(
   container,

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -94,7 +94,7 @@ const wrapSingleQueryWithSuggestion = (query, queryAllByName, variant) => (
 ) => {
   const element = query(container, ...args)
   const [{suggest = getConfig().throwSuggestions} = {}] = args.slice(-1)
-  if (suggest) {
+  if (element && suggest) {
     const suggestion = getSuggestedQuery(element, variant)
     if (suggestion && !queryAllByName.endsWith(suggestion.queryName)) {
       throw getSuggestionError(suggestion.toString(), container)
@@ -111,7 +111,7 @@ const wrapAllByQueryWithSuggestion = (query, queryAllByName, variant) => (
   const els = query(container, ...args)
 
   const [{suggest = getConfig().throwSuggestions} = {}] = args.slice(-1)
-  if (suggest) {
+  if (els.length && suggest) {
     // get a unique list of all suggestion messages.  We are only going to make a suggestion if
     // all the suggestions are the same
     const uniqueSuggestionMessages = [

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,6 +1,7 @@
 import {computeAccessibleName} from 'dom-accessibility-api'
 import {getRoles} from './role-helpers'
 import {getDefaultNormalizer} from './matches'
+import {getNodeText} from './get-node-text'
 
 const normalize = getDefaultNormalizer()
 
@@ -57,7 +58,7 @@ export function getSuggestedQuery(element, variant) {
     return makeSuggestion('PlaceholderText', placeholderText, {variant})
   }
 
-  const textContent = normalize(element.textContent)
+  const textContent = normalize(getNodeText(element))
   if (textContent && !element.matches('script, style')) {
     return makeSuggestion('Text', textContent, {variant})
   }

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -58,7 +58,7 @@ export function getSuggestedQuery(element, variant) {
   }
 
   const textContent = normalize(element.textContent)
-  if (textContent) {
+  if (textContent && !element.matches('script, style')) {
     return makeSuggestion('Text', textContent, {variant})
   }
 

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -2,7 +2,6 @@ import {computeAccessibleName} from 'dom-accessibility-api'
 import {getRoles} from './role-helpers'
 import {getDefaultNormalizer} from './matches'
 import {getNodeText} from './get-node-text'
-// eslint-disable-next-line import/no-cycle
 import {DEFAULT_IGNORE_TAGS} from './config'
 
 const normalize = getDefaultNormalizer()

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -2,6 +2,8 @@ import {computeAccessibleName} from 'dom-accessibility-api'
 import {getRoles} from './role-helpers'
 import {getDefaultNormalizer} from './matches'
 import {getNodeText} from './get-node-text'
+// eslint-disable-next-line import/no-cycle
+import {DEFAULT_IGNORE_TAGS} from './config'
 
 const normalize = getDefaultNormalizer()
 
@@ -59,7 +61,7 @@ export function getSuggestedQuery(element, variant) {
   }
 
   const textContent = normalize(getNodeText(element))
-  if (textContent && !element.matches('script, style')) {
+  if (textContent && !element.matches(DEFAULT_IGNORE_TAGS)) {
     return makeSuggestion('Text', textContent, {variant})
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: properly handles `ignore` option in suggestions.

<!-- Why are these changes necessary? -->

**Why**: previously if you try to get a suggestion on a random element it would not ignore script, style tags and suggest getByText on those elements.

<!-- How were these changes implemented? -->

**How**: `.matches("script, style")`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->