### PR TITLE
fix: suggest hidden:true with getByRole if element is not accessible 

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -549,3 +549,18 @@ test('should get the first label with aria-labelledby contains multiple ids', ()
     variant: 'get',
   })
 })
+
+test('should suggest hidden option if element is not in the accessibilty tree', () => {
+  const {container} = renderIntoDocument(`
+    <input type="text" aria-hidden=true />
+  `)
+
+  expect(
+    getSuggestedQuery(container.querySelector('input'), 'get', 'role'),
+  ).toMatchObject({
+    queryName: 'Role',
+    queryMethod: 'getByRole',
+    queryArgs: ['textbox', {hidden: true}],
+    variant: 'get',
+  })
+})


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: If an element is inaccessible `getSuggestedQuery` should suggest to use `hidden:true` with `getByRole` 

<!-- Why are these changes necessary? -->

**Why**: Answering to this issue https://github.com/testing-library/dom-testing-library/issues/744, I wanted to share a link of `testing-playground` but the query was not suggested as I expected.  

<!-- How were these changes implemented? -->

**How**: If the element is inaccessible and the query is `getByRole` I have added to `queryArgs` an `hidden:true`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
