### PR TITLE
feat(waitFor): add onTimeout which adds DOM output to timeout errors

### DIFF
--- a/src/__tests__/base-queries-warn-on-invalid-container.js
+++ b/src/__tests__/base-queries-warn-on-invalid-container.js
@@ -112,7 +112,7 @@ describe('asynchronous queries throw on invalid container type', () => {
     ['findAllByTestId', findAllByTestId],
   ])('%s', (_queryName, query) => {
     const queryOptions = {}
-    const waitOptions = {timeout: 1}
+    const waitOptions = {timeout: 1, onTimeout: e => e}
     return expect(
       query(
         'invalid type for container',

--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -42,7 +42,7 @@ test('fake timer timeout', async () => {
       () => {
         throw new Error('always throws')
       },
-      {timeout: 10},
+      {timeout: 10, onTimeout: e => e},
     ),
   ).rejects.toMatchInlineSnapshot(`[Error: always throws]`)
 })
@@ -53,7 +53,7 @@ test('times out after 1000ms by default', async () => {
   // there's a bug with this rule here...
   // eslint-disable-next-line jest/valid-expect
   await expect(
-    waitForElementToBeRemoved(() => container),
+    waitForElementToBeRemoved(() => container, {onTimeout: e => e}),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"Timed out in waitForElementToBeRemoved."`,
   )

--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -96,7 +96,7 @@ test('rethrows non-testing-lib errors', () => {
 test('logs timeout error when it times out', async () => {
   const div = document.createElement('div')
   await expect(
-    waitForElementToBeRemoved(() => div, {timeout: 1}),
+    waitForElementToBeRemoved(() => div, {timeout: 1, onTimeout: e => e}),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
     `"Timed out in waitForElementToBeRemoved."`,
   )

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -35,7 +35,7 @@ test('if no error is thrown then throws a timeout error', async () => {
       // eslint-disable-next-line no-throw-literal
       throw undefined
     },
-    {timeout: 8, interval: 5},
+    {timeout: 8, interval: 5, onTimeout: e => e},
   ).catch(e => e)
   expect(result).toMatchInlineSnapshot(`[Error: Timed out in waitFor.]`)
 })
@@ -100,4 +100,28 @@ test('throws nice error if provided callback is not a function', () => {
   expect(() => waitFor(someElement)).toThrow(
     'Received `callback` arg must be a function',
   )
+})
+
+test('timeout logs a pretty DOM', async () => {
+  renderIntoDocument(`<div id="pretty">how pretty</div>`)
+  const error = await waitFor(
+    () => {
+      throw new Error('always throws')
+    },
+    {timeout: 1},
+  ).catch(e => e)
+  expect(error.message).toMatchInlineSnapshot(`
+    "always throws
+
+    <html>
+      <head />
+      <body>
+        <div
+          id="pretty"
+        >
+          how pretty
+        </div>
+      </body>
+    </html>"
+  `)
 })

--- a/types/wait-for.d.ts
+++ b/types/wait-for.d.ts
@@ -2,6 +2,7 @@ export interface waitForOptions {
   container?: HTMLElement
   timeout?: number
   interval?: number
+  onTimeout?: (error: Error) => Error
   mutationObserverOptions?: MutationObserverInit
 }
 


### PR DESCRIPTION
**What**: add onTimeout which adds DOM output to timeout errors

<!-- Why are these changes necessary? -->

**Why**: Closes #559 (nicer error messages)

<!-- How were these changes implemented? -->

**How**: add the parameter and have it use prettyDOM to attach the nice message to the error

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/512
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
