### PR TITLE
chore: remove outdated code comments

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -531,15 +531,11 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole(/heading/i)).toHaveLength(6)
   expect(queryAllByRole('list')).toHaveLength(2)
   expect(queryAllByRole(/listitem/i)).toHaveLength(3)
-  // TODO: with https://github.com/A11yance/aria-query/pull/42
-  // the actual value will match `toHaveLength(2)`
   expect(queryAllByRole(/textbox/i)).toHaveLength(2)
   expect(queryAllByRole(/checkbox/i)).toHaveLength(1)
   expect(queryAllByRole(/radio/i)).toHaveLength(1)
   expect(queryAllByRole('row')).toHaveLength(3)
   expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
-  // TODO: with https://github.com/A11yance/aria-query/pull/42
-  // the actual value will match `toHaveLength(3)`
   expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
   expect(queryAllByRole(/img/i)).toHaveLength(1)
   expect(queryAllByRole('meter')).toHaveLength(1)


### PR DESCRIPTION
Resolves https://github.com/testing-library/dom-testing-library/pull/664#discussion_r444028138

**What**:

No code changes

**Why**:

#664 reatained some outdated code comments that were made obsolete with that PR

**How**:

Remove comments

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- ~[ ] Tests~
- ~[ ] Typescript definitions updated~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
