### PR TITLE
fix: fix typo in config type properties

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -5,7 +5,7 @@ export interface Config {
   asyncUtilTimeout: number
   computedStyleSupportsPseudoElements: boolean
   defaultHidden: boolean
-  showOriginalStrackTrace: boolean
+  showOriginalStackTrace: boolean
   throwSuggestions: boolean
   getElementError: (message: string, container: HTMLElement) => Error
 }


### PR DESCRIPTION
Closes #761
Actual name: https://github.com/testing-library/dom-testing-library/blob/741096b5763c850ae26441343e14f83034231946/src/config.js#L21