### PR TITLE
get by label concat values

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -188,6 +188,7 @@ test('can get form controls by label text', () => {
   expect(getByLabelText('5th two').id).toBe('fifth-id')
   expect(getByLabelText('6th one').id).toBe('sixth-id')
   expect(getByLabelText('6th two').id).toBe('sixth-id')
+  expect(getByLabelText('6th one 6th two').id).toBe('sixth-id')
   expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
   expect(getByLabelText('7th one').id).toBe('seventh-id')
 })
@@ -341,6 +342,61 @@ test('label with no form control', () => {
 <div>
   <label>
     All alone
+  </label>
+</div>"
+`)
+})
+
+test('label with no form control and fuzzy matcher', () => {
+  const {getByLabelText, queryByLabelText} = render(
+    `<label>All alone label</label>`,
+  )
+  expect(queryByLabelText('alone', {exact: false})).toBeNull()
+  expect(() => getByLabelText('alone', {exact: false}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+
+<div>
+  <label>
+    All alone label
+  </label>
+</div>"
+`)
+})
+
+test('label with children with no form control', () => {
+  const {getByLabelText, queryByLabelText} = render(`
+  <label>
+    All alone but with children
+    <textarea>Hello</textarea>
+    <select><option value="0">zero</option></select>
+  </label>`)
+  expect(queryByLabelText(/alone/, {selector: 'input'})).toBeNull()
+  expect(() => getByLabelText(/alone/, {selector: 'input'}))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+
+<div>
+  
+  
+  <label>
+    
+    All alone but with children
+    
+    <textarea>
+      Hello
+    </textarea>
+    
+    
+    <select>
+      <option
+        value="0"
+      >
+        zero
+      </option>
+    </select>
+    
+  
   </label>
 </div>"
 `)
@@ -960,4 +1016,27 @@ test('can get a select with options', () => {
     </label>
   `)
   getByLabelText('Label')
+})
+
+test('can get an element with aria-labelledby when label has a child', () => {
+  const {getByLabelText} = render(`
+    <div>
+      <label id='label-with-textarea'>
+        First Label
+        <textarea>Value</textarea>
+      </label>
+      <input aria-labelledby='label-with-textarea' id='1st-input'/>
+      <label id='label-with-select'>
+        Second Label
+        <select><option value="1">one</option></select>
+      </label>
+      <input aria-labelledby='label-with-select' id='2nd-input'/>
+    </div>
+  `)
+  expect(getByLabelText('First Label', {selector: 'input'}).id).toBe(
+    '1st-input',
+  )
+  expect(getByLabelText('Second Label', {selector: 'input'}).id).toBe(
+    '2nd-input',
+  )
 })

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -171,7 +171,8 @@ test('can get form controls by label text', () => {
       <div>
         <input id="sixth-label-one" value="6th one"/>
         <input id="sixth-label-two" value="6th two"/>
-        <input aria-labelledby="sixth-label-one sixth-label-two" id="sixth-id" />
+        <label id="sixth-label-three">6th three</label>
+        <input aria-labelledby="sixth-label-one sixth-label-two sixth-label-three" id="sixth-id" />
       </div>
     </div>
   `)
@@ -183,6 +184,7 @@ test('can get form controls by label text', () => {
   expect(getByLabelText('5th two').id).toBe('fifth-id')
   expect(getByLabelText('6th one').id).toBe('sixth-id')
   expect(getByLabelText('6th two').id).toBe('sixth-id')
+  expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
 })
 
 test('can get elements labelled with aria-labelledby attribute', () => {

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -174,6 +174,10 @@ test('can get form controls by label text', () => {
         <label id="sixth-label-three">6th three</label>
         <input aria-labelledby="sixth-label-one sixth-label-two sixth-label-three" id="sixth-id" />
       </div>
+      <div>
+        <span id="seventh-label-one">7th one</span>
+        <input aria-labelledby="seventh-label-one" id="seventh-id" />
+      </div>
     </div>
   `)
   expect(getByLabelText('1st').id).toBe('first-id')
@@ -185,6 +189,7 @@ test('can get form controls by label text', () => {
   expect(getByLabelText('6th one').id).toBe('sixth-id')
   expect(getByLabelText('6th two').id).toBe('sixth-id')
   expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
+  expect(getByLabelText('7th one').id).toBe('seventh-id')
 })
 
 test('can get elements labelled with aria-labelledby attribute', () => {

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -168,6 +168,11 @@ test('can get form controls by label text', () => {
         <label id="fifth-label-two">5th two</label>
         <input aria-labelledby="fifth-label-one fifth-label-two" id="fifth-id" />
       </div>
+      <div>
+        <input id="sixth-label-one" value="6th one"/>
+        <input id="sixth-label-two" value="6th two"/>
+        <input aria-labelledby="sixth-label-one sixth-label-two" id="sixth-id" />
+      </div>
     </div>
   `)
   expect(getByLabelText('1st').id).toBe('first-id')
@@ -176,6 +181,8 @@ test('can get form controls by label text', () => {
   expect(getByLabelText('4th').id).toBe('fourth.id')
   expect(getByLabelText('5th one').id).toBe('fifth-id')
   expect(getByLabelText('5th two').id).toBe('fifth-id')
+  expect(getByLabelText('6th one').id).toBe('sixth-id')
+  expect(getByLabelText('6th two').id).toBe('sixth-id')
 })
 
 test('can get elements labelled with aria-labelledby attribute', () => {

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -11,21 +11,6 @@ import {
   wrapSingleQueryWithSuggestion,
 } from './all-utils'
 
-function getCombinations(labels, matcher) {
-  const combs = [[]]
-  const matching = []
-  for (const label of labels) {
-    const copy = [...combs]
-    for (const prefix of copy) {
-      const combination = prefix.concat(label.textToMatch)
-      combs.push(combination)
-      if (matcher(combination.join(' '), label.node)) {
-        matching.push(label.node)
-      }
-    }
-  }
-  return matching
-}
 function queryAllLabels(container) {
   return Array.from(container.querySelectorAll('label,input'))
     .map(node => {
@@ -59,22 +44,11 @@ function queryAllLabelsByText(
 
   const textToMatchByLabels = queryAllLabels(container)
 
-  const nodesByLabelMatchingText = textToMatchByLabels
+  return textToMatchByLabels
     .filter(({node, textToMatch}) =>
       matcher(textToMatch, node, text, matchNormalizer),
     )
     .map(({node}) => node)
-  const labelsNotMatchingTextAndNotEmpty = textToMatchByLabels.filter(
-    ({node, textToMatch}) =>
-      textToMatch && !nodesByLabelMatchingText.some(n => n.isEqualNode(node)),
-  )
-
-  const concatLabelsMatching = getCombinations(
-    labelsNotMatchingTextAndNotEmpty,
-    (textToMatch, node) => matcher(textToMatch, node, text, matchNormalizer),
-  )
-
-  return nodesByLabelMatchingText.concat(concatLabelsMatching)
 }
 
 function queryAllByLabelText(

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -10,7 +10,6 @@ import {
   wrapAllByQueryWithSuggestion,
   wrapSingleQueryWithSuggestion,
 } from './all-utils'
-import {queryAllByText} from './text'
 
 function getCombinations(labels, matcher) {
   const combs = [[]]
@@ -85,74 +84,93 @@ function queryAllByLabelText(
 ) {
   checkContainerType(container)
 
+  const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  const labels = queryAllLabelsByText(container, text, {
-    exact,
-    normalizer: matchNormalizer,
-  })
 
-  const labelledElements = labels
-    .reduce((matchedElements, label) => {
-      const elementsForLabel = []
-      if (label.control) {
-        elementsForLabel.push(label.control)
-      }
-      /* istanbul ignore if */
-      if (label.getAttribute('for')) {
-        // we're using this notation because with the # selector we would have to escape special characters e.g. user.name
-        // see https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector#Escaping_special_characters
-        // <label for="someId">text</label><input id="someId" />
-
-        // .control support has landed in jsdom (https://github.com/jsdom/jsdom/issues/2175)
-        elementsForLabel.push(
-          container.querySelector(`[id="${label.getAttribute('for')}"]`),
+  const matchingLabelledElements = Array.from(container.querySelectorAll('*'))
+    .filter(element => element.hasAttribute('aria-labelledby'))
+    .reduce((labelledElements, labelledElement) => {
+      const labelsId = labelledElement
+        .getAttribute('aria-labelledby')
+        .split(' ')
+      const labelsValue = labelsId.map(labelId => {
+        const labellingElement = container.querySelector(`[id=${labelId}]`)
+        let labelValue =
+          labellingElement.getAttribute('value') || labellingElement.textContent
+        Array.from(labellingElement.querySelectorAll('textarea')).forEach(
+          textarea => {
+            labelValue = labelValue.replace(textarea.value, '')
+          },
         )
+        Array.from(labellingElement.querySelectorAll('select')).forEach(
+          select => {
+            labelValue = labelValue.replace(select.textContent, '')
+          },
+        )
+        return labelValue
+      })
+      if (
+        matcher(labelsValue.join(' '), labelledElement, text, matchNormalizer)
+      )
+        labelledElements.push(labelledElement)
+      if (labelsValue.length > 1) {
+        labelsValue.forEach((labelValue, index) => {
+          if (matcher(labelValue, labelledElement, text, matchNormalizer))
+            labelledElements.push(labelledElement)
+
+          const labelsFiltered = [...labelsValue].splice(index, 1)
+
+          if (labelsFiltered.length > 1) {
+            if (
+              matcher(
+                labelsFiltered.join(' '),
+                labelledElement,
+                text,
+                matchNormalizer,
+              )
+            )
+              labelledElements.push(labelledElement)
+          }
+        })
       }
-      if (label.getAttribute('id')) {
-        // <label id="someId">text</label><input aria-labelledby="someId" />
-        Array.from(
-          container.querySelectorAll(
-            `[aria-labelledby~="${label.getAttribute('id')}"]`,
-          ),
-        ).forEach(element => elementsForLabel.push(element))
-      }
-      if (label.childNodes.length) {
-        // <label>text: <input /></label>
-        const formControlSelector =
-          'button, input, meter, output, progress, select, textarea'
-        const labelledFormControl = Array.from(
-          label.querySelectorAll(formControlSelector),
-        ).filter(element => element.matches(selector))[0]
-        if (labelledFormControl) elementsForLabel.push(labelledFormControl)
-      }
-      return matchedElements.concat(elementsForLabel)
+
+      return labelledElements
     }, [])
-    .filter(element => element !== null)
     .concat(queryAllByAttribute('aria-label', container, text, {exact}))
 
-  const possibleAriaLabelElements = queryAllByText(container, text, {
-    exact,
-    normalizer: matchNormalizer,
-  })
-
-  const ariaLabelledElements = possibleAriaLabelElements.reduce(
-    (allLabelledElements, nextLabelElement) => {
-      const labelId = nextLabelElement.getAttribute('id')
-
-      if (!labelId) return allLabelledElements
-
-      // ARIA labels can label multiple elements
-      const labelledNodes = Array.from(
-        container.querySelectorAll(`[aria-labelledby~="${labelId}"]`),
+  const matchingElementsByLabels = Array.from(
+    container.querySelectorAll('label'),
+  ).reduce((labelledElements, label) => {
+    let textToMatch = label.textContent
+    Array.from(label.querySelectorAll('textarea')).forEach(textarea => {
+      textToMatch = textToMatch.replace(textarea.value, '')
+    })
+    Array.from(label.querySelectorAll('select')).forEach(select => {
+      textToMatch = textToMatch.replace(select.textContent, '')
+    })
+    if (label.hasAttribute('for')) {
+      const node = container.querySelector(
+        `[id="${label.getAttribute('for')}"]`,
       )
-
-      return allLabelledElements.concat(labelledNodes)
-    },
-    [],
-  )
+      if (matcher(textToMatch, node, text, matchNormalizer))
+        labelledElements.push(node)
+    }
+    if (label.childNodes.length) {
+      const formControlSelector =
+        'button, input, meter, output, progress, select, textarea'
+      const labelledFormControl = Array.from(
+        label.querySelectorAll(formControlSelector),
+      ).filter(element => element.matches(selector))[0]
+      if (labelledFormControl) {
+        if (matcher(textToMatch, labelledFormControl, text, matchNormalizer))
+          labelledElements.push(labelledFormControl)
+      }
+    }
+    return labelledElements
+  }, [])
 
   return Array.from(
-    new Set([...labelledElements, ...ariaLabelledElements]),
+    new Set([...matchingLabelledElements, ...matchingElementsByLabels]),
   ).filter(element => element.matches(selector))
 }
 

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -118,7 +118,8 @@ function queryAllByLabelText(
           if (matcher(labelValue, labelledElement, text, matchNormalizer))
             labelledElements.push(labelledElement)
 
-          const labelsFiltered = [...labelsValue].splice(index, 1)
+          const labelsFiltered = [...labelsValue]
+          labelsFiltered.splice(index, 1)
 
           if (labelsFiltered.length > 1) {
             if (

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -16,7 +16,7 @@ function getCombinations(labels, matcher) {
   const combs = [[]]
   const matching = []
   for (const label of labels) {
-    const copy = [...combs] // See note below.
+    const copy = [...combs]
     for (const prefix of copy) {
       const combination = prefix.concat(label.textToMatch)
       combs.push(combination)
@@ -67,10 +67,7 @@ function queryAllLabelsByText(
     .map(({node}) => node)
   const labelsNotMatchingTextAndNotEmpty = textToMatchByLabels.filter(
     ({node, textToMatch}) =>
-      Boolean(textToMatch) &&
-      nodesByLabelMatchingText.findIndex(nodeByLabelByText =>
-        nodeByLabelByText.isEqualNode(node),
-      ) === -1,
+      textToMatch && !nodesByLabelMatchingText.some(n => n.isEqualNode(node)),
   )
 
   const concatLabelsMatching = getCombinations(

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -19,22 +19,24 @@ function queryAllLabelsByText(
 ) {
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  return Array.from(container.querySelectorAll('label')).filter(label => {
-    let textToMatch = label.textContent
-
+  return Array.from(container.querySelectorAll('label,input')).filter(node => {
+    let textToMatch =
+      node.tagName.toLowerCase() === 'label'
+        ? node.textContent
+        : node.value || null
     // The children of a textarea are part of `textContent` as well. We
     // need to remove them from the string so we can match it afterwards.
-    Array.from(label.querySelectorAll('textarea')).forEach(textarea => {
+    Array.from(node.querySelectorAll('textarea')).forEach(textarea => {
       textToMatch = textToMatch.replace(textarea.value, '')
     })
 
     // The children of a select are also part of `textContent`, so we
     // need also to remove their text.
-    Array.from(label.querySelectorAll('select')).forEach(select => {
+    Array.from(node.querySelectorAll('select')).forEach(select => {
       textToMatch = textToMatch.replace(select.textContent, '')
     })
 
-    return matcher(textToMatch, label, text, matchNormalizer)
+    return matcher(textToMatch, node, text, matchNormalizer)
   })
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- `input` elements with not empty value are retrieved by `getAllLabelsByText`
- `getByLabelText` gets labels even when it receives a label composed of a concatenation

<!-- Why are these changes necessary? -->

**Why**:

Issue #545 finds out that `input` elements are not recognized as labels and  labelling by concatenation is not got by `getByLabelText`.

<!-- How were these changes implemented? -->

**How**:
1. `queryAllLabelsByText` now makes a query not only on elements of type 
 label but on input elements too. The empty input are excluded.
2. after evaluating labels node through `matcher`, the labels that doesn't match are combined through an helper function. If a combination matches with the received text than the labels is returned by `queryAllLabelsByText`. 

<!-- Have you done all of these things?  -->

**Checklist**:

- [x] make `queryAllLabelsByText` look for `input` elements too
- [x] create a `queryAllLabels` function that retrieves all labels without any regards about text to be matched
- [x] find labels matching 
- [x] create `combination` function that concatenate all the labels and returns the node that through some combination matches with the received text
- [x] `queryAllLabelsByText` returns now the labels matching by itself and the ones matching through concantenation
 
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I have already opened #607 to fix this behavior but maybe not in the right way. I hope this idea is better than the one I have submitted before.