### PR TITLE
Fix null labels on hidden inputs

### DIFF
--- a/src/__tests__/label-helpers.js
+++ b/src/__tests__/label-helpers.js
@@ -1,0 +1,7 @@
+import {getRealLabels} from '../label-helpers'
+
+test('hidden inputs are not labelable', () => {
+  const element = document.createElement('input')
+  element.type = 'hidden'
+  expect(getRealLabels(element)).toEqual([])
+})

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -35,6 +35,7 @@ test('find asynchronously finds elements', async () => {
       <div role="dialog"></div>
       <div role="meter progressbar"></div>
       <header>header</header>
+      <input type="hidden" />
     </div>
   `)
   await expect(findByLabelText('test-label')).resolves.toBeTruthy()

--- a/src/label-helpers.js
+++ b/src/label-helpers.js
@@ -34,9 +34,9 @@ function getLabelContent(node) {
 
 // Based on https://github.com/eps1lon/dom-accessibility-api/pull/352
 function getRealLabels(element) {
-  if (element.labels !== undefined) return element.labels
-
   if (!isLabelable(element)) return []
+
+  if (element.labels !== undefined) return element.labels
 
   const labels = element.ownerDocument.querySelectorAll('label')
   return Array.from(labels).filter(label => label.control === element)

--- a/src/label-helpers.js
+++ b/src/label-helpers.js
@@ -34,9 +34,9 @@ function getLabelContent(node) {
 
 // Based on https://github.com/eps1lon/dom-accessibility-api/pull/352
 function getRealLabels(element) {
-  if (!isLabelable(element)) return []
+  if (element.labels !== undefined) return element.labels ?? []
 
-  if (element.labels !== undefined) return element.labels
+  if (!isLabelable(element)) return []
 
   const labels = element.ownerDocument.querySelectorAll('label')
   return Array.from(labels).filter(label => label.control === element)


### PR DESCRIPTION
**What**:

This PR ensures `*LabelText` helpers do not throw an error when there are hidden inputs.

**Why**:

The `labels` property on `input` elements of type `hidden` is [`null` rather than `NodeList`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels). This meant the `getRealLabels` function would return `null` causing `queryAllByLabelText` to throw an error when it tried to [call `length` on `null`](https://github.com/testing-library/dom-testing-library/blob/62f4e5e09a4b81ef66679560b540523edccdef98/src/queries/label-text.js#L52).

I noticed this issue when using `cy.findByLabelText` (from [@testing-library/cypress](https://github.com/testing-library/cypress-testing-library)) – which fails with the following exception on pages with hidden inputs:

```
Timed out retrying: Cannot read property 'length' of null
```

**How**:

This fixes the issue by ensuring the element is labelable before calling `labels` on it. There was already an `isLabelable` guard clause in place, but it was only checked _after_ returning `element.labels` (which is `null` for hidden inputs). Alternative solutions might be to add a different guard clause to return an empty array if `element.labels` is `null`, or to check the return value from `getRealLabels` before calling `length` on it.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) **N/A**
- [x] Tests
- [ ] Typescript definitions updated **N/A**
- [x] Ready to be merged