### PR TITLE
fix: createEvent type

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -1,4 +1,5 @@
 import {
+  createEvent,
   fireEvent,
   isInaccessible,
   queries,
@@ -144,6 +145,10 @@ function eventTest() {
     throw new Error(`Can't find firstChild`)
   }
   fireEvent.click(element.firstChild)
+
+  // Custom event
+  const customEvent = createEvent('customEvent', element)
+  fireEvent(element, customEvent)
 }
 
 async function testWaitFors() {

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -94,7 +94,7 @@ export type FireObject = {
   ) => boolean
 }
 export type CreateFunction = (
-  eventName: EventType,
+  eventName: string,
   node: Document | Element | Window | Node,
   init?: {},
   options?: {EventType?: string; defaultInit?: {}},

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -106,5 +106,5 @@ export type CreateObject = {
   ) => Event
 }
 
-export const createEvent: CreateObject
+export const createEvent: CreateObject & CreateFunction
 export const fireEvent: FireFunction & FireObject


### PR DESCRIPTION
fix #775


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fix typescript type

<!-- Why are these changes necessary? -->

**Why**: It was not correct, because you can create custom Event using `createEvent` function

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [X] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
