### PR TITLE
feat: return more data from getSuggestedQuery to support tooling

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -72,7 +72,7 @@ test(`should not suggest if the suggestion would give different results`, () => 
 test('should suggest by label over title', () => {
   renderIntoDocument(`<label><span>bar</span><input title="foo" /></label>`)
 
-  expect(() => screen.getByTitle('foo')).toThrowError(/getByLabelText\("bar"\)/)
+  expect(() => screen.getByTitle('foo')).toThrowError(/getByLabelText\('bar'\)/)
 })
 
 test('should not suggest if there would be mixed suggestions', () => {
@@ -99,7 +99,7 @@ test('should suggest getByRole when used with getBy', () => {
 
   expect(() => screen.getByTestId('foo')).toThrowErrorMatchingInlineSnapshot(`
 "A better query is available, try this:
-getByRole("button", {name: /submit/i})
+getByRole('button', { name: /submit/i })
 
 
 <body>
@@ -120,7 +120,7 @@ test('should suggest getAllByRole when used with getAllByTestId', () => {
   expect(() => screen.getAllByTestId('foo'))
     .toThrowErrorMatchingInlineSnapshot(`
 "A better query is available, try this:
-getAllByRole("button", {name: /submit/i})
+getAllByRole('button', { name: /submit/i })
 
 
 <body>
@@ -148,10 +148,10 @@ test('should suggest findByRole when used with findByTestId', async () => {
   `)
 
   await expect(screen.findByTestId('foo')).rejects.toThrowError(
-    /findByRole\("button", \{name: \/submit\/i\}\)/,
+    /findByRole\('button', \{ name: \/submit\/i \}\)/,
   )
   await expect(screen.findAllByTestId(/foo/)).rejects.toThrowError(
-    /findAllByRole\("button", \{name: \/submit\/i\}\)/,
+    /findAllByRole\('button', \{ name: \/submit\/i \}\)/,
   )
 })
 
@@ -159,7 +159,7 @@ test('should suggest img role w/ alt text', () => {
   renderIntoDocument(`<img data-testid="img" alt="Incredibles 2 Poster"  />`)
 
   expect(() => screen.getByAltText('Incredibles 2 Poster')).toThrowError(
-    /getByRole\("img", \{name: \/incredibles 2 poster\/i\}\)/,
+    /getByRole\('img', \{ name: \/incredibles 2 poster\/i \}\)/,
   )
 })
 
@@ -169,7 +169,7 @@ test('escapes regular expressions in suggestion', () => {
   )
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByRole\("img", \{name: \/the problem \\\(picture of a question mark\\\)\/i\}\)/,
+    /getByRole\('img', \{ name: \/the problem \\\(picture of a question mark\\\)\/i \}\)/,
   )
 })
 
@@ -178,7 +178,7 @@ test('should suggest getByLabelText when no role available', () => {
     `<label for="foo">Username</label><input data-testid="foo" id="foo" />`,
   )
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByLabelText\("Username"\)/,
+    /getByLabelText\('Username'\)/,
   )
 })
 
@@ -191,7 +191,7 @@ test(`should suggest getByLabel on non form elements`, () => {
   `)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByLabelText\("Section One"\)/,
+    /getByLabelText\('Section One'\)/,
   )
 })
 
@@ -203,24 +203,24 @@ test.each([
   renderIntoDocument(html)
 
   expect(() => screen.getByLabelText('Username')).toThrowError(
-    /getByRole\("textbox", \{name: \/username\/i\}\)/,
+    /getByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
   expect(() => screen.getAllByLabelText('Username')).toThrowError(
-    /getAllByRole\("textbox", \{name: \/username\/i\}\)/,
+    /getAllByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
 
   expect(() => screen.queryByLabelText('Username')).toThrowError(
-    /queryByRole\("textbox", \{name: \/username\/i\}\)/,
+    /queryByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
   expect(() => screen.queryAllByLabelText('Username')).toThrowError(
-    /queryAllByRole\("textbox", \{name: \/username\/i\}\)/,
+    /queryAllByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
 
   await expect(screen.findByLabelText('Username')).rejects.toThrowError(
-    /findByRole\("textbox", \{name: \/username\/i\}\)/,
+    /findByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
   await expect(screen.findAllByLabelText(/Username/)).rejects.toThrowError(
-    /findAllByRole\("textbox", \{name: \/username\/i\}\)/,
+    /findAllByRole\('textbox', \{ name: \/username\/i \}\)/,
   )
 })
 
@@ -230,7 +230,7 @@ test(`should suggest label over placeholder text`, () => {
   )
 
   expect(() => screen.getByPlaceholderText('Username')).toThrowError(
-    /getByLabelText\("Username"\)/,
+    /getByLabelText\('Username'\)/,
   )
 })
 
@@ -238,7 +238,7 @@ test(`should suggest getByPlaceholderText`, () => {
   renderIntoDocument(`<input data-testid="foo" placeholder="Username" />`)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByPlaceholderText\("Username"\)/,
+    /getByPlaceholderText\('Username'\)/,
   )
 })
 
@@ -246,7 +246,7 @@ test(`should suggest getByText for simple elements`, () => {
   renderIntoDocument(`<div data-testid="foo">hello there</div>`)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByText\("hello there"\)/,
+    /getByText\('hello there'\)/,
   )
 })
 
@@ -256,7 +256,7 @@ test(`should suggest getByDisplayValue`, () => {
   document.getElementById('lastName').value = 'Prine' // RIP John Prine
 
   expect(() => screen.getByTestId('lastName')).toThrowError(
-    /getByDisplayValue\("Prine"\)/,
+    /getByDisplayValue\('Prine'\)/,
   )
 })
 
@@ -269,10 +269,10 @@ test(`should suggest getByAltText`, () => {
     `)
 
   expect(() => screen.getByTestId('input')).toThrowError(
-    /getByAltText\("last name"\)/,
+    /getByAltText\('last name'\)/,
   )
   expect(() => screen.getByTestId('area')).toThrowError(
-    /getByAltText\("Computer"\)/,
+    /getByAltText\('Computer'\)/,
   )
 })
 
@@ -285,25 +285,25 @@ test(`should suggest getByTitle`, () => {
   </svg>`)
 
   expect(() => screen.getByTestId('delete')).toThrowError(
-    /getByTitle\("Delete"\)/,
+    /getByTitle\('Delete'\)/,
   )
   expect(() => screen.getAllByTestId('delete')).toThrowError(
-    /getAllByTitle\("Delete"\)/,
+    /getAllByTitle\('Delete'\)/,
   )
   expect(() => screen.queryByTestId('delete')).toThrowError(
-    /queryByTitle\("Delete"\)/,
+    /queryByTitle\('Delete'\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\("Delete"\)/,
+    /queryAllByTitle\('Delete'\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\("Delete"\)/,
+    /queryAllByTitle\('Delete'\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\("Delete"\)/,
+    /queryAllByTitle\('Delete'\)/,
   )
 
   // Since `ByTitle` and `ByText` will both return the <title> element
   // `getByText` will always be the suggested query as it is higher up the list.
-  expect(() => screen.getByTestId('svg')).toThrowError(/getByText\("Close"\)/)
+  expect(() => screen.getByTestId('svg')).toThrowError(/getByText\('Close'\)/)
 })

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -30,17 +30,14 @@ function escapeRegExp(string) {
   return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
 
-function makeSuggestion(queryName, content, {
-  variant = 'get',
-  name
-}) {
-  const queryArgs = [content];
+function makeSuggestion(queryName, content, {variant = 'get', name}) {
+  const queryArgs = [content]
 
   if (name) {
-    queryArgs.push({ name: new RegExp(escapeRegExp(name.toLowerCase()), 'i') })
+    queryArgs.push({name: new RegExp(escapeRegExp(name.toLowerCase()), 'i')})
   }
 
-  const queryMethod = `${variant}By${queryName}`;
+  const queryMethod = `${variant}By${queryName}`
 
   return {
     queryName,
@@ -48,10 +45,14 @@ function makeSuggestion(queryName, content, {
     queryArgs,
     variant,
     toString() {
-      const options = queryArgs[1] ? `, { ${Object.entries(queryArgs[1]).map(([k, v]) => `${k}: ${v}`).join(', ')} }` : '';
-      return `${queryMethod}("${content}"${options})`;
-    }
-  };
+      const options = queryArgs[1]
+        ? `, { ${Object.entries(queryArgs[1])
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ')} }`
+        : ''
+      return `${queryMethod}('${content}'${options})`
+    },
+  }
 }
 
 export function getSuggestedQuery(element, variant) {

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -29,16 +29,29 @@ function getLabelTextFor(element) {
 function escapeRegExp(string) {
   return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
-function makeSuggestion(queryName, content, {variant, name}) {
+
+function makeSuggestion(queryName, content, {
+  variant = 'get',
+  name
+}) {
+  const queryArgs = [content];
+
+  if (name) {
+    queryArgs.push({ name: new RegExp(escapeRegExp(name.toLowerCase()), 'i') })
+  }
+
+  const queryMethod = `${variant}By${queryName}`;
+
   return {
     queryName,
+    queryMethod,
+    queryArgs,
+    variant,
     toString() {
-      const options = name
-        ? `, {name: /${escapeRegExp(name.toLowerCase())}/i}`
-        : ''
-      return `${variant}By${queryName}("${content}"${options})`
-    },
-  }
+      const options = queryArgs[1] ? `, { ${Object.entries(queryArgs[1]).map(([k, v]) => `${k}: ${v}`).join(', ')} }` : '';
+      return `${queryMethod}("${content}"${options})`;
+    }
+  };
 }
 
 export function getSuggestedQuery(element, variant) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
#### 1. Return rich data from `getSuggestedQuery`
I've added more data to the object that `getSuggestedQuery` returns. Before this change, the returned value would be something like:

```js
{
  queryName: 'Role',
}
```

By calling the `toString` method, the caller would get more information, but formatted as string: (the full expression statement)

```
getByRole('button', { name: /submit/i })
```

With this change, the caller gets rich data, upon which he can build tooling.

Example result:

```js
{
  queryName: 'Role',
  queryMethod: 'getByRole',
  queryArgs: ['button', { name: /submit/i }],
  variant: 'get'
}
```

#### 2. Change formatting of the suggested query

Before this change, queries were returned with double quotes and without spacing. I've updated the `toString()` method to match the style that's being used throughout the docs.

```js
// before
getByRole("button", {name: /submit/i});

// after
getByRole('button', { name: /submit/i });
```

#### 3. Fix a small bug 

The variant now defaults to `get`, to fix a bug that was causing suggestions like `undefinedByRole(…)` to be generated.

```js
// before
getSuggestedQuery('button').toString() // » undefinedByRole("button")
 
// after
getSuggestedQuery('button').toString() // » getByRole('button') 

```

**Why**:

<!-- How were these changes implemented? -->
To support the development of tools around query suggestions.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This PR fixes 3 related things. Let me know if you want me to break things up in separate branches.

Also, if you're not comfortable with the suggestion style change (single quotes and spaces in expression arguments), let me know, and I can undo that part.