### PR TITLE
[#610] waitForElementToBeRemoved: fix return type

### DIFF
--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -77,6 +77,18 @@ test('requires an unempty array of elements to exist first (function form)', () 
   )
 })
 
+test('after successful removal, fullfills promise with empty value (undefined)', () => {
+  const {getByTestId} = renderIntoDocument(`
+  <div data-testid="div"></div>
+`)
+  const div = getByTestId('div')
+  const waitResult = waitForElementToBeRemoved(() => getByTestId('div'), {
+    timeout: 100,
+  })
+  div.parentElement.removeChild(div)
+  return expect(waitResult).resolves.toBeUndefined()
+})
+
 describe('timers', () => {
   const expectElementToBeRemoved = async () => {
     const importedWaitForElementToBeRemoved = importModule()

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -34,14 +34,14 @@ async function waitForElementToBeRemoved(callback, options) {
       result = callback()
     } catch (error) {
       if (error.name === 'TestingLibraryElementError') {
-        return true
+        return undefined
       }
       throw error
     }
     if (!isRemoved(result)) {
       throw timeoutError
     }
-    return true
+    return undefined
   }, options)
 }
 

--- a/types/wait-for-element-to-be-removed.d.ts
+++ b/types/wait-for-element-to-be-removed.d.ts
@@ -3,4 +3,4 @@ import { waitForOptions } from "./wait-for";
 export function waitForElementToBeRemoved<T>(
     callback: (() => T) | T,
     options?: waitForOptions,
-): Promise<T>;
+): Promise<void>;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
A possible fix for issue #610 -> a refinement to the return value (and TS type) for `waitForElementToBeRemoved`

<!-- Why are these changes necessary? -->

**Why**:
There's a mismatch between implementation and type signature (and docs)

<!-- How were these changes implemented? -->

**How**: 
I've updated the return type to `Promise<void>` (and implemented by returning undefined)

For more details, please refer to the commit message(s)!

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [X] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
