### PR TITLE
fix: Treat header as banner role

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.10.2",
-    "aria-query": "^4.0.2",
+    "aria-query": "^4.2.1",
     "dom-accessibility-api": "^0.4.5",
     "pretty-format": "^25.5.0"
   },

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -34,6 +34,7 @@ test('find asynchronously finds elements', async () => {
       <span title="test title" />
       <div role="dialog"></div>
       <div role="meter progressbar"></div>
+      <header>header</header>
     </div>
   `)
   await expect(findByLabelText('test-label')).resolves.toBeTruthy()
@@ -65,6 +66,9 @@ test('find asynchronously finds elements', async () => {
   await expect(
     findAllByRole('progressbar', {queryFallbacks: true}),
   ).resolves.toHaveLength(1)
+
+  await expect(findByRole('banner')).resolves.toBeTruthy()
+  await expect(findAllByRole('banner')).resolves.toHaveLength(1)
 
   await expect(findByTestId('test-id')).resolves.toBeTruthy()
   await expect(findAllByTestId('test-id')).resolves.toHaveLength(1)


### PR DESCRIPTION
**What**:

`<header>` is not recognized as `banner` role, and cannot be selected with `getByRole("banner")`.

See also: #578

**Why**:

It should work correctly according to the [specs](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/banner.html).

**How**:

Update `aria-query` dependency. The latest [aria-query version](https://github.com/A11yance/aria-query/releases/tag/v4.2.2) fixes the issue of failing to recognize `<header>` as a `banner` role.

**Checklist**:

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] Typescript definitions updated N/A
- [x] Ready to be merged

Fixes: #578