### PR TITLE
Added explicit error message for null or undefined matchers

### DIFF
--- a/src/__tests__/matches.js
+++ b/src/__tests__/matches.js
@@ -31,11 +31,11 @@ test('matchers throw on invalid matcher inputs', () => {
   expect(() =>
     matches('ABC', node, null, normalizer),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"It looks like null was passed instead of a matcher. Did you do something like getByText(\\"null\\")?"`,
+    `"It looks like null was passed instead of a matcher. Did you do something like getByText(null)?"`,
   )
   expect(() =>
     fuzzyMatches('ABC', node, undefined, normalizer),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"It looks like undefined was passed instead of a matcher. Did you do something like getByText(\\"undefined\\")?"`,
+    `"It looks like undefined was passed instead of a matcher. Did you do something like getByText(undefined)?"`,
   )
 })

--- a/src/__tests__/matches.js
+++ b/src/__tests__/matches.js
@@ -31,11 +31,11 @@ test('matchers throw on invalid matcher inputs', () => {
   expect(() =>
     matches('ABC', node, null, normalizer),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"It looks like you passed null instead of a matcher. Did you do something like getByText(\\"null\\")?"`,
+    `"It looks like null was passed instead of a matcher. Did you do something like getByText(\\"null\\")?"`,
   )
   expect(() =>
     fuzzyMatches('ABC', node, undefined, normalizer),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"It looks like you passed undefined instead of a matcher. Did you do something like getByText(\\"undefined\\")?"`,
+    `"It looks like undefined was passed instead of a matcher. Did you do something like getByText(\\"undefined\\")?"`,
   )
 })

--- a/src/__tests__/matches.js
+++ b/src/__tests__/matches.js
@@ -26,3 +26,16 @@ test('matchers return false if text to match is not a string', () => {
   expect(matches(null, node, 'ABC', normalizer)).toBe(false)
   expect(fuzzyMatches(null, node, 'ABC', normalizer)).toBe(false)
 })
+
+test('matchers throw on invalid matcher inputs', () => {
+  expect(() =>
+    matches('ABC', node, null, normalizer),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"It looks like you passed null instead of a matcher. Did you do something like getByText(\\"null\\")?"`,
+  )
+  expect(() =>
+    fuzzyMatches('ABC', node, undefined, normalizer),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"It looks like you passed undefined instead of a matcher. Did you do something like getByText(\\"undefined\\")?"`,
+  )
+})

--- a/src/matches.js
+++ b/src/matches.js
@@ -1,7 +1,17 @@
+function assertNotNullOrUndefined(matcher) {
+  if (matcher == null) {
+    throw new Error(
+      `It looks like you passed ${matcher} instead of a matcher. Did you do something like getByText("${matcher}")?`,
+    )
+  }
+}
+
 function fuzzyMatches(textToMatch, node, matcher, normalizer) {
   if (typeof textToMatch !== 'string') {
     return false
   }
+
+  assertNotNullOrUndefined(matcher)
 
   const normalizedText = normalizer(textToMatch)
   if (typeof matcher === 'string') {
@@ -17,6 +27,8 @@ function matches(textToMatch, node, matcher, normalizer) {
   if (typeof textToMatch !== 'string') {
     return false
   }
+
+  assertNotNullOrUndefined(matcher)
 
   const normalizedText = normalizer(textToMatch)
   if (typeof matcher === 'string') {

--- a/src/matches.js
+++ b/src/matches.js
@@ -1,7 +1,7 @@
 function assertNotNullOrUndefined(matcher) {
   if (matcher == null) {
     throw new Error(
-      `It looks like ${matcher} was passed instead of a matcher. Did you do something like getByText("${matcher}")?`,
+      `It looks like ${matcher} was passed instead of a matcher. Did you do something like getByText(${matcher})?`,
     )
   }
 }

--- a/src/matches.js
+++ b/src/matches.js
@@ -1,7 +1,7 @@
 function assertNotNullOrUndefined(matcher) {
   if (matcher == null) {
     throw new Error(
-      `It looks like you passed ${matcher} instead of a matcher. Did you do something like getByText("${matcher}")?`,
+      `It looks like ${matcher} was passed instead of a matcher. Did you do something like getByText("${matcher}")?`,
     )
   }
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added a nice explicit error message for the case in #717 of `null` or `undefined` as a `matcher`.

**Why**:

Better error messages = happier users! 💝

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

As before: I'm not attached to this particular error message, if a reviewer can think of something better that'd be nice.

