### PR TITLE
feat(role): support `{pressed: true}` for buttons

### DIFF
--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -9,6 +9,15 @@ test('`selected` throws on unsupported roles', () => {
   )
 })
 
+test('`pressed` throws on unsupported roles', () => {
+  const {getByRole} = render(`<input aria-pressed="true" type="text" />`)
+  expect(() =>
+    getByRole('textbox', {pressed: true}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"\\"aria-pressed\\" is not supported on role \\"textbox\\"."`,
+  )
+})
+
 test('`checked` throws on unsupported roles', () => {
   const {getByRole} = render(`<input aria-checked="true" type="text">`)
   expect(() =>
@@ -135,4 +144,26 @@ test('`selected: true` matches `aria-selected="true"` on supported roles', () =>
   expect(getAllByRole('tab', {selected: true}).map(({id}) => id)).toEqual([
     'selected-tab',
   ])
+})
+
+test('`pressed: true|false` matches `pressed` buttons', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button aria-pressed="true" />
+      <button aria-pressed="false" />
+    </div>`,
+  )
+  expect(getByRole('button', {pressed: true})).toBeInTheDocument()
+  expect(getByRole('button', {pressed: false})).toBeInTheDocument()
+})
+
+test('`pressed: true|false` matches `pressed` elements with proper role', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <span role="button" aria-pressed="true">✔</span>
+      <span role="button" aria-pressed="false">𝒙</span>
+    </div>`,
+  )
+  expect(getByRole('button', {pressed: true})).toBeInTheDocument()
+  expect(getByRole('button', {pressed: false})).toBeInTheDocument()
 })

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -3,6 +3,7 @@ import {roles as allRoles} from 'aria-query'
 import {
   computeAriaSelected,
   computeAriaChecked,
+  computeAriaPressed,
   getImplicitAriaRoles,
   prettyRoles,
   isInaccessible,
@@ -31,6 +32,7 @@ function queryAllByRole(
     queryFallbacks = false,
     selected,
     checked,
+    pressed,
   } = {},
 ) {
   checkContainerType(container)
@@ -48,6 +50,13 @@ function queryAllByRole(
     // guard against unknown roles
     if (allRoles.get(role)?.props['aria-checked'] === undefined) {
       throw new Error(`"aria-checked" is not supported on role "${role}".`)
+    }
+  }
+
+  if (pressed !== undefined) {
+    // guard against unknown roles
+    if (allRoles.get(role)?.props['aria-pressed'] === undefined) {
+      throw new Error(`"aria-pressed" is not supported on role "${role}".`)
     }
   }
 
@@ -93,6 +102,9 @@ function queryAllByRole(
       }
       if (checked !== undefined) {
         return checked === computeAriaChecked(element)
+      }
+      if (pressed !== undefined) {
+        return pressed === computeAriaPressed(element)
       }
       // don't care if aria attributes are unspecified
       return true

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -209,6 +209,15 @@ function computeAriaChecked(element) {
   return checkBooleanAttribute(element, 'aria-checked')
 }
 
+/**
+ * @param {Element} element -
+ * @returns {boolean | undefined} - false/true if (not)pressed, undefined if not press-able
+ */
+function computeAriaPressed(element) {
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
+  return checkBooleanAttribute(element, 'aria-pressed')
+}
+
 function checkBooleanAttribute(element, attribute) {
   const attributeValue = element.getAttribute(attribute)
   if (attributeValue === 'true') {
@@ -229,4 +238,5 @@ export {
   isInaccessible,
   computeAriaSelected,
   computeAriaChecked,
+  computeAriaPressed,
 }

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -84,6 +84,11 @@ export interface ByRoleOptions extends MatcherOptions {
    */
   checked?: boolean
   /**
+   * If true only includes elements in the query set that are marked as
+   * pressed in the accessibility tree, i.e., `aria-pressed="true"`
+   */
+  pressed?: boolean
+  /**
    * Includes every role used in the `role` attribute
    * For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progressbar">`.
    */


### PR DESCRIPTION
Hat tip to Sebastian Silbermann for his prior work on PR #692

**What**: Adds support for querying based on `aria-pressed` state for elements with a role of "button" (see https://www.w3.org/TR/wai-aria-1.1/#aria-pressed)

**Why**: `aria-checked` and `aria-selected` area already supported; adding the ability to query by `aria-pressed` should round out support for querying by these types of parameters.

**How**: This is implemented in exactly the same fashion as Sebastian Silbermann's implementation in PR #692.

**Checklist**:
- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
