### PR TITLE
fix: Mark deprecated methods as `@deprecated`

### DIFF
--- a/types/wait-for-dom-change.d.ts
+++ b/types/wait-for-dom-change.d.ts
@@ -1,3 +1,7 @@
 import { waitForOptions } from "./wait-for";
 
+/**
+ * @deprecated `waitForDomChange` has been deprecated.
+ * Use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.
+ */
 export function waitForDomChange(options?: waitForOptions): Promise<any>;

--- a/types/wait-for-element.d.ts
+++ b/types/wait-for-element.d.ts
@@ -1,3 +1,8 @@
 import { waitForOptions } from "./wait-for";
 
+/**
+ * @deprecated `waitForElement` has been deprecated.
+ * Use a `find*` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby)
+ * or use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor
+ */
 export function waitForElement<T>(callback: () => T, options?: waitForOptions): Promise<T>;

--- a/types/wait.d.ts
+++ b/types/wait.d.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated `wait` has been deprecated and replaced by `waitFor` instead.
+ * In most cases you should be able to find/replace `wait` with `waitFor`.
+ * Learn more: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.
+ */
 export function wait(
     callback?: () => void,
     options?: {


### PR DESCRIPTION
For warning TS users early.

How it looks in 'VS Code':

![image](https://user-images.githubusercontent.com/1198848/94243194-bf7e0e80-ff1f-11ea-9ef0-8c2243376252.png)
