### PR TITLE
fix: canSuggest should not be case sensitive 

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -373,7 +373,9 @@ test('getSuggestedQuery can return specified methods in addition to the best', (
   const input = container.querySelector('input')
   const button = container.querySelector('button')
 
-  expect(getSuggestedQuery(input, 'get', 'Role')).toMatchObject({
+  // this function should be insensitive for the method param.
+  // Role and role should work the same
+  expect(getSuggestedQuery(input, 'get', 'role')).toMatchObject({
     queryName: 'Role',
     queryMethod: 'getByRole',
     queryArgs: ['textbox', {name: /label/i}],

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -69,7 +69,11 @@ function makeSuggestion(queryName, content, {variant = 'get', name}) {
 }
 
 function canSuggest(currentMethod, requestedMethod, data) {
-  return data && (!requestedMethod || requestedMethod === currentMethod)
+  return (
+    data &&
+    (!requestedMethod ||
+      requestedMethod.toLowerCase() === currentMethod.toLowerCase())
+  )
 }
 
 export function getSuggestedQuery(element, variant, method) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Following up #627 I have updated `canSuggest` function because it only works when methods where exactly the same.

**Why**:

because I think that  `getSuggestedQuery` should return the same result for method 'Role' and method 'role'.

**How**:

I have compared lowecase strings.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
