### PR TITLE
Disconnect MutationObserver synchronously in wait-for

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,1 +1,0 @@
-module.exports = require('kcd-scripts/husky')

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,1 @@
+module.exports = require('kcd-scripts/husky')

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -95,10 +95,6 @@ function waitFor(
       if (!usingFakeTimers) {
         clearInterval(intervalId)
         observer.disconnect()
-
-        // Call also the disconnect method on setImmediate for projects not using the MutationObersver implementation of jsdom.
-        // But using for example `@sheerun/mutationobserver-shim` which  provokes infinite loop when being called immediately on `onDone` function
-        setImmediate(() => observer.disconnect())
       }
 
       if (error) {

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -94,6 +94,10 @@ function waitFor(
 
       if (!usingFakeTimers) {
         clearInterval(intervalId)
+        observer.disconnect()
+
+        // Call also the disconnect method on setImmediate for projects not using the MutationObersver implementation of jsdom.
+        // But using for example `@sheerun/mutationobserver-shim` which  provokes infinite loop when being called immediately on `onDone` function
         setImmediate(() => observer.disconnect())
       }
 


### PR DESCRIPTION
Here is a little PR after opening this issue https://github.com/testing-library/dom-testing-library/issues/800
(my investigation is on it)

**What**:

My test are slow because of MutationObersion disconnections made at the end of my tests.


**Why**:

Currently `observer.disconnect()`is called in setImmediate, I guess the main thread is not available until the end of the test, so the check callback is called too much times.
This was done in this PR #102 

**How**:

All my explanations are visible here: https://github.com/testing-library/dom-testing-library/issues/800#issuecomment-720140316

After making many test, I didn't see any problem to call both: 
```
setImmediate(() => observer.disconnect());
observer.disconnect();
```


**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [] Ready to be merged: I made a change on the husky config to be able to commit. Do not merge that like that!!


