### PR TITLE
feat(waitFor): allow returning a promise

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -174,6 +174,5 @@ async function testWaitFors() {
   await waitForElementToBeRemoved(getByText(element, 'apple'))
   await waitForElementToBeRemoved(getAllByText(element, 'apple'))
 
-  // $ExpectError
   await waitFor(async () => {})
 }

--- a/types/wait-for.d.ts
+++ b/types/wait-for.d.ts
@@ -7,6 +7,6 @@ export interface waitForOptions {
 }
 
 export function waitFor<T>(
-  callback: () => T extends Promise<any> ? never : T,
+  callback: () => T | Promise<T>,
   options?: waitForOptions,
 ): Promise<T>


### PR DESCRIPTION
You can now return a promise in the waitFor callback and your callback
will not be called again until the promise rejects. If the promise
rejects, then the callback will be called again until it gets a promise
which resolves or it times out.

**What**: feat(waitFor): allow returning a promise

<!-- Why are these changes necessary? -->

**Why**: So we don't have to do weird things like this: https://github.com/kentcdodds/bookshelf/pull/83/files#diff-f3caa0e4f827bc632c53d30ddb2aeb60R26-R29

Specifically, we need to `waitFor` something, but the callback has to do something asynchronous to determine whether we can continue our test. Today, `waitFor` does not support this... Until now...

<!-- How were these changes implemented? -->

**How**: Store a promiseStatus and if the waitFor callback returns a "thennable" then we attach our own handler onto the promise and update the promiseStatus to be "pending". So long as the promiseStatus is "pending" we will not call the callback again.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs/pull/642)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
