### PR TITLE
fix: use the first label for LabelText query suggestions

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -485,3 +485,29 @@ test('getSuggestedQuery does not create suggestions for script and style element
   expect(getSuggestedQuery(script, 'get', 'TestId')).toBeUndefined()
   expect(getSuggestedQuery(style, 'get', 'TestId')).toBeUndefined()
 })
+
+test('should not thrown when getting query byLabelText if ID has special chars or spaces', () => {
+  const {container, rerender} = renderIntoDocument(`
+    <div id="not usual id">One</div>
+    <input
+      type="text"
+      aria-labelledby="not usual id"
+    />
+  `)
+
+  expect(() =>
+    getSuggestedQuery(container.querySelector('input'), 'get', 'labelText'),
+  ).not.toThrow()
+
+  rerender(`
+    <div id="why you need to use \\/|"£$ ?">One</div>
+    <input
+      type="text"
+      aria-labelledby="why you need to use \\/|"£$ ?"
+    />
+  `)
+
+  expect(() =>
+    getSuggestedQuery(container.querySelector('input'), 'get', 'labelText'),
+  ).not.toThrow()
+})

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -486,28 +486,25 @@ test('getSuggestedQuery does not create suggestions for script and style element
   expect(getSuggestedQuery(style, 'get', 'TestId')).toBeUndefined()
 })
 
-test('should not thrown when getting query byLabelText if ID has special chars or spaces', () => {
-  const {container, rerender} = renderIntoDocument(`
-    <div id="not usual id">One</div>
+// this is only a temporary fix. The problem is that at the moment @testing-library/dom
+// not support label concatenation
+// see https://github.com/testing-library/dom-testing-library/issues/545
+test('should get the first label with aria-labelledby contains multiple ids', () => {
+  const {container} = renderIntoDocument(`
+    <div id="one">One</div>
+    <div id="two">One</div>
     <input
       type="text"
-      aria-labelledby="not usual id"
+      aria-labelledby="one two"
     />
   `)
 
-  expect(() =>
+  expect(
     getSuggestedQuery(container.querySelector('input'), 'get', 'labelText'),
-  ).not.toThrow()
-
-  rerender(`
-    <div id="why you need to use \\/|"£$ ?">One</div>
-    <input
-      type="text"
-      aria-labelledby="why you need to use \\/|"£$ ?"
-    />
-  `)
-
-  expect(() =>
-    getSuggestedQuery(container.querySelector('input'), 'get', 'labelText'),
-  ).not.toThrow()
+  ).toMatchObject({
+    queryName: 'LabelText',
+    queryMethod: 'getByLabelText',
+    queryArgs: [/one/i],
+    variant: 'get',
+  })
 })

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -15,9 +15,13 @@ function getLabelTextFor(element) {
   if (!label) {
     const ariaLabelledBy = element.getAttribute('aria-labelledby')
     if (ariaLabelledBy) {
+      // this is only a temporary fix. The problem is that at the moment @testing-library/dom
+      // not support label concatenation
+      // see https://github.com/testing-library/dom-testing-library/issues/545
+      const firstId = ariaLabelledBy.split(' ')[0]
       // we're using this notation because with the # selector we would have to escape special characters e.g. user.name
       // see https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#Escaping_special_characters
-      label = document.querySelector(`[id="${ariaLabelledBy}"]`)
+      label = document.querySelector(`[id="${firstId}"]`)
     }
   }
 

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -17,7 +17,7 @@ function getLabelTextFor(element) {
     if (ariaLabelledBy) {
       // we're using this notation because with the # selector we would have to escape special characters e.g. user.name
       // see https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#Escaping_special_characters
-      label = document.querySelector(`[id=${ariaLabelledBy}]`)
+      label = document.querySelector(`[id="${ariaLabelledBy}"]`)
     }
   }
 


### PR DESCRIPTION
**What**:  Fix a little bug 


**Why**:  As reported [here](https://github.com/testing-library/testing-playground/issues/214) when `getSuggestedQuery` tried to get label text through `aria-labelledby` it threw an exception when the id had spaces or special chars

<!-- How were these changes implemented? -->

**How**: Surrounding the selector with `" "`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
