### PR TITLE
fix: Consider title for name of svg element

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.10.3",
     "@types/aria-query": "^4.2.0",
     "aria-query": "^4.2.2",
-    "dom-accessibility-api": "^0.4.5",
+    "dom-accessibility-api": "^0.4.6",
     "pretty-format": "^25.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes #685

**Why**:

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title#:~:text=The%20element%20provides%20an,display%20it%20as%20a%20tooltip.

**How**:

Propagate https://github.com/eps1lon/dom-accessibility-api/pull/324 to library dependents.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the~
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests (tested in dom-accessibility-api)
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
