### PR TITLE
fix: add getConfig to types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,14 +1,15 @@
 export interface Config {
-    testIdAttribute: string;
-    asyncWrapper(cb: (...args: any[]) => any): Promise<any>;
-    eventWrapper(cb: (...args: any[]) => any): void;
-    asyncUtilTimeout: number;
-    defaultHidden: boolean;
-    throwSuggestions: boolean;
+  testIdAttribute: string
+  asyncWrapper(cb: (...args: any[]) => any): Promise<any>
+  eventWrapper(cb: (...args: any[]) => any): void
+  asyncUtilTimeout: number
+  defaultHidden: boolean
+  throwSuggestions: boolean
 }
 
 export interface ConfigFn {
-    (existingConfig: Config): Partial<Config>;
+  (existingConfig: Config): Partial<Config>
 }
 
-export function configure(configDelta: Partial<Config> | ConfigFn): void;
+export function configure(configDelta: Partial<Config> | ConfigFn): void
+export function getConfig(): Config


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- adds the `getConfig` type to the TS typings

<!-- Why are these changes necessary? -->

**Why**:

- otherwise it seems that `getConfig` isn't exported

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

- add it to type types file

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
