### PR TITLE
Use custom testIdAttribute in getSuggestedQuery

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -6,6 +6,10 @@ beforeAll(() => {
   configure({throwSuggestions: true})
 })
 
+afterEach(() => {
+  configure({testIdAttribute: 'data-testid'})
+})
+
 afterAll(() => {
   configure({throwSuggestions: false})
 })
@@ -433,6 +437,34 @@ test('getSuggestedQuery can return specified methods in addition to the best', (
 
   // return undefined if requested query can't be made
   expect(getSuggestedQuery(button, 'get', 'TestId')).toBeUndefined()
+})
+
+test('getSuggestedQuery works with custom testIdAttribute', () => {
+  configure({testIdAttribute: 'data-test'})
+
+  const {container} = render(`
+    <label for="username">label</label>
+    <input
+      id="username"
+      name="name"
+      placeholder="placeholder"
+      data-test="testid"
+      title="title"
+      alt="alt"
+      value="value"
+      type="text"
+    />
+    <button>button</button>
+  `)
+
+  const input = container.querySelector('input')
+
+  expect(getSuggestedQuery(input, 'get', 'TestId')).toMatchObject({
+    queryName: 'TestId',
+    queryMethod: 'getByTestId',
+    queryArgs: ['testid'],
+    variant: 'get',
+  })
 })
 
 test('getSuggestedQuery does not create suggestions for script and style elements', () => {

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -1,7 +1,7 @@
 import {computeAccessibleName} from 'dom-accessibility-api'
 import {getDefaultNormalizer} from './matches'
 import {getNodeText} from './get-node-text'
-import {DEFAULT_IGNORE_TAGS} from './config'
+import {DEFAULT_IGNORE_TAGS, getConfig} from './config'
 import {getImplicitAriaRoles} from './role-helpers'
 
 const normalize = getDefaultNormalizer()
@@ -120,7 +120,7 @@ export function getSuggestedQuery(element, variant = 'get', method) {
     return makeSuggestion('Title', title, {variant})
   }
 
-  const testId = element.getAttribute('data-testid')
+  const testId = element.getAttribute(getConfig().testIdAttribute)
   if (canSuggest('TestId', method, testId)) {
     return makeSuggestion('TestId', testId, {variant})
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Currently `getSuggestedQuery` always uses `data-testid` to find relevant
elements. This change updates it to use the configured `testIdAttribute`
if one has been set in the configuration. (Thanks to @smeijer for 
pointing me in the right direction for a solution.)

<!-- Why are these changes necessary? -->

**Why**:

If a user has set `testIdAttribute` suggestions will run `getByTestId` against the wrong elements.

<!-- How were these changes implemented? -->

**How**:

There's a new test to verify this behavior and a small change to the suggestions code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [X] Tests
- [ ] Typescript definitions updated N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This does not appear to solve #643 yet, but it's a first step in narrowing down the possible cause.