### PR TITLE
fix: getByLabelText for output

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -293,7 +293,7 @@ test('returns the labelable element control inside a label', () => {
       <output />
       <progress />
       <select />
-      <textarea />
+      <textarea ></textarea>
     </label>
   `)
 
@@ -558,7 +558,7 @@ test('query/get element by its title', () => {
   expect(getByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Delete').id).toEqual('2')
   expect(queryByTitle('Del', {exact: false}).id).toEqual('2')
-  expect(queryByTitle("HelloWorld")).toBeNull()
+  expect(queryByTitle('HelloWorld')).toBeNull()
 })
 
 test('query/get title element of SVG', () => {
@@ -1199,4 +1199,24 @@ it('gets form controls by label text on IE and other legacy browsers', () => {
     </label>
   `)
   expect(getByLabelText('Label text').id).toBe('input-id')
+})
+
+// https://github.com/testing-library/dom-testing-library/issues/787
+it(`get the output element by it's label`, () => {
+  const {getByLabelText} = renderIntoDocument(`
+    <label>foo
+      <output>bar</output>
+    </label>
+  `)
+  expect(getByLabelText('foo')).toBeInTheDocument()
+})
+
+// https://github.com/testing-library/dom-testing-library/issues/343#issuecomment-555385756
+it(`should get element by it's label when there are elements with same text`, () => {
+  const {getByLabelText} = renderIntoDocument(`
+    <label>test 1
+      <textarea defaultValue="test"></textarea>
+    </label>
+  `)
+  expect(getByLabelText('test 1')).toBeInTheDocument()
 })

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1224,7 +1224,7 @@ it(`get the output element by it's label`, () => {
 it(`should get element by it's label when there are elements with same text`, () => {
   const {getByLabelText} = renderIntoDocument(`
     <label>test 1
-      <textarea defaultValue="test"></textarea>
+      <textarea>test</textarea>
     </label>
   `)
   expect(getByLabelText('test 1')).toBeInTheDocument()

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1203,11 +1203,20 @@ it('gets form controls by label text on IE and other legacy browsers', () => {
 
 // https://github.com/testing-library/dom-testing-library/issues/787
 it(`get the output element by it's label`, () => {
-  const {getByLabelText} = renderIntoDocument(`
+  const {getByLabelText, rerender} = renderIntoDocument(`
     <label>foo
       <output>bar</output>
     </label>
   `)
+  expect(getByLabelText('foo')).toBeInTheDocument()
+
+  rerender(`
+    <label>
+      <small>foo</small>
+      <output>bar</output>
+    </label>
+  `)
+
   expect(getByLabelText('foo')).toBeInTheDocument()
 })
 

--- a/src/get-node-text.js
+++ b/src/get-node-text.js
@@ -1,6 +1,4 @@
-// Constant node.nodeType for text nodes, see:
-// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
-const TEXT_NODE = 3
+const {TEXT_NODE} = require('./helpers')
 
 function getNodeText(node) {
   if (node.matches('input[type=submit], input[type=button]')) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,7 @@
 const globalObj = typeof window === 'undefined' ? global : window
+// Constant node.nodeType for text nodes, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
+const TEXT_NODE = 3
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
@@ -127,4 +130,5 @@ export {
   runWithRealTimers,
   checkContainerType,
   jestFakeTimersAreEnabled,
+  TEXT_NODE,
 }

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -47,9 +47,7 @@ function getTextContent(node) {
     'textarea',
     'input',
   ]
-  if (
-    labelledNodeNames.some(nodeName => node.nodeName.toLowerCase() === nodeName)
-  ) {
+  if (labelledNodeNames.includes(node.nodeName.toLowerCase())) {
     return ''
   }
 

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -11,6 +11,16 @@ import {
   wrapSingleQueryWithSuggestion,
 } from './all-utils'
 
+const labelledNodeNames = [
+  'button',
+  'meter',
+  'output',
+  'progress',
+  'select',
+  'textarea',
+  'input',
+]
+
 function queryAllLabels(container) {
   return Array.from(container.querySelectorAll('label,input'))
     .map(node => {
@@ -38,15 +48,7 @@ function queryAllLabelsByText(
 
 function getTextContent(node) {
   const TEXT_NODE = 3
-  const labelledNodeNames = [
-    'button',
-    'meter',
-    'output',
-    'progress',
-    'select',
-    'textarea',
-    'input',
-  ]
+
   if (labelledNodeNames.includes(node.nodeName.toLowerCase())) {
     return ''
   }
@@ -94,8 +96,7 @@ function queryAllByLabelText(
           })
         : Array.from(getLabels(labelledElement)).map(label => {
             const textToMatch = getLabelContent(label)
-            const formControlSelector =
-              'button, input, meter, output, progress, select, textarea'
+            const formControlSelector = labelledNodeNames.join(',')
             const labelledFormControl = Array.from(
               label.querySelectorAll(formControlSelector),
             ).filter(element => element.matches(selector))[0]

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -1,5 +1,5 @@
 import {getConfig} from '../config'
-import {checkContainerType} from '../helpers'
+import {checkContainerType, TEXT_NODE} from '../helpers'
 import {
   fuzzyMatches,
   matches,
@@ -47,8 +47,6 @@ function queryAllLabelsByText(
 }
 
 function getTextContent(node) {
-  const TEXT_NODE = 3
-
   if (labelledNodeNames.includes(node.nodeName.toLowerCase())) {
     return ''
   }


### PR DESCRIPTION
**What**: I have fixed #787 and the comment in https://github.com/testing-library/dom-testing-library/issues/343#issuecomment-555385756

<!-- Why are these changes necessary? -->

**Why**: Because following specs it should be possible to get `output` by it's label. 



**How**: Instead of replacing string that could cause the issue in the comment https://github.com/testing-library/dom-testing-library/issues/343#issuecomment-555385756 I have looped al the childNodes taking text only from the right nodes

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
