### PR TITLE
fix: catch missing parenthesis

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,7 @@ function getJestFakeTimersType() {
       // jest.getRealSystemTime is only supported for Jest's `modern` fake timers and otherwise throws
       jest.getRealSystemTime()
       return 'modern'
-    } catch {
+    } catch(error) {
       // not using Jest's modern fake timers
     }
   }


### PR DESCRIPTION
Hello, I am facing an 'Unexpected token' error with Jest when I run npm test, here is the log :

`FAIL  src/components/ToolPage/CreateAccount/__tests__/index.spec.js
  ● Test suite failed to run

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /home/renaud/Documents/workspace/ihm-cetautomatix/node_modules/@testing-library/dom/dist/helpers.js:44
        } catch {// not using Jest's modern fake timers
                ^

    SyntaxError: Unexpected token {

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1258:14)
      at Object.<anonymous> (node_modules/@testing-library/dom/dist/pretty-dom.js:13:16)
`

**What**:

I added missing parenthesis and argument

**Why**:

It fixes an 'unexpected tokens' error I encountered with the module

**How**:

N/A

**Checklist**: 

N/A

Tell me if I forgot to add something !
