### PR TITLE
fix: Bump dom-accessibility-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.2",
     "aria-query": "^4.0.2",
-    "dom-accessibility-api": "^0.4.4",
+    "dom-accessibility-api": "^0.4.5",
     "pretty-format": "^25.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**What**:

Closes #591

**Why**:

Use implemented behavior of browsers over spec 

**How**:

Bump `dom-accessibility-api`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- ~[ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)~
- [x] Tests Verify with codesandbox of linked issue
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
