### PR TITLE
fix(ByLabelText): support IE and other legacy browsers

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1186,7 +1186,7 @@ test('return a proper error message when no label is found and there is an aria-
 // https://github.com/testing-library/dom-testing-library/issues/723
 it('gets form controls by label text on IE and other legacy browsers', () => {
   // Simulate lack of support for HTMLInputElement.prototype.labels
-  const inputLabelsSpy = jest
+  jest
     .spyOn(HTMLInputElement.prototype, 'labels', 'get')
     .mockReturnValue(undefined)
 
@@ -1241,6 +1241,4 @@ it('gets form controls by label text on IE and other legacy browsers', () => {
   expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
   expect(getByLabelText('7th one').id).toBe('seventh-id')
   expect(getByLabelText('8th one').id).toBe('eighth.id')
-
-  inputLabelsSpy.mockRestore()
 })

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1191,54 +1191,10 @@ it('gets form controls by label text on IE and other legacy browsers', () => {
     .mockReturnValue(undefined)
 
   const {getByLabelText} = renderIntoDocument(`
-    <div>
-      <label>
-        1st<input id="first-id" />
-      </label>
-      <div>
-        <label for="second-id">2nd</label>
-        <input id="second-id" />
-      </div>
-      <div>
-        <label id="third-label">3rd</label>
-        <input aria-labelledby="third-label" id="third-id" />
-      </div>
-      <div>
-        <label for="fourth.id">4th</label>
-        <input id="fourth.id" />
-      </div>
-      <div>
-      <div>
-        <label id="fifth-label-one">5th one</label>
-        <label id="fifth-label-two">5th two</label>
-        <input aria-labelledby="fifth-label-one fifth-label-two" id="fifth-id" />
-      </div>
-      <div>
-        <input id="sixth-label-one" value="6th one"/>
-        <input id="sixth-label-two" value="6th two"/>
-        <label id="sixth-label-three">6th three</label>
-        <input aria-labelledby="sixth-label-one sixth-label-two sixth-label-three" id="sixth-id" />
-      </div>
-      <div>
-        <span id="seventh-label-one">7th one</span>
-        <input aria-labelledby="seventh-label-one" id="seventh-id" />
-      </div>
-      <div>
-        <label id="eighth.label">8th one</label>
-        <input aria-labelledby="eighth.label" id="eighth.id" />
-      </div>
-    </div>
+    <label>
+      Label text
+      <input id="input-id" />
+    </label>
   `)
-  expect(getByLabelText('1st').id).toBe('first-id')
-  expect(getByLabelText('2nd').id).toBe('second-id')
-  expect(getByLabelText('3rd').id).toBe('third-id')
-  expect(getByLabelText('4th').id).toBe('fourth.id')
-  expect(getByLabelText('5th one').id).toBe('fifth-id')
-  expect(getByLabelText('5th two').id).toBe('fifth-id')
-  expect(getByLabelText('6th one').id).toBe('sixth-id')
-  expect(getByLabelText('6th two').id).toBe('sixth-id')
-  expect(getByLabelText('6th one 6th two').id).toBe('sixth-id')
-  expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
-  expect(getByLabelText('7th one').id).toBe('seventh-id')
-  expect(getByLabelText('8th one').id).toBe('eighth.id')
+  expect(getByLabelText('Label text').id).toBe('input-id')
 })

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1182,3 +1182,65 @@ test('return a proper error message when no label is found and there is an aria-
 </div>"
 `)
 })
+
+// https://github.com/testing-library/dom-testing-library/issues/723
+it('gets form controls by label text on IE and other legacy browsers', () => {
+  // Simulate lack of support for HTMLInputElement.prototype.labels
+  const inputLabelsSpy = jest
+    .spyOn(HTMLInputElement.prototype, 'labels', 'get')
+    .mockReturnValue(undefined)
+
+  const {getByLabelText} = renderIntoDocument(`
+    <div>
+      <label>
+        1st<input id="first-id" />
+      </label>
+      <div>
+        <label for="second-id">2nd</label>
+        <input id="second-id" />
+      </div>
+      <div>
+        <label id="third-label">3rd</label>
+        <input aria-labelledby="third-label" id="third-id" />
+      </div>
+      <div>
+        <label for="fourth.id">4th</label>
+        <input id="fourth.id" />
+      </div>
+      <div>
+      <div>
+        <label id="fifth-label-one">5th one</label>
+        <label id="fifth-label-two">5th two</label>
+        <input aria-labelledby="fifth-label-one fifth-label-two" id="fifth-id" />
+      </div>
+      <div>
+        <input id="sixth-label-one" value="6th one"/>
+        <input id="sixth-label-two" value="6th two"/>
+        <label id="sixth-label-three">6th three</label>
+        <input aria-labelledby="sixth-label-one sixth-label-two sixth-label-three" id="sixth-id" />
+      </div>
+      <div>
+        <span id="seventh-label-one">7th one</span>
+        <input aria-labelledby="seventh-label-one" id="seventh-id" />
+      </div>
+      <div>
+        <label id="eighth.label">8th one</label>
+        <input aria-labelledby="eighth.label" id="eighth.id" />
+      </div>
+    </div>
+  `)
+  expect(getByLabelText('1st').id).toBe('first-id')
+  expect(getByLabelText('2nd').id).toBe('second-id')
+  expect(getByLabelText('3rd').id).toBe('third-id')
+  expect(getByLabelText('4th').id).toBe('fourth.id')
+  expect(getByLabelText('5th one').id).toBe('fifth-id')
+  expect(getByLabelText('5th two').id).toBe('fifth-id')
+  expect(getByLabelText('6th one').id).toBe('sixth-id')
+  expect(getByLabelText('6th two').id).toBe('sixth-id')
+  expect(getByLabelText('6th one 6th two').id).toBe('sixth-id')
+  expect(getByLabelText('6th one 6th two 6th three').id).toBe('sixth-id')
+  expect(getByLabelText('7th one').id).toBe('seventh-id')
+  expect(getByLabelText('8th one').id).toBe('eighth.id')
+
+  inputLabelsSpy.mockRestore()
+})

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -37,5 +37,5 @@ beforeAll(() => {
 })
 
 afterAll(() => {
-  console.warn.mockRestore()
+  jest.restoreAllMocks()
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
`*ByLabelText` is updated to support IE11 and other legacy browsers.

<!-- Why are these changes necessary? -->

**Why**:
 Closes #723.

<!-- How were these changes implemented? -->

**How**:
`HTMLInputElement.prototype.labels` is polyfilled. [Existing test covering primary use cases of getByLabelText](https://github.com/testing-library/dom-testing-library/blob/2c57f06cf76a3f388e943628de7aba6eb5d6afe1/src/__tests__/element-queries.js#L147) is copied into a new test, where the `labels` property is mocked to simulate absence of support.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~ N/A
- [x] Tests
- [ ] ~Typescript definitions updated~ N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
This PR stops short of polyfilling `HTMLLabelElement.prototype.control`, which [appears to be well-supported](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control#Browser_compatibility) in older browsers. 