### PR TITLE
fix(events): got-/lostpointercapture bubble

### DIFF
--- a/src/event-map.js
+++ b/src/event-map.js
@@ -332,11 +332,11 @@ export const eventMap = {
     },
     gotPointerCapture: {
       EventType: 'PointerEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
+      defaultInit: {bubbles: true, cancelable: false, composed: true},
     },
     lostPointerCapture: {
       EventType: 'PointerEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
+      defaultInit: {bubbles: true, cancelable: false, composed: true},
     },
     // history events
     popState: {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix `gotpointer` and `lostpointercapture` not bubbling

**Why**:

- Not spec-compliant (see https://www.w3.org/TR/pointerevents/#attributes-and-default-actions)
- Results in React event listeners not being triggered 
  Failing with current version of DTL: https://travis-ci.org/github/testing-library/react-testing-library/jobs/726794155#L289-L323
  Passing with this PR: waiting for codesandbox


**How**:

Fix entry for `gotpointercapture` and `lostpointercapture` in `event-map`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- ~[ ] Tests~
- ~[ ] Typescript definitions updated~
- [ ] Ready to be merged (want to run it in https://github.com/testing-library/react-testing-library/pull/786 first)
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
