### PR TITLE
fix: improve suggested message, can't await getBy

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -18,7 +18,7 @@ describe('window retrieval throws when given something other than a node', () =>
     expect(() =>
       getWindowFromNode(new Promise(jest.fn())),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to do \`fireEvent.click(await screen.getBy...\`?"`,
+      `"It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?"`,
     )
   })
   test('unknown as node', () => {
@@ -61,8 +61,8 @@ test('should always use realTimers before using callback when timers are faked w
   runWithRealTimers(() => {
     expect(originalSetTimeout).toEqual(globalObj.setTimeout)
   })
-  expect(globalObj.setTimeout._isMockFunction).toBe(true);
-  expect(globalObj.setTimeout.clock).toBeUndefined();
+  expect(globalObj.setTimeout._isMockFunction).toBe(true)
+  expect(globalObj.setTimeout.clock).toBeUndefined()
 
   jest.useRealTimers()
 
@@ -71,24 +71,24 @@ test('should always use realTimers before using callback when timers are faked w
   runWithRealTimers(() => {
     expect(originalSetTimeout).toEqual(globalObj.setTimeout)
   })
-  expect(globalObj.setTimeout._isMockFunction).toBeUndefined();
-  expect(globalObj.setTimeout.clock).toBeDefined();
+  expect(globalObj.setTimeout._isMockFunction).toBeUndefined()
+  expect(globalObj.setTimeout.clock).toBeDefined()
 })
 
 test('should not use realTimers when timers are not faked with useFakeTimers', () => {
-  const originalSetTimeout = globalObj.setTimeout;
-  
-  // useFakeTimers is not used, timers are faked in some other way
-  const fakedSetTimeout = (callback) => {
-    callback();
-  };
-  fakedSetTimeout.clock = jest.fn();
+  const originalSetTimeout = globalObj.setTimeout
 
-  globalObj.setTimeout = fakedSetTimeout;
+  // useFakeTimers is not used, timers are faked in some other way
+  const fakedSetTimeout = callback => {
+    callback()
+  }
+  fakedSetTimeout.clock = jest.fn()
+
+  globalObj.setTimeout = fakedSetTimeout
 
   runWithRealTimers(() => {
     expect(fakedSetTimeout).toEqual(globalObj.setTimeout)
   })
 
-  globalObj.setTimeout = originalSetTimeout;
-});
+  globalObj.setTimeout = originalSetTimeout
+})

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,26 +2,30 @@ const globalObj = typeof window === 'undefined' ? global : window
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
-  const usingJestAndTimers = typeof jest !== 'undefined' && typeof globalObj.setTimeout !== 'undefined';
-  const usingLegacyJestFakeTimers = usingJestAndTimers && typeof globalObj.setTimeout._isMockFunction !== 'undefined' && globalObj.setTimeout._isMockFunction;
+  const usingJestAndTimers =
+    typeof jest !== 'undefined' && typeof globalObj.setTimeout !== 'undefined'
+  const usingLegacyJestFakeTimers =
+    usingJestAndTimers &&
+    typeof globalObj.setTimeout._isMockFunction !== 'undefined' &&
+    globalObj.setTimeout._isMockFunction
 
-  let usingModernJestFakeTimers = false;
+  let usingModernJestFakeTimers = false
   if (
     usingJestAndTimers &&
-    typeof globalObj.setTimeout.clock !== "undefined" &&
-    typeof jest.getRealSystemTime !== "undefined"
+    typeof globalObj.setTimeout.clock !== 'undefined' &&
+    typeof jest.getRealSystemTime !== 'undefined'
   ) {
     try {
       // jest.getRealSystemTime is only supported for Jest's `modern` fake timers and otherwise throws
-      jest.getRealSystemTime();
-      usingModernJestFakeTimers = true;
+      jest.getRealSystemTime()
+      usingModernJestFakeTimers = true
     } catch {
       // not using Jest's modern fake timers
     }
   }
 
   const usingJestFakeTimers =
-    usingLegacyJestFakeTimers || usingModernJestFakeTimers;
+    usingLegacyJestFakeTimers || usingModernJestFakeTimers
 
   if (usingJestFakeTimers) {
     jest.useRealTimers()
@@ -51,7 +55,7 @@ function getTimeFunctions() {
   }
 }
 
-const { clearTimeoutFn, setImmediateFn, setTimeoutFn } = runWithRealTimers(
+const {clearTimeoutFn, setImmediateFn, setTimeoutFn} = runWithRealTimers(
   getTimeFunctions,
 )
 
@@ -74,7 +78,7 @@ function getWindowFromNode(node) {
     return node.window
   } else if (node.then instanceof Function) {
     throw new Error(
-      `It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to do \`fireEvent.click(await screen.getBy...\`?`,
+      `It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?`,
     )
   } else {
     // The user passed something unusual to a calling function


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Improve suggestion when a Promise is passed to a `fireEvent` method

<!-- Why are these changes necessary? -->

**Why**:

- A `getBy` query can't be awaited and the messages says `await screen.getBy`

<!-- How were these changes implemented? -->

**How**:

- Change the message (and the test)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
