### PR TITLE
fix aria-labelledby with not found id 

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1045,3 +1045,30 @@ test('can get an element with aria-labelledby when label has a child', () => {
     '2nd-input',
   )
 })
+test('gets an element when there is an aria-labelledby a not found id', () => {
+  const {getByLabelText} = render(`
+    <div>
+      <input aria-labelledby="not-existing-label"/>
+      <label id="existing-label">Test</label>
+      <input aria-labelledby="existing-label" id="input-id" />
+    </div>
+  `)
+  expect(getByLabelText('Test').id).toBe('input-id')
+})
+
+test('return a proper error message when no label is found and there is an aria-labelledby a not found id', () => {
+  const {getByLabelText} = render(
+    '<input aria-labelledby="not-existing-label"/>',
+  )
+
+  expect(() => getByLabelText('LucyRicardo'))
+    .toThrowErrorMatchingInlineSnapshot(`
+"Unable to find a label with the text of: LucyRicardo
+
+<div>
+  <input
+    aria-labelledby="not-existing-label"
+  />
+</div>"
+`)
+})

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -79,10 +79,12 @@ function queryAllByLabelText(
       const labelsId = labelledElement.getAttribute('aria-labelledby')
         ? labelledElement.getAttribute('aria-labelledby').split(' ')
         : []
-      const labelsValue = labelsId.length
+      let labelsValue = labelsId.length
         ? labelsId.map(labelId => {
-            const labellingElement = container.querySelector(`[id="${labelId}"]`)
-            return getLabelContent(labellingElement)
+            const labellingElement = container.querySelector(
+              `[id="${labelId}"]`,
+            )
+            return labellingElement ? getLabelContent(labellingElement) : ''
           })
         : Array.from(labelledElement.labels).map(label => {
             const textToMatch = getLabelContent(label)
@@ -99,6 +101,7 @@ function queryAllByLabelText(
             }
             return textToMatch
           })
+      labelsValue = labelsValue.filter(Boolean)
       if (
         matcher(labelsValue.join(' '), labelledElement, text, matchNormalizer)
       )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This should fix #710. 

<!-- Why are these changes necessary? -->

**Why**:

#681 introduces a bug that makes code fails if an element's `aria-labelledby` attribute has a value not existing in dom as element id .

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
