### PR TITLE
fix(screen): broken link when there's no document

### DIFF
--- a/src/__node_tests__/screen.js
+++ b/src/__node_tests__/screen.js
@@ -4,6 +4,6 @@ test('the screen export throws a helpful error message when no global document i
   expect(() =>
     screen.getByText(/hello world/i),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/s/screen-global-error"`,
+    `"For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/docs/dom-testing-library/api-queries#screen"`,
   )
 })

--- a/src/screen.js
+++ b/src/screen.js
@@ -14,7 +14,7 @@ export const screen =
         (helpers, key) => {
           helpers[key] = () => {
             throw new TypeError(
-              'For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/s/screen-global-error',
+              'For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/docs/dom-testing-library/api-queries#screen',
             )
           }
           return helpers


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix a broken link when there's no document defined 

<!-- Why are these changes necessary? -->

**Why**: The link is broken

<!-- How were these changes implemented? -->

**How**: I've put a link to the screen api definition. I couldn't find the page that was there before in the docs repo neither in the commits history.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - N/A
- [X] Tests
- [ ] Typescript definitions updated - N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
