### PR TITLE
fix: runWithRealTimers to be compatible with new version of jest

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -1,4 +1,11 @@
-import {getDocument, getWindowFromNode, checkContainerType} from '../helpers'
+import {
+  getDocument,
+  getWindowFromNode,
+  checkContainerType,
+  runWithRealTimers,
+} from '../helpers'
+
+const globalObj = typeof window === 'undefined' ? global : window
 
 test('returns global document if exists', () => {
   expect(getDocument()).toBe(document)
@@ -41,5 +48,21 @@ describe('query container validation throws when validation fails', () => {
     expect(() => checkContainerType({})).toThrowErrorMatchingInlineSnapshot(
       `"Expected container to be an Element, a Document or a DocumentFragment but got Object."`,
     )
+  })
+})
+
+test('should always use realTimers before using callback', () => {
+  const originalSetTimeout = globalObj.setTimeout
+
+  jest.useFakeTimers('legacy')
+  runWithRealTimers(() => {
+    expect(originalSetTimeout).toEqual(globalObj.setTimeout)
+  })
+
+  jest.useRealTimers()
+
+  jest.useFakeTimers('modern')
+  runWithRealTimers(() => {
+    expect(originalSetTimeout).toEqual(globalObj.setTimeout)
   })
 })

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -7,6 +7,8 @@ import {
 
 const globalObj = typeof window === 'undefined' ? global : window
 
+afterEach(() => jest.useRealTimers())
+
 test('returns global document if exists', () => {
   expect(getDocument()).toBe(document)
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,8 @@ const globalObj = typeof window === 'undefined' ? global : window
 function runWithRealTimers(callback) {
   const usingJestFakeTimers =
     globalObj.setTimeout &&
-    globalObj.setTimeout._isMockFunction &&
+    (globalObj.setTimeout._isMockFunction ||
+      typeof globalObj.setTimeout.clock !== 'undefined') &&
     typeof jest !== 'undefined'
 
   if (usingJestFakeTimers) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This change will fix issue #612.

**Why**:

With the version 26.0.0 of jest the `jest.useFakeTimers` function uses `@sinonjs/fake-timers`.
With this new package the property `_isMockFunction` is no more available.

**How**:

To fix the issue I have added a new check to `clock` property.
`@testing-library/dom` is now compatible with both version of `useFakeTimers`, the legacy and the modern one.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
