### PR TITLE
fix(types): make third and fourth params optional for findAllBy and findBy built queries

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -80,6 +80,11 @@ async function testQueryHelpers() {
   getByAutomationId(element, ['id', 'automationId'])
   findAllByAutomationId(element, 'id', {}, {timeout: 1000})
   findByAutomationId(element, 'id', {}, {timeout: 1000})
+  // test optional params too
+  findAllByAutomationId(element, 'id', {})
+  findByAutomationId(element, 'id', {})
+  findAllByAutomationId(element, 'id')
+  findByAutomationId(element, 'id')
 }
 
 async function testByRole() {

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -1,5 +1,5 @@
-import { Matcher, MatcherOptions } from './matches'
-import { waitForOptions } from './wait-for'
+import {Matcher, MatcherOptions} from './matches'
+import {waitForOptions} from './wait-for'
 
 export interface SelectorMatcherOptions extends MatcherOptions {
   selector?: string
@@ -39,12 +39,12 @@ export type GetAllBy<Arguments extends any[]> = QueryMethod<
   HTMLElement[]
 >
 export type FindAllBy<Arguments extends any[]> = QueryMethod<
-  [Arguments[0], Arguments[1], waitForOptions],
+  [Arguments[0], Arguments[1]?, waitForOptions?],
   Promise<HTMLElement[]>
 >
 export type GetBy<Arguments extends any[]> = QueryMethod<Arguments, HTMLElement>
 export type FindBy<Arguments extends any[]> = QueryMethod<
-  [Arguments[0], Arguments[1], waitForOptions],
+  [Arguments[0], Arguments[1]?, waitForOptions?],
   Promise<HTMLElement>
 >
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Updated types for built findBy / findAllBy custom queries and added extra type tests

<!-- Why are these changes necessary? -->

**Why**: A fix made in PR #574 / Issue #534 added these parameters but accidentally made them required (see https://github.com/testing-library/dom-testing-library/pull/574#issuecomment-629213137)

<!-- How were these changes implemented? -->

**How**: Updated the types in `query-helpers.d.ts` to mimic the built-in types in `queries.d.ts`, and added more type tests to ensure it won't regress.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
