### PR TITLE
feat(userEvent): Add paste API (fixes #640)

### DIFF
--- a/src/user-event/__tests__/paste.js
+++ b/src/user-event/__tests__/paste.js
@@ -1,0 +1,157 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import userEvent from '..'
+import {setup} from './helpers/utils'
+import './helpers/customElement'
+
+test('should paste text', async () => {
+  const {element, getEventCalls} = setup(<input />)
+  await userEvent.paste(element, 'Sup')
+  expect(getEventCalls()).toMatchInlineSnapshot(`
+    focus
+    input: "{CURSOR}" -> "Sup"
+  `)
+})
+
+test('does not paste when readOnly', () => {
+  const handleChange = jest.fn()
+  render(<input data-testid="input" readOnly onChange={handleChange} />)
+  userEvent.paste(screen.getByTestId('input'), 'hi')
+  expect(handleChange).not.toHaveBeenCalled()
+})
+
+test('does not paste when disabled', () => {
+  const handleChange = jest.fn()
+  render(<input data-testid="input" disabled onChange={handleChange} />)
+  userEvent.paste(screen.getByTestId('input'), 'hi')
+  expect(handleChange).not.toHaveBeenCalled()
+})
+
+test.each(['input', 'textarea'])('should paste text in <%s>', type => {
+  const onChange = jest.fn()
+  render(
+    React.createElement(type, {
+      'data-testid': 'input',
+      onChange,
+    }),
+  )
+  const text = 'Hello, world!'
+  userEvent.paste(screen.getByTestId('input'), text)
+
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(screen.getByTestId('input')).toHaveProperty('value', text)
+})
+
+test.each(['input', 'textarea'])(
+  'should paste text in <%s> up to maxLength if provided',
+  async type => {
+    const onChange = jest.fn()
+    const onKeyDown = jest.fn()
+    const onKeyPress = jest.fn()
+    const onKeyUp = jest.fn()
+    const maxLength = 10
+
+    render(
+      React.createElement(type, {
+        'data-testid': 'input',
+        onChange,
+        onKeyDown,
+        onKeyPress,
+        onKeyUp,
+        maxLength,
+      }),
+    )
+
+    const text = 'superlongtext'
+    const slicedText = text.slice(0, maxLength)
+
+    const inputEl = screen.getByTestId('input')
+
+    await userEvent.type(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(slicedText.length)
+    expect(onKeyPress).toHaveBeenCalledTimes(text.length)
+    expect(onKeyDown).toHaveBeenCalledTimes(text.length)
+    expect(onKeyUp).toHaveBeenCalledTimes(text.length)
+
+    inputEl.value = ''
+    onChange.mockClear()
+    onKeyPress.mockClear()
+    onKeyDown.mockClear()
+    onKeyUp.mockClear()
+
+    userEvent.paste(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onKeyPress).not.toHaveBeenCalled()
+    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onKeyUp).not.toHaveBeenCalled()
+  },
+)
+
+test.each(['input', 'textarea'])(
+  'should append text in <%s> up to maxLength if provided',
+  async type => {
+    const onChange = jest.fn()
+    const onKeyDown = jest.fn()
+    const onKeyPress = jest.fn()
+    const onKeyUp = jest.fn()
+    const maxLength = 10
+
+    render(
+      React.createElement(type, {
+        'data-testid': 'input',
+        onChange,
+        onKeyDown,
+        onKeyPress,
+        onKeyUp,
+        maxLength,
+      }),
+    )
+
+    const text1 = 'superlong'
+    const text2 = 'text'
+    const text = text1 + text2
+    const slicedText = text.slice(0, maxLength)
+
+    const inputEl = screen.getByTestId('input')
+
+    await userEvent.type(inputEl, text1)
+    await userEvent.type(inputEl, text2)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(slicedText.length)
+    expect(onKeyPress).toHaveBeenCalledTimes(text.length)
+    expect(onKeyDown).toHaveBeenCalledTimes(text.length)
+    expect(onKeyUp).toHaveBeenCalledTimes(text.length)
+
+    inputEl.value = ''
+    onChange.mockClear()
+    onKeyPress.mockClear()
+    onKeyDown.mockClear()
+    onKeyUp.mockClear()
+
+    userEvent.paste(inputEl, text)
+
+    expect(inputEl).toHaveProperty('value', slicedText)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onKeyPress).not.toHaveBeenCalled()
+    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onKeyUp).not.toHaveBeenCalled()
+  },
+)
+
+test('should replace selected text all at once', async () => {
+  const onChange = jest.fn()
+  const {
+    container: {firstChild: input},
+  } = render(<input defaultValue="hello world" onChange={onChange} />)
+  const selectionStart = 'hello world'.search('world')
+  const selectionEnd = selectionStart + 'world'.length
+  input.setSelectionRange(selectionStart, selectionEnd)
+  await userEvent.paste(input, 'friend')
+  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(input).toHaveValue('hello friend')
+})

--- a/src/user-event/__tests__/paste.js
+++ b/src/user-event/__tests__/paste.js
@@ -13,6 +13,7 @@ test('should paste text in input', async () => {
     input[value=""] - focus
     input[value=""] - select
     input[value="Hello, world!"] - input
+      "{CURSOR}" -> "Hello, world!{CURSOR}"
     input[value="Hello, world!"] - select
   `)
 })
@@ -29,6 +30,7 @@ test('should paste text in textarea', async () => {
     textarea[value=""] - focus
     textarea[value=""] - select
     textarea[value="Hello, world!"] - input
+      "{CURSOR}" -> "Hello, world!{CURSOR}"
     textarea[value="Hello, world!"] - select
   `)
 })

--- a/src/user-event/index.js
+++ b/src/user-event/index.js
@@ -1,5 +1,6 @@
 export {click, dblClick} from './click'
 export {type} from './type'
+export {paste} from './paste'
 export {clear} from './clear'
 export {tab} from './tab'
 export {hover, unhover} from './hover'

--- a/src/user-event/paste.js
+++ b/src/user-event/paste.js
@@ -1,0 +1,122 @@
+import {
+  getConfig as getDOMTestingLibraryConfig,
+  fireEvent,
+} from '@testing-library/dom'
+
+// this needs to be wrapped in the asyncWrapper for React's act and angular's change detection
+async function paste(...args) {
+  let result
+  await getDOMTestingLibraryConfig().asyncWrapper(async () => {
+    result = await pasteImpl(...args)
+  })
+  return result
+}
+
+const getActiveElement = document => {
+  const activeElement = document.activeElement
+  if (activeElement.shadowRoot) {
+    return getActiveElement(activeElement.shadowRoot) || activeElement
+  } else {
+    return activeElement
+  }
+}
+
+// eslint-disable-next-line complexity
+function pasteImpl(
+  element,
+  text,
+  {initialSelectionStart, initialSelectionEnd} = {},
+) {
+  if (element.disabled) return
+
+  element.focus()
+
+  // The focused element could change between each event, so get the currently active element each time
+  const currentElement = () => getActiveElement(element.ownerDocument)
+  const currentValue = () => currentElement().value
+  const setSelectionRange = ({newValue, newSelectionStart}) => {
+    // if we *can* change the selection start, then we will if the new value
+    // is the same as the current value (so it wasn't programatically changed
+    // when the fireEvent.input was triggered).
+    // The reason we have to do this at all is because it actually *is*
+    // programmatically changed by fireEvent.input, so we have to simulate the
+    // browser's default behavior
+    if (
+      currentElement().selectionStart !== null &&
+      currentValue() === newValue
+    ) {
+      currentElement().setSelectionRange?.(newSelectionStart, newSelectionStart)
+    }
+  }
+
+  // by default, a new element has it's selection start and end at 0
+  // but most of the time when people call "paste", they expect it to paste
+  // at the end of the current input value. So, if the selection start
+  // and end are both the default of 0, then we'll go ahead and change
+  // them to the length of the current value.
+  // the only time it would make sense to pass the initialSelectionStart or
+  // initialSelectionEnd is if you have an input with a value and want to
+  // explicitely start typing with the cursor at 0. Not super common.
+  if (
+    currentElement().selectionStart === 0 &&
+    currentElement().selectionEnd === 0
+  ) {
+    currentElement().setSelectionRange(
+      initialSelectionStart ?? currentValue()?.length ?? 0,
+      initialSelectionEnd ?? currentValue()?.length ?? 0,
+    )
+  }
+
+  if (!element.readOnly) {
+    const {newValue, newSelectionStart} = calculateNewValue(text)
+    fireEvent.input(element, {
+      target: {value: newValue},
+    })
+    setSelectionRange({newValue, newSelectionStart})
+  }
+
+  function calculateNewValue(newEntry) {
+    const {selectionStart, selectionEnd} = currentElement()
+    // can't use .maxLength property because of a jsdom bug:
+    // https://github.com/jsdom/jsdom/issues/2927
+    const maxLength = Number(currentElement().getAttribute('maxlength') ?? -1)
+    const value = currentValue()
+    let newValue, newSelectionStart
+
+    if (selectionStart === null) {
+      // at the end of an input type that does not support selection ranges
+      // https://github.com/testing-library/user-event/issues/316#issuecomment-639744793
+      newValue = value + newEntry
+    } else if (selectionStart === selectionEnd) {
+      if (selectionStart === 0) {
+        // at the beginning of the input
+        newValue = newEntry + value
+      } else if (selectionStart === value.length) {
+        // at the end of the input
+        newValue = value + newEntry
+      } else {
+        // in the middle of the input
+        newValue =
+          value.slice(0, selectionStart) + newEntry + value.slice(selectionEnd)
+      }
+      newSelectionStart = selectionStart + newEntry.length
+    } else {
+      // we have something selected
+      const firstPart = value.slice(0, selectionStart) + newEntry
+      newValue = firstPart + value.slice(selectionEnd)
+      newSelectionStart = firstPart.length
+    }
+
+    if (maxLength < 0) {
+      return {newValue, newSelectionStart}
+    } else {
+      return {
+        newValue: newValue.slice(0, maxLength),
+        newSelectionStart:
+          newSelectionStart > maxLength ? maxLength : newSelectionStart,
+      }
+    }
+  }
+}
+
+export {paste}

--- a/src/user-event/paste.js
+++ b/src/user-event/paste.js
@@ -1,5 +1,5 @@
 import {getConfig as getDOMTestingLibraryConfig} from '../config'
-import {fireEvent} from '../events'
+import {fireEvent} from './utils'
 
 // this needs to be wrapped in the asyncWrapper for React's act and angular's change detection
 async function paste(...args) {
@@ -20,7 +20,7 @@ const getActiveElement = document => {
 }
 
 // eslint-disable-next-line complexity
-function pasteImpl(
+async function pasteImpl(
   element,
   text,
   {initialSelectionStart, initialSelectionEnd} = {},
@@ -67,7 +67,7 @@ function pasteImpl(
 
   if (!element.readOnly) {
     const {newValue, newSelectionStart} = calculateNewValue(text)
-    fireEvent.input(element, {
+    await fireEvent.input(element, {
       target: {value: newValue},
     })
     setSelectionRange({newValue, newSelectionStart})

--- a/src/user-event/paste.js
+++ b/src/user-event/paste.js
@@ -1,7 +1,5 @@
-import {
-  getConfig as getDOMTestingLibraryConfig,
-  fireEvent,
-} from '@testing-library/dom'
+import {getConfig as getDOMTestingLibraryConfig} from '../config'
+import {fireEvent} from '../events'
 
 // this needs to be wrapped in the asyncWrapper for React's act and angular's change detection
 async function paste(...args) {

--- a/src/user-event/type.js
+++ b/src/user-event/type.js
@@ -1,5 +1,5 @@
 import {wrapAsync} from '../wrap-async'
-import {fireEvent, getActiveElement} from './utils'
+import {fireEvent, getActiveElement, calculateNewValue} from './utils'
 import {tick} from './tick'
 import {click} from './click'
 
@@ -303,48 +303,6 @@ function calculateNewDeleteValue(element) {
   }
 
   return {newValue, newSelectionStart: selectionStart}
-}
-
-function calculateNewValue(newEntry, element) {
-  const {selectionStart, selectionEnd, value} = element
-  // can't use .maxLength property because of a jsdom bug:
-  // https://github.com/jsdom/jsdom/issues/2927
-  const maxLength = Number(element.getAttribute('maxlength') ?? -1)
-  let newValue, newSelectionStart
-
-  if (selectionStart === null) {
-    // at the end of an input type that does not support selection ranges
-    // https://github.com/testing-library/user-event/issues/316#issuecomment-639744793
-    newValue = value + newEntry
-  } else if (selectionStart === selectionEnd) {
-    if (selectionStart === 0) {
-      // at the beginning of the input
-      newValue = newEntry + value
-    } else if (selectionStart === value.length) {
-      // at the end of the input
-      newValue = value + newEntry
-    } else {
-      // in the middle of the input
-      newValue =
-        value.slice(0, selectionStart) + newEntry + value.slice(selectionEnd)
-    }
-    newSelectionStart = selectionStart + newEntry.length
-  } else {
-    // we have something selected
-    const firstPart = value.slice(0, selectionStart) + newEntry
-    newValue = firstPart + value.slice(selectionEnd)
-    newSelectionStart = firstPart.length
-  }
-
-  if (maxLength < 0) {
-    return {newValue, newSelectionStart}
-  } else {
-    return {
-      newValue: newValue.slice(0, maxLength),
-      newSelectionStart:
-        newSelectionStart > maxLength ? maxLength : newSelectionStart,
-    }
-  }
 }
 
 function getEventCallbackMap({


### PR DESCRIPTION
Migrated from testing-library/user-event#343

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add paste API (fixes #640)

<!-- Why are these changes necessary? -->

**Why**: The `allAtOnce` option of `type` doesn't represent real user interaction intuitively, and we need to fire `paste` events with the relevant `clipboardData`

<!-- How were these changes implemented? -->

**How**:

- [x] Extract `paste` event from old code for `type`'s `allAtOnce` option
- [x] Implement `clipboardData` support #585
- [ ] Add events
  - [ ] `paste` with `clipboardData`
  - [ ] `input` with matching value
  - [ ] `focus`
- [ ] `DataTransfer` mock objects

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
