### PR TITLE
fix(userEvent): don't select option if select is disabled

### DIFF
--- a/src/user-event/__tests__/helpers/utils.js
+++ b/src/user-event/__tests__/helpers/utils.js
@@ -24,10 +24,14 @@ function setup(ui, {eventHandlers} = {}) {
   return {element, ...addListeners(element, {eventHandlers})}
 }
 
-function setupSelect({multiple = false} = {}) {
+function setupSelect({disabled = false, multiple = false} = {}) {
   const form = document.createElement('form')
   form.innerHTML = `
-    <select name="select" ${multiple ? 'multiple' : ''}>
+    <select
+      name="select"
+      ${disabled ? 'disabled' : ''}
+      ${multiple ? 'multiple' : ''}
+    >
       <option value="1">1</option>
       <option value="2">2</option>
       <option value="3">3</option>

--- a/src/user-event/__tests__/helpers/utils.js
+++ b/src/user-event/__tests__/helpers/utils.js
@@ -24,7 +24,11 @@ function setup(ui, {eventHandlers} = {}) {
   return {element, ...addListeners(element, {eventHandlers})}
 }
 
-function setupSelect({disabled = false, multiple = false} = {}) {
+function setupSelect({
+  disabled = false,
+  disabledOptions = false,
+  multiple = false,
+} = {}) {
   const form = document.createElement('form')
   form.innerHTML = `
     <select
@@ -32,9 +36,9 @@ function setupSelect({disabled = false, multiple = false} = {}) {
       ${disabled ? 'disabled' : ''}
       ${multiple ? 'multiple' : ''}
     >
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value="1" ${disabledOptions ? 'disabled' : ''}>1</option>
+      <option value="2" ${disabledOptions ? 'disabled' : ''}>2</option>
+      <option value="3" ${disabledOptions ? 'disabled' : ''}>3</option>
     </select>
   `
   document.body.append(form)

--- a/src/user-event/__tests__/select-options.js
+++ b/src/user-event/__tests__/select-options.js
@@ -119,3 +119,17 @@ test('does not select anything if select is disabled', async () => {
   expect(o2.selected).toBe(false)
   expect(o3.selected).toBe(false)
 })
+
+test('does not select anything if options are disabled', async () => {
+  const {select, options, getEventSnapshot} = setupSelect({
+    disabledOptions: true,
+  })
+  await userEvent.selectOptions(select, '2')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(
+    `No events were fired on: select[name="select"][value=""]`,
+  )
+  const [o1, o2, o3] = options
+  expect(o1.selected).toBe(false)
+  expect(o2.selected).toBe(false)
+  expect(o3.selected).toBe(false)
+})

--- a/src/user-event/__tests__/select-options.js
+++ b/src/user-event/__tests__/select-options.js
@@ -107,3 +107,19 @@ test('throws an error if multiple are passed but not a multiple select', async (
   const error = await userEvent.selectOptions(select, ['2', '3']).catch(e => e)
   expect(error.message).toMatch(/cannot select multiple/i)
 })
+
+test('does not select anything if select is disabled', () => {
+  const {
+    container: {firstChild: select},
+  } = render(
+    <select disabled>
+      <option>No value selected</option>
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </select>,
+  )
+
+  userEvent.selectOptions(select, '1')
+  expect(select.selectedIndex).toBe(0)
+})

--- a/src/user-event/__tests__/select-options.js
+++ b/src/user-event/__tests__/select-options.js
@@ -108,18 +108,14 @@ test('throws an error if multiple are passed but not a multiple select', async (
   expect(error.message).toMatch(/cannot select multiple/i)
 })
 
-test('does not select anything if select is disabled', () => {
-  const {
-    container: {firstChild: select},
-  } = render(
-    <select disabled>
-      <option>No value selected</option>
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
-    </select>,
+test('does not select anything if select is disabled', async () => {
+  const {select, options, getEventSnapshot} = setupSelect({disabled: true})
+  await userEvent.selectOptions(select, '2')
+  expect(getEventSnapshot()).toMatchInlineSnapshot(
+    `No events were fired on: select[name="select"][value="1"]`,
   )
-
-  userEvent.selectOptions(select, '1')
-  expect(select.selectedIndex).toBe(0)
+  const [o1, o2, o3] = options
+  expect(o1.selected).toBe(true)
+  expect(o2.selected).toBe(false)
+  expect(o3.selected).toBe(false)
 })

--- a/src/user-event/select-options.js
+++ b/src/user-event/select-options.js
@@ -14,23 +14,25 @@ async function selectOptionsBase(newValue, select, values, init) {
   }
   const valArray = Array.isArray(values) ? values : [values]
   const allOptions = Array.from(select.querySelectorAll('option'))
-  const selectedOptions = valArray.map(val => {
-    if (allOptions.includes(val)) {
-      return val
-    } else {
-      const matchingOption = allOptions.find(o => o.value === val)
-      if (matchingOption) {
-        return matchingOption
+  const selectedOptions = valArray
+    .map(val => {
+      if (allOptions.includes(val)) {
+        return val
       } else {
-        throw getConfig().getElementError(
-          `Value "${val}" not found in options`,
-          select,
-        )
+        const matchingOption = allOptions.find(o => o.value === val)
+        if (matchingOption) {
+          return matchingOption
+        } else {
+          throw getConfig().getElementError(
+            `Value "${val}" not found in options`,
+            select,
+          )
+        }
       }
-    }
-  })
+    })
+    .filter(option => !option.disabled)
 
-  if (select.disabled) return
+  if (select.disabled || !selectedOptions.length) return
 
   if (select.multiple) {
     for (const option of selectedOptions) {

--- a/src/user-event/select-options.js
+++ b/src/user-event/select-options.js
@@ -30,6 +30,8 @@ async function selectOptionsBase(newValue, select, values, init) {
     }
   })
 
+  if (select.disabled) return
+
   if (select.multiple) {
     for (const option of selectedOptions) {
       // events fired for multiple select are weird. Can't use hover...


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Migrated from testing-library/user-event#344 by @ben-dyer

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Prevent a select's value from changing with `selectOptions` if it is disabled

<!-- Why are these changes necessary? -->

**Why**: It's possible to change the value of a disabled select using `selectOptions`. For instance this is passing:
```
  const {
    container: {firstChild: select},
  } = render(
    <select disabled>
      <option>No value selected</option>
      <option value="1">1</option>
      <option value="2">2</option>
      <option value="3">3</option>
    </select>,
  )

  expect(select.selectedIndex).toBe(0)

  userEvent.selectOptions(select, '1')
  expect(select.selectedIndex).toBe(1)
```

<!-- How were these changes implemented? -->

**How**: Exit early in `selectOptions` if the element is disabled, similar to what is done in `clear` and `upload`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ignore disabled options
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
