### PR TITLE
Lists elements that matched multiple error

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -390,7 +390,7 @@ test('accessible regex name in error message for multiple found', () => {
 
   expect(() => getByRole('button', {name: /value/i}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found multiple elements with the role "button"
+"Found multiple elements with the role "button" and name \`/value/i\`
 
 Here are the matching elements:
 
@@ -399,9 +399,12 @@ Here are the matching elements:
 </button>
 
 <button>
+  Decrement value
+</button>
+
+<button>
   Reset value
 </button>
-"Found multiple elements with the role "button" and name \`/value/i\`
 
 (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
@@ -431,6 +434,20 @@ test('accessible string name in error message for multiple found', () => {
     .toThrowErrorMatchingInlineSnapshot(`
 "Found multiple elements with the role "button" and name "Submit"
 
+Here are the matching elements:
+
+<button>
+  Submit
+</button>
+
+<button>
+  Submit
+</button>
+
+<button>
+  Submit
+</button>
+
 (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
 <div>
@@ -458,7 +475,7 @@ test('matching elements in error for multiple found', () => {
 
   expect(() => getByRole('button', {name: /value/i}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found multiple elements with the role "button"
+"Found multiple elements with the role "button" and name \`/value/i\`
 
 Here are the matching elements:
 

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -346,7 +346,9 @@ Here are the accessible roles:
 test('has no useful error message in findBy', async () => {
   const {findByRole} = render(`<li />`)
 
-  await expect(findByRole('option', {timeout: 1})).rejects.toThrow('Unable to find role="option"')
+  await expect(findByRole('option', {timeout: 1})).rejects.toThrow(
+    'Unable to find role="option"',
+  )
 })
 
 test('explicit role is most specific', () => {
@@ -375,6 +377,48 @@ Here are the accessible roles:
     role="tab"
   />
 </body>"
+`)
+})
+
+test('matching elements in error for multiple found', () => {
+  const {getByRole} = render(
+    `<button>Increment value</button
+      ><button>Different label</button
+      ><p>Wrong role</p
+      ><button>Reset value</button
+    >`,
+  )
+
+  expect(() => getByRole('button', {name: /value/i}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Found multiple elements with the role "button"
+
+Here are the matching elements:
+
+<button>
+  Increment value
+</button>
+
+<button>
+  Reset value
+</button>
+
+(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+
+<div>
+  <button>
+    Increment value
+  </button>
+  <button>
+    Different label
+  </button>
+  <p>
+    Wrong role
+  </p>
+  <button>
+    Reset value
+  </button>
+</div>"
 `)
 })
 

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -9,7 +9,6 @@ import {
 } from '../role-helpers'
 import {wrapAllByQueryWithSuggestion} from '../query-helpers'
 import {checkContainerType} from '../helpers'
-import {prettyDOM} from '../pretty-dom'
 import {
   buildQueries,
   fuzzyMatches,
@@ -108,11 +107,8 @@ function queryAllByRole(
     })
 }
 
-const getMultipleError = ({elements}, role) => {
-  const suggestions = elements.map(element => prettyDOM(element)).join('\n')
-
-  return `Found multiple elements with the role "${role}"
-  ${suggestions}`
+const getMultipleError = (c, role) => {
+  return `Found multiple elements with the role "${role}"`
 }
 
 const getMissingError = (

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -9,6 +9,7 @@ import {
 } from '../role-helpers'
 import {wrapAllByQueryWithSuggestion} from '../query-helpers'
 import {checkContainerType} from '../helpers'
+import {prettyDOM} from '../pretty-dom'
 import {
   buildQueries,
   fuzzyMatches,
@@ -107,8 +108,12 @@ function queryAllByRole(
     })
 }
 
-const getMultipleError = (c, role) =>
-  `Found multiple elements with the role "${role}"`
+const getMultipleError = ({elements}, role) => {
+  const suggestions = elements.map(element => prettyDOM(element)).join('\n')
+
+  return `Found multiple elements with the role "${role}"
+  ${suggestions}`
+}
 
 const getMissingError = (
   container,

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -46,7 +46,7 @@ function makeSingleQuery(allQuery, getMultipleError) {
     const els = allQuery(container, ...args)
     if (els.length > 1) {
       throw getMultipleElementsFoundError(
-        getMultipleError(container, ...args),
+        getMultipleError({container, elements: els}, ...args),
         container,
       )
     }

--- a/src/query-helpers.js
+++ b/src/query-helpers.js
@@ -1,3 +1,4 @@
+import {prettyDOM} from './pretty-dom'
 import {getSuggestedQuery} from './suggestions'
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
 import {waitFor} from './wait-for'
@@ -45,8 +46,14 @@ function makeSingleQuery(allQuery, getMultipleError) {
   return (container, ...args) => {
     const els = allQuery(container, ...args)
     if (els.length > 1) {
+      const elementStrings = els.map(element => prettyDOM(element)).join('\n\n')
+
       throw getMultipleElementsFoundError(
-        getMultipleError({container, elements: els}, ...args),
+        `${getMultipleError(container, ...args)}
+
+Here are the matching elements:
+
+${elementStrings}`,
         container,
       )
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR adds the found elements to the log output of the MultipleError

<!-- Why are these changes necessary? -->
**Current error**
```
TestingLibraryElementError: Found multiple elements with the role "definition"
```

**New error**
```
TestingLibraryElementError: Found multiple elements with the role "definition"
    <dd
      aria-labelledby="uid-4-propertyValue"
      class="mb-0 text-size-large"
    >
      565000           
    </dd>
    <dd
      aria-labelledby="uid-4-appraisedValue"
      class="mb-0 text-size-large"
    >
      None         
    </dd>
    <dd
      aria-labelledby="uid-4-appraisedValue"
      class="mb-0 text-size-large"
    >
      2240 sqft         
    </dd>
```
**Why**:

It's not always immediately obvious which elements are conflicting, and since dom-testing-library needs to find them in order to know there are multiples it makes sense to expose that to the user

<!-- How were these changes implemented? -->

**How**:

I'm quite certain this is not the correct implementation of this feature, but I wanted to trial it out before investing too much time. If it's something deemed worthy of inclusion, I'd appreciate a little guidance on how to structure this (possibly a new wrapQuery type function) in a way that's idiomatic to the codebase
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
