### PR TITLE
fix: error when selecting element without 'matches' fn

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -96,7 +96,10 @@ function canSuggest(currentMethod, requestedMethod, data) {
 
 export function getSuggestedQuery(element, variant = 'get', method) {
   // don't create suggestions for script and style elements
-  if (element.matches(DEFAULT_IGNORE_TAGS)) {
+  if (
+    typeof element.matches !== 'function' ||
+    element.matches(DEFAULT_IGNORE_TAGS)
+  ) {
     return undefined
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add an extra check to `getSuggestedQuery` to make sure that the element has a `matches` handler, before calling it.

<!-- Why are these changes necessary? -->

**Why**:
Not all DOM elements have a `matches` handler. The one that I've encountered is `document`. I feel the question rising: "_But who tests `document`_"? Well, this can happen when entering iframes. Or when hovering the document in testing-playground (chrome extension).

<!-- How were these changes implemented? -->

**How**:
```diff
  if (
+    typeof element.matches !== 'function' ||
    element.matches(DEFAULT_IGNORE_TAGS)
  ) {
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [n/a Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- n/a Tests N/A
- n/a Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
