### PR TITLE
fix: getByTitle returning element matching textContent instead of title

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -558,7 +558,7 @@ test('query/get element by its title', () => {
   expect(getByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Del', {exact: false}).id).toEqual('2')
-  expect(queryByTitle("HelloWorld")?.id).not.toEqual('4')
+  expect(queryByTitle("HelloWorld")).toBeNull()
 })
 
 test('query/get title element of SVG', () => {

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -551,12 +551,14 @@ test('query/get element by its title', () => {
         <span title="Ignore this" id="1"/>
         <span title="Delete" id="2"/>
         <span title="Ignore this as well" id="3"/>
+        <div title="WrongTitle" id="4">HelloWorld</div>
     </div>
   `)
 
   expect(getByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Del', {exact: false}).id).toEqual('2')
+  expect(queryByTitle("HelloWorld")?.id).not.toEqual('4')
 })
 
 test('query/get title element of SVG', () => {

--- a/src/queries/title.js
+++ b/src/queries/title.js
@@ -8,6 +8,10 @@ import {
   buildQueries,
 } from './all-utils'
 
+const isSvgTitle = node =>
+  node.tagName.toLowerCase() === 'title' &&
+  node.parentElement?.tagName.toLowerCase() === 'svg'
+
 function queryAllByTitle(
   container,
   text,
@@ -19,7 +23,8 @@ function queryAllByTitle(
   return Array.from(container.querySelectorAll('[title], svg > title')).filter(
     node =>
       matcher(node.getAttribute('title'), node, text, matchNormalizer) ||
-      matcher(getNodeText(node), node, text, matchNormalizer),
+      (isSvgTitle(node) &&
+        matcher(getNodeText(node), node, text, matchNormalizer)),
   )
 }
 


### PR DESCRIPTION
Fix #741 

**What**: The `getByTitle` query was meant to match the `title` attribute or `svg > title` element. The logic was implemented that it would also match the text content of any element containing a `title` attribute.

**Why**: We want to correct the behavior of the query. It should only match text content of the `svg > title` element and not any element with a `title` attribute.

**How**: Add a condition of the text content matcher to ensure the node we are checking is `svg > title` element.

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

