### PR TITLE
fix: Ignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 coverage
 dist
 .DS_Store
-
+.idea
 # these cause more harm than good
 # when working with contributors
 package-lock.json


### PR DESCRIPTION
What ? 
WebStorm creates an .idea folder as you start a project. This folder contains some important settings and configurations, like syntax highlighting settings, VCS mapping, debug configuration, and so on. Sometimes user details such as username and password also come up in the .idea folder.
It's important to ignore this folder 

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
