### PR TITLE
fix: typescript definitions for suggestions

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -72,7 +72,7 @@ function canSuggest(currentMethod, requestedMethod, data) {
   return data && (!requestedMethod || requestedMethod === currentMethod)
 }
 
-export function getSuggestedQuery(element, variant, method) {
+export function getSuggestedQuery(element, variant = 'get', method) {
   // don't create suggestions for script and style elements
   if (element.matches(DEFAULT_IGNORE_TAGS)) {
     return undefined

--- a/types/suggestions.d.ts
+++ b/types/suggestions.d.ts
@@ -13,16 +13,24 @@ export type Variant =
 
 export type Method =
   | 'Role'
+  | 'role'
   | 'LabelText'
+  | 'labeltext'
   | 'PlaceholderText'
+  | 'placeholdertext'
   | 'Text'
+  | 'text'
   | 'DisplayValue'
+  | 'displayvalue'
   | 'AltText'
+  | 'alttext'
   | 'Title'
+  | 'title'
   | 'TestId'
+  | 'testtd'
 
 export function getSuggestedQuery(
   element: HTMLElement,
-  variant: Variant,
+  variant?: Variant,
   method?: Method,
 ): Suggestion | undefined

--- a/types/suggestions.d.ts
+++ b/types/suggestions.d.ts
@@ -3,4 +3,26 @@ export interface Suggestion {
   toString(): string
 }
 
-export function getSuggestedQuery(element: HTMLElement): Suggestion | undefined
+export type Variant =
+  | 'get'
+  | 'getAll'
+  | 'query'
+  | 'queryAll'
+  | 'find'
+  | 'findAll'
+
+export type Method =
+  | 'Role'
+  | 'LabelText'
+  | 'PlaceholderText'
+  | 'Text'
+  | 'DisplayValue'
+  | 'AltText'
+  | 'Title'
+  | 'TestId'
+
+export function getSuggestedQuery(
+  element: HTMLElement,
+  variant: Variant,
+  method?: Method,
+): Suggestion | undefined


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I have updated typescript definitions

**Why**:

As before you can't pass both variant and method parameters

**How**:

I have added two new types `Variant` and `Method` and used them as types for the respective params.
Method params is also optional

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [X] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
