### PR TITLE
Issue 707- getByLabelText does not work with some IDs when using aria-labelledby

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -178,6 +178,10 @@ test('can get form controls by label text', () => {
         <span id="seventh-label-one">7th one</span>
         <input aria-labelledby="seventh-label-one" id="seventh-id" />
       </div>
+      <div>
+        <label id="eighth.label">8th one</label>
+        <input aria-labelledby="eighth.label" id="eighth.id" />
+      </div>
     </div>
   `)
   expect(getByLabelText('1st').id).toBe('first-id')
@@ -191,6 +195,7 @@ test('can get form controls by label text', () => {
   expect(getByLabelText('6th one 6th two').id).toBe('sixth-id')
   expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
   expect(getByLabelText('7th one').id).toBe('seventh-id')
+  expect(getByLabelText('8th one').id).toBe('eighth.id')
 })
 
 test('can get elements labelled with aria-labelledby attribute', () => {

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -81,7 +81,7 @@ function queryAllByLabelText(
         : []
       const labelsValue = labelsId.length
         ? labelsId.map(labelId => {
-            const labellingElement = container.querySelector(`[id=${labelId}]`)
+            const labellingElement = container.querySelector(`[id="${labelId}"]`)
             return getLabelContent(labellingElement)
           })
         : Array.from(labelledElement.labels).map(label => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: When using aria-labelledby, getByLabelText should account for a selector that might need quotes around it.

<!-- Why are these changes necessary? -->

**Why**: In such a case, the selector is invalid causing unexpected test failures 

<!-- How were these changes implemented? -->

**How**: Just a one line change to wrap quotes around the id in the selector.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Closes https://github.com/testing-library/dom-testing-library/issues/707