### PR TITLE
Added explicit error message for Promises passed to getWindowFromNode

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -1,7 +1,22 @@
-import {getDocument, checkContainerType} from '../helpers'
+import {getDocument, getWindowFromNode, checkContainerType} from '../helpers'
 
 test('returns global document if exists', () => {
   expect(getDocument()).toBe(document)
+})
+
+describe('window retrieval throws when given something other than a node', () => {
+  test('Promise as node', () => {
+    expect(() =>
+      getWindowFromNode(new Promise(jest.fn())),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"It looks like you passed a Promise object instead of a DOM node. Did you use a \\"find\\" search instead of a \\"get\\" or \\"query\\"?"`,
+    )
+  })
+  test('unknown as node', () => {
+    expect(() => getWindowFromNode({})).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find the \\"window\\" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new"`,
+    )
+  })
 })
 
 describe('query container validation throws when validation fails', () => {

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -9,7 +9,7 @@ describe('window retrieval throws when given something other than a node', () =>
     expect(() =>
       getWindowFromNode(new Promise(jest.fn())),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"It looks like you passed a Promise object instead of a DOM node. Did you use a \\"find\\" search instead of a \\"get\\" or \\"query\\"?"`,
+      `"It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to do \`fireEvent.click(await screen.getBy...\`?"`,
     )
   })
   test('unknown as node', () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -47,7 +47,6 @@ function getDocument() {
   return window.document
 }
 function getWindowFromNode(node) {
-  // istanbul ignore next I'm not sure what could cause the final else so we'll leave it uncovered.
   if (node.defaultView) {
     // node is document
     return node.defaultView
@@ -57,8 +56,12 @@ function getWindowFromNode(node) {
   } else if (node.window) {
     // node is window
     return node.window
+  } else if (node.then instanceof Function) {
+    throw new Error(
+      `It looks like you passed a Promise object instead of a DOM node. Did you use a "find" search instead of a "get" or "query"?`,
+    )
   } else {
-    // no idea...
+    // The user passed something unusual to a calling function
     throw new Error(
       `Unable to find the "window" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`,
     )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -58,7 +58,7 @@ function getWindowFromNode(node) {
     return node.window
   } else if (node.then instanceof Function) {
     throw new Error(
-      `It looks like you passed a Promise object instead of a DOM node. Did you use a "find" search instead of a "get" or "query"?`,
+      `It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to do \`fireEvent.click(await screen.getBy...\`?`,
     )
   } else {
     // The user passed something unusual to a calling function


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added a nice explicit error message for the case in #609 of a `Promise` or Promise-like passed to a function that expects a DOM node.

<!-- Why are these changes necessary? -->

**Why**:

Better error messages = happier users! 💝 

**How**:

Per https://github.com/testing-library/dom-testing-library/issues/609#issuecomment-643660994, checked if `node.then instanceof Function`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I'm not attached to this particular error message, if a reviewer can think of something better that'd be nice.