### PR TITLE
fix: update config type

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -3,6 +3,7 @@ export interface Config {
     asyncWrapper(cb: (...args: any[]) => any): Promise<any>;
     asyncUtilTimeout: number;
     defaultHidden: boolean;
+    throwSuggestions: boolean;
 }
 
 export interface ConfigFn {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: We forgot to add the `throwSuggestions` option in the global config

<!-- Why are these changes necessary? -->

**Why**: To have intellisense. In TS projects we also currently get an error while trying to do the following.

```ts
configure({ throwSuggestions: true });
```

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Should we try to keep the naming consistent? 
For the global config it's `throwSuggestions` , while the config on a query basis is `suggest`.

```
configure({throwSuggestions: true})
// vs
screen.getByText('Increment', {suggest: true})
```
