### PR TITLE
Copy non-enumerable data transfer props

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -295,6 +295,28 @@ test('assigns dataTransfer properties', () => {
   expect(spy.mock.calls[0][0]).toHaveProperty('dataTransfer.dropEffect', 'move')
 })
 
+test('assigns dataTransfer non-enumerable properties', () => {
+  window.DataTransfer = function DataTransfer() {}
+  const node = document.createElement('div')
+  const spy = jest.fn()
+  const item = {
+    webkitGetAsEntry: () => ({})
+  };
+  const dataTransfer = new window.DataTransfer();
+
+  Object.defineProperty(dataTransfer, 'items', {
+    value: [item],
+    enumerable: false
+  })
+  node.addEventListener('drop', spy)
+  fireEvent.drop(node, {dataTransfer})
+
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy.mock.calls[0][0].dataTransfer.items).toHaveLength(1)
+
+  delete window.DataTransfer
+})
+
 test('assigning the files property on dataTransfer', () => {
   const node = document.createElement('div')
   const file = new document.defaultView.File(['(⌐□_□)'], 'chucknorris.png', {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -299,9 +299,7 @@ test('assigns dataTransfer non-enumerable properties', () => {
   window.DataTransfer = function DataTransfer() {}
   const node = document.createElement('div')
   const spy = jest.fn()
-  const item = {
-    webkitGetAsEntry: () => ({})
-  };
+  const item = {};
   const dataTransfer = new window.DataTransfer();
 
   Object.defineProperty(dataTransfer, 'items', {

--- a/src/events.js
+++ b/src/events.js
@@ -71,7 +71,12 @@ function createEvent(
       /* istanbul ignore if  */
       if (typeof window.DataTransfer === 'function') {
         Object.defineProperty(event, dataTransferKey, {
-          value: Object.assign(new window.DataTransfer(), dataTransferValue),
+          value: Object
+            .getOwnPropertyNames(dataTransferValue)
+            .reduce((acc, propName) => {
+              Object.defineProperty(acc, propName, {value: dataTransferValue[propName]});
+              return acc;
+            }, new window.DataTransfer())
         })
       } else {
         Object.defineProperty(event, dataTransferKey, {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Change the logic of copying `dataTransfer` props

**Why**:

At the moment `Object.assign` is used  to extend event object with passed data, but doesn't copy non-enumerable props

**How**:

In order to iterate by non-enumerable props `getOwnPropertyNames` method is used

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
