### PR TITLE
feat: use regex based TextMatch for suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 coverage
 dist
 .DS_Store
-.idea
 
 # these cause more harm than good
 # when working with contributors

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 .DS_Store
+.idea
 
 # these cause more harm than good
 # when working with contributors

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -72,7 +72,9 @@ test(`should not suggest if the suggestion would give different results`, () => 
 test('should suggest by label over title', () => {
   renderIntoDocument(`<label><span>bar</span><input title="foo" /></label>`)
 
-  expect(() => screen.getByTitle('foo')).toThrowError(/getByLabelText\('bar'\)/)
+  expect(() => screen.getByTitle('foo')).toThrowError(
+    /getByLabelText\(\/bar\/i\)/,
+  )
 })
 
 test('should not suggest if there would be mixed suggestions', () => {
@@ -178,7 +180,7 @@ test('should suggest getByLabelText when no role available', () => {
     `<label for="foo">Username</label><input data-testid="foo" id="foo" />`,
   )
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByLabelText\('Username'\)/,
+    /getByLabelText\(\/username\/i\)/,
   )
 })
 
@@ -191,7 +193,7 @@ test(`should suggest getByLabel on non form elements`, () => {
   `)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByLabelText\('Section One'\)/,
+    /getByLabelText\(\/section one\/i\)/,
   )
 })
 
@@ -230,7 +232,7 @@ test(`should suggest label over placeholder text`, () => {
   )
 
   expect(() => screen.getByPlaceholderText('Username')).toThrowError(
-    /getByLabelText\('Username'\)/,
+    /getByLabelText\(\/username\/i\)/,
   )
 })
 
@@ -238,7 +240,7 @@ test(`should suggest getByPlaceholderText`, () => {
   renderIntoDocument(`<input data-testid="foo" placeholder="Username" />`)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByPlaceholderText\('Username'\)/,
+    /getByPlaceholderText\(\/username\/i\)/,
   )
 })
 
@@ -246,7 +248,7 @@ test(`should suggest getByText for simple elements`, () => {
   renderIntoDocument(`<div data-testid="foo">hello there</div>`)
 
   expect(() => screen.getByTestId('foo')).toThrowError(
-    /getByText\('hello there'\)/,
+    /getByText\(\/hello there\/i\)/,
   )
 })
 
@@ -256,7 +258,7 @@ test(`should suggest getByDisplayValue`, () => {
   document.getElementById('lastName').value = 'Prine' // RIP John Prine
 
   expect(() => screen.getByTestId('lastName')).toThrowError(
-    /getByDisplayValue\('Prine'\)/,
+    /getByDisplayValue\(\/prine\/i\)/,
   )
 })
 
@@ -269,10 +271,10 @@ test(`should suggest getByAltText`, () => {
     `)
 
   expect(() => screen.getByTestId('input')).toThrowError(
-    /getByAltText\('last name'\)/,
+    /getByAltText\(\/last name\/i\)/,
   )
   expect(() => screen.getByTestId('area')).toThrowError(
-    /getByAltText\('Computer'\)/,
+    /getByAltText\(\/computer\/i\)/,
   )
 })
 
@@ -285,27 +287,29 @@ test(`should suggest getByTitle`, () => {
   </svg>`)
 
   expect(() => screen.getByTestId('delete')).toThrowError(
-    /getByTitle\('Delete'\)/,
+    /getByTitle\(\/delete\/i\)/,
   )
   expect(() => screen.getAllByTestId('delete')).toThrowError(
-    /getAllByTitle\('Delete'\)/,
+    /getAllByTitle\(\/delete\/i\)/,
   )
   expect(() => screen.queryByTestId('delete')).toThrowError(
-    /queryByTitle\('Delete'\)/,
+    /queryByTitle\(\/delete\/i\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\('Delete'\)/,
+    /queryAllByTitle\(\/delete\/i\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\('Delete'\)/,
+    /queryAllByTitle\(\/delete\/i\)/,
   )
   expect(() => screen.queryAllByTestId('delete')).toThrowError(
-    /queryAllByTitle\('Delete'\)/,
+    /queryAllByTitle\(\/delete\/i\)/,
   )
 
   // Since `ByTitle` and `ByText` will both return the <title> element
   // `getByText` will always be the suggested query as it is higher up the list.
-  expect(() => screen.getByTestId('svg')).toThrowError(/getByText\('Close'\)/)
+  expect(() => screen.getByTestId('svg')).toThrowError(
+    /getByText\(\/close\/i\)/,
+  )
 })
 
 test('getSuggestedQuery handles `variant` and defaults to `get`', () => {
@@ -343,9 +347,9 @@ test('getSuggestedQuery returns rich data for tooling', () => {
   expect(getSuggestedQuery(div)).toMatchObject({
     queryName: 'Text',
     queryMethod: 'getByText',
-    queryArgs: ['cancel'],
+    queryArgs: [/cancel/i],
     variant: 'get',
   })
 
-  expect(getSuggestedQuery(div).toString()).toEqual(`getByText('cancel')`)
+  expect(getSuggestedQuery(div).toString()).toEqual(`getByText(/cancel/i)`)
 })

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -30,8 +30,12 @@ function escapeRegExp(string) {
   return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
 
+function getRegExpMatcher(string) {
+  return new RegExp(string.toLowerCase(), 'i')
+}
+
 function makeSuggestion(queryName, content, {variant = 'get', name}) {
-  const queryArgs = [content]
+  const queryArgs = [queryName === 'Role' ? content : getRegExpMatcher(content)]
 
   if (name) {
     queryArgs.push({name: new RegExp(escapeRegExp(name.toLowerCase()), 'i')})
@@ -45,12 +49,17 @@ function makeSuggestion(queryName, content, {variant = 'get', name}) {
     queryArgs,
     variant,
     toString() {
-      const options = queryArgs[1]
-        ? `, { ${Object.entries(queryArgs[1])
+      let [text, options] = queryArgs
+
+      text = typeof text === 'string' ? `'${text}'` : text
+
+      options = options
+        ? `, { ${Object.entries(options)
             .map(([k, v]) => `${k}: ${v}`)
             .join(', ')} }`
         : ''
-      return `${queryMethod}('${content}'${options})`
+
+      return `${queryMethod}(${text}${options})`
     },
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
I've adjusted the query suggestions to use regex-based text matchers when possible. This impacts all query methods, except for the `Role` variants. I believe `roles` need to be exact.

Currently, suggestions like these are made:
```js
screen.getByRole('button', { name: /google search/i }) // regex name option
screen.getByText('A privacy reminder from Google')     // string text arg
```

With this PR, the same suggestions look like:
```js
screen.getByRole('button', { name: /google search/i }) // regex name option
screen.getByText(/a privacy reminder from google/i)    // regex text arg
```

<!-- Why are these changes necessary? -->

**Why**:
Because I believe that tests shouldn't fail due to a change in capitalization.

For that same reason, we already did this for `name` option in `Role` queries:

```js
// current suggestion results 
screen.getByRole('button', { name: /search/i });
screen.getByRole('link', { name: /english/i });
```

So it only makes sense to do this for other queries as well.

<!-- How were these changes implemented? -->

**How**:
In the `makeSuggestion` function, the `TextMatch` is now wrapped in a regex when the query name isn't `Role`. Nothing fancy, just `query !== 'Role'` => `text = new RegExp(text.toLowerCase(), 'i')`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] I've prepared a PR for types targeting
      [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__dom)
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I've also added `.idea` to `.gitignore`. Am I really the only one who's using WebStorm? :scream: 