### PR TITLE
Adds matcher name to multiple elements error

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -346,7 +346,9 @@ Here are the accessible roles:
 test('has no useful error message in findBy', async () => {
   const {findByRole} = render(`<li />`)
 
-  await expect(findByRole('option', {timeout: 1})).rejects.toThrow('Unable to find role="option"')
+  await expect(findByRole('option', {timeout: 1})).rejects.toThrow(
+    'Unable to find role="option"',
+  )
 })
 
 test('explicit role is most specific', () => {
@@ -375,6 +377,49 @@ Here are the accessible roles:
     role="tab"
   />
 </body>"
+`)
+})
+
+test('accessible name in error message for multiple found', () => {
+  const {getByRole} = render(`
+    <div>
+      <button> Increment value </button>
+      <button> Decrement value </button>
+      <button> Reset value </button>
+    </div>
+  `)
+
+  expect(() => getByRole('button', {name: /value/i}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Found multiple elements with the role "button" and name \`/value/i\`
+
+(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+
+<div>
+  
+    
+  <div>
+    
+      
+    <button>
+       Increment value 
+    </button>
+    
+      
+    <button>
+       Decrement value 
+    </button>
+    
+      
+    <button>
+       Reset value 
+    </button>
+    
+    
+  </div>
+  
+  
+</div>"
 `)
 })
 

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -380,7 +380,7 @@ Here are the accessible roles:
 `)
 })
 
-test('accessible name in error message for multiple found', () => {
+test('accessible regex name in error message for multiple found', () => {
   const {getByRole} = render(
     `<button>Increment value</button
       ><button>Decrement value</button
@@ -403,6 +403,34 @@ test('accessible name in error message for multiple found', () => {
   </button>
   <button>
     Reset value
+  </button>
+</div>"
+`)
+})
+
+test('accessible string name in error message for multiple found', () => {
+  const {getByRole} = render(
+    `<button>Submit</button
+      ><button>Submit</button
+      ><button>Submit</button
+    >`,
+  )
+
+  expect(() => getByRole('button', {name: 'Submit'}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Found multiple elements with the role "button" and name "Submit"
+
+(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+
+<div>
+  <button>
+    Submit
+  </button>
+  <button>
+    Submit
+  </button>
+  <button>
+    Submit
   </button>
 </div>"
 `)

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -381,13 +381,12 @@ Here are the accessible roles:
 })
 
 test('accessible name in error message for multiple found', () => {
-  const {getByRole} = render(`
-    <div>
-      <button> Increment value </button>
-      <button> Decrement value </button>
-      <button> Reset value </button>
-    </div>
-  `)
+  const {getByRole} = render(
+    `<button>Increment value</button
+      ><button>Decrement value</button
+      ><button>Reset value</button
+    >`,
+  )
 
   expect(() => getByRole('button', {name: /value/i}))
     .toThrowErrorMatchingInlineSnapshot(`
@@ -396,29 +395,15 @@ test('accessible name in error message for multiple found', () => {
 (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
 <div>
-  
-    
-  <div>
-    
-      
-    <button>
-       Increment value 
-    </button>
-    
-      
-    <button>
-       Decrement value 
-    </button>
-    
-      
-    <button>
-       Reset value 
-    </button>
-    
-    
-  </div>
-  
-  
+  <button>
+    Increment value
+  </button>
+  <button>
+    Decrement value
+  </button>
+  <button>
+    Reset value
+  </button>
 </div>"
 `)
 })

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -107,8 +107,8 @@ function queryAllByRole(
     })
 }
 
-const getMultipleError = (c, role) =>
-  `Found multiple elements with the role "${role}"`
+const getMultipleError = (c, role, {name} = {}) =>
+  `Found multiple elements with the role "${role}" matching ${name}`
 
 const getMissingError = (
   container,

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -107,8 +107,18 @@ function queryAllByRole(
     })
 }
 
-const getMultipleError = (c, role, {name} = {}) =>
-  `Found multiple elements with the role "${role}" matching ${name}`
+const getMultipleError = (c, role, {name} = {}) => {
+  let nameHint = ''
+  if (name === undefined) {
+    nameHint = ''
+  } else if (typeof name === 'string') {
+    nameHint = ` and name "${name}"`
+  } else {
+    nameHint = ` and name \`${name}\``
+  }
+
+  return `Found multiple elements with the role "${role}"${nameHint}`
+}
 
 const getMissingError = (
   container,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The getByRole queries are designed to return a single element whose role matches the provided role argument and whose accessible name matches the provided name argument.

When multiple elements are matched, the language in the error message only mentions the role and not the accessible name.

**Sample query**
```js
screen.getByRole('definition', { name: /value/i })
```

**Current error message**
```
TestingLibraryElementError: Found multiple elements with the role "definition"
```
**New error messages**
```
TestingLibraryElementError: Found multiple elements with the role "definition" and name "value"
```
```
TestingLibraryElementError: Found multiple elements with the role "definition" and name `/value/i`
```

<!-- Why are these changes necessary? -->

**Why**:

When you have several queries against the same role but for different accessible names, the error messages produced by them are identical. The only way to figure out which name is finding duplicates is to look at the code trace.

<!-- How were these changes implemented? -->

**How**:

The information including the accessible name parameter was already provided to the error message handler. The logic for displaying the name with or without quotes depending on its type was already present in the `getMissingError` handler, so I copied it to the `getMultipleError` handler

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
