### PR TITLE
chore: add option to get specific query suggestions

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -353,3 +353,95 @@ test('getSuggestedQuery returns rich data for tooling', () => {
 
   expect(getSuggestedQuery(div).toString()).toEqual(`getByText(/cancel/i)`)
 })
+
+test('getSuggestedQuery can return specified methods in addition to the best', () => {
+  const {container} = render(`
+    <label for="username">label</label>
+    <input
+      id="username"
+      name="name"
+      placeholder="placeholder"
+      data-testid="testid"
+      title="title"
+      alt="alt"
+      value="value"
+      type="text"
+    />
+    <button>button</button>
+  `)
+
+  const input = container.querySelector('input')
+  const button = container.querySelector('button')
+
+  expect(getSuggestedQuery(input, 'get', 'Role')).toMatchObject({
+    queryName: 'Role',
+    queryMethod: 'getByRole',
+    queryArgs: ['textbox', {name: /label/i}],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'LabelText')).toMatchObject({
+    queryName: 'LabelText',
+    queryMethod: 'getByLabelText',
+    queryArgs: [/label/i],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'PlaceholderText')).toMatchObject({
+    queryName: 'PlaceholderText',
+    queryMethod: 'getByPlaceholderText',
+    queryArgs: [/placeholder/i],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(button, 'get', 'Text')).toMatchObject({
+    queryName: 'Text',
+    queryMethod: 'getByText',
+    queryArgs: [/button/],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'DisplayValue')).toMatchObject({
+    queryName: 'DisplayValue',
+    queryMethod: 'getByDisplayValue',
+    queryArgs: [/value/i],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'AltText')).toMatchObject({
+    queryName: 'AltText',
+    queryMethod: 'getByAltText',
+    queryArgs: [/alt/],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'Title')).toMatchObject({
+    queryName: 'Title',
+    queryMethod: 'getByTitle',
+    queryArgs: [/title/i],
+    variant: 'get',
+  })
+
+  expect(getSuggestedQuery(input, 'get', 'TestId')).toMatchObject({
+    queryName: 'TestId',
+    queryMethod: 'getByTestId',
+    queryArgs: ['testid'],
+    variant: 'get',
+  })
+
+  // return undefined if requested query can't be made
+  expect(getSuggestedQuery(button, 'get', 'TestId')).toBeUndefined()
+})
+
+test('getSuggestedQuery does not create suggestions for script and style elements', () => {
+  const {container} = render(`
+    <script data-testid="script"></script>
+    <style data-testid="style"></style>
+  `)
+
+  const script = container.querySelector('script')
+  const style = container.querySelector('style')
+
+  expect(getSuggestedQuery(script, 'get', 'TestId')).toBeUndefined()
+  expect(getSuggestedQuery(style, 'get', 'TestId')).toBeUndefined()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

### 1 - Add support for getting specific query method suggestions

**What**:
I've added an option to specify the desired method to the `getSuggestedQuery` method.

<!-- Why are these changes necessary? -->

**Why**:
To enable tools (such as https://testing-playground.com) to show specific suggestions instead of only the most recommended one.

<!-- How were these changes implemented? -->

**How**:
`getSuggestedQuery` accepted the arguments `element, variant`, I've extended that to `element, variant, method`.

Method defaults to "best", but if specified, only the requested query will be suggested, or none at all.

This enables us to use it like:

```js
getSuggestedQuery(input, 'get', 'PlaceholderText'));
```

If that call results in a valid suggestion, the suggestion is returned otherwise it will return `undefined`. It will not fall back to alternative methods!

The default behavior of the method has been left unchanged. A call like:

```js
getSuggestedQuery(input, 'get'));
```

Still returns either the best query available, or `undefined`.


### 2 - added `getByTestId` suggestion

Sorry, I should learn to limit the scope of pull-requests. Even when they are tiny.

While working on the above, I noticed that a suggestion for `getByTestId` wasn't implemented. Testing-playground will render it red! But when there are really no other options, this query should still be suggested. It is part of the library after all.

So, I've also added the `getByTestId` suggestion, as last option available.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
