### PR TITLE
fix: not throw if input is hidden and his labels are null

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -35,65 +35,65 @@ test('get throws a useful error message', () => {
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find a label with the text of: LucyRicardo
+    "Unable to find a label with the text of: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByPlaceholderText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the placeholder text of: LucyRicardo
+    "Unable to find an element with the placeholder text of: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+    "Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element by: [data-testid="LucyRicardo"]
+    "Unable to find an element by: [data-testid="LucyRicardo"]
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the alt text: LucyRicardo
+    "Unable to find an element with the alt text: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the title: LucyRicardo.
+    "Unable to find an element with the title: LucyRicardo.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByDisplayValue('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the display value: LucyRicardo.
+    "Unable to find an element with the display value: LucyRicardo.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "LucyRicardo"
+    "Unable to find an accessible element with the role "LucyRicardo"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
 })
 
 test('can get elements by matching their text content', () => {
@@ -342,14 +342,14 @@ test('label with no form control', () => {
   const {getByLabelText, queryByLabelText} = render(`<label>All alone</label>`)
   expect(queryByLabelText(/alone/)).toBeNull()
   expect(() => getByLabelText(/alone/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label>
-    All alone
-  </label>
-</div>"
-`)
+    <div>
+      <label>
+        All alone
+      </label>
+    </div>"
+  `)
 })
 
 test('label with "for" attribute but no form control and fuzzy matcher', () => {
@@ -359,16 +359,16 @@ test('label with "for" attribute but no form control and fuzzy matcher', () => {
   expect(queryByLabelText('alone', {exact: false})).toBeNull()
   expect(() => getByLabelText('alone', {exact: false}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label
-    for="foo"
-  >
-    All alone label
-  </label>
-</div>"
-`)
+    <div>
+      <label
+        for="foo"
+      >
+        All alone label
+      </label>
+    </div>"
+  `)
 })
 
 test('label with children with no form control', () => {
@@ -381,32 +381,32 @@ test('label with children with no form control', () => {
   expect(queryByLabelText(/alone/, {selector: 'input'})).toBeNull()
   expect(() => getByLabelText(/alone/, {selector: 'input'}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  
-  
-  <label>
-    
-    All alone but with children
-    
-    <textarea>
-      Hello
-    </textarea>
-    
-    
-    <select>
-      <option
-        value="0"
-      >
-        zero
-      </option>
-    </select>
-    
-  
-  </label>
-</div>"
-`)
+    <div>
+      
+      
+      <label>
+        
+        All alone but with children
+        
+        <textarea>
+          Hello
+        </textarea>
+        
+        
+        <select>
+          <option
+            value="0"
+          >
+            zero
+          </option>
+        </select>
+        
+      
+      </label>
+    </div>"
+  `)
 })
 
 test('label with non-labellable element', () => {
@@ -421,35 +421,35 @@ test('label with non-labellable element', () => {
 
   expect(queryByLabelText(/Label/)).toBeNull()
   expect(() => getByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
+    "Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
 
-<div>
-  
-  
-  <div>
-    
-    
-    <label
-      for="div1"
-    >
-      Label 1
-    </label>
-    
-    
-    <div
-      id="div1"
-    >
+    <div>
       
-      Hello
-    
-    </div>
-    
-  
-  </div>
-  
-  
-</div>"
-`)
+      
+      <div>
+        
+        
+        <label
+          for="div1"
+        >
+          Label 1
+        </label>
+        
+        
+        <div
+          id="div1"
+        >
+          
+          Hello
+        
+        </div>
+        
+      
+      </div>
+      
+      
+    </div>"
+  `)
 })
 
 test('multiple labels with non-labellable elements', () => {
@@ -468,65 +468,65 @@ test('multiple labels with non-labellable elements', () => {
 
   expect(queryAllByLabelText(/Label/)).toEqual([])
   expect(() => getAllByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
+    "Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
 
-Found a label with the text of: /Label/, however the element associated with this label (<p />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <p />, you can use aria-label or aria-labelledby instead.
+    Found a label with the text of: /Label/, however the element associated with this label (<p />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <p />, you can use aria-label or aria-labelledby instead.
 
-<div>
-  
-  
-  <div>
-    
-    
-    <label
-      for="span1"
-    >
-      Label 1
-    </label>
-    
-    
-    <span
-      id="span1"
-    >
+    <div>
       
-      Hello
-    
-    </span>
-    
-    
-    <label
-      for="p1"
-    >
-      Label 2
-    </label>
-    
-    
-    <p
-      id="p1"
-    >
       
-      World
-    
-    </p>
-    
-  
-  </div>
-  
-  
-</div>"
-`)
+      <div>
+        
+        
+        <label
+          for="span1"
+        >
+          Label 1
+        </label>
+        
+        
+        <span
+          id="span1"
+        >
+          
+          Hello
+        
+        </span>
+        
+        
+        <label
+          for="p1"
+        >
+          Label 2
+        </label>
+        
+        
+        <p
+          id="p1"
+        >
+          
+          World
+        
+        </p>
+        
+      
+      </div>
+      
+      
+    </div>"
+  `)
 })
 
 test('totally empty label', () => {
   const {getByLabelText, queryByLabelText} = render(`<label />`)
   expect(queryByLabelText('')).toBeNull()
   expect(() => getByLabelText('')).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label />
-</div>"
-`)
+    <div>
+      <label />
+    </div>"
+  `)
 })
 
 test('getByLabelText with aria-label', () => {
@@ -1175,14 +1175,14 @@ test('return a proper error message when no label is found and there is an aria-
 
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find a label with the text of: LucyRicardo
+    "Unable to find a label with the text of: LucyRicardo
 
-<div>
-  <input
-    aria-labelledby="not-existing-label"
-  />
-</div>"
-`)
+    <div>
+      <input
+        aria-labelledby="not-existing-label"
+      />
+    </div>"
+  `)
 })
 
 // https://github.com/testing-library/dom-testing-library/issues/723
@@ -1228,4 +1228,42 @@ it(`should get element by it's label when there are elements with same text`, ()
     </label>
   `)
   expect(getByLabelText('test 1')).toBeInTheDocument()
+})
+
+// https://github.com/testing-library/dom-testing-library/issues/805
+it(`should throw error because input element is not labellable and his labels are null`, () => {
+  const {getByLabelText} = renderIntoDocument(`
+   <form>
+    <label for="hidden-input">Test</label>
+    <input id="hidden-input" type="hidden" />
+   </form>
+  `)
+
+  expect(() => getByLabelText('Test')).toThrowErrorMatchingInlineSnapshot(`
+    "Found a label with the text of: Test, however the element associated with this label (<input />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <input />, you can use aria-label or aria-labelledby instead.
+
+    <body>
+      
+       
+      <form>
+        
+        
+        <label
+          for="hidden-input"
+        >
+          Test
+        </label>
+        
+        
+        <input
+          id="hidden-input"
+          type="hidden"
+        />
+        
+       
+      </form>
+      
+      
+    </body>"
+  `)
 })

--- a/src/label-helpers.js
+++ b/src/label-helpers.js
@@ -34,7 +34,7 @@ function getLabelContent(node) {
 
 // Based on https://github.com/eps1lon/dom-accessibility-api/pull/352
 function getRealLabels(element) {
-  if (element.labels !== undefined) return element.labels
+  if (element.labels !== undefined) return element.labels ?? []
 
   if (!isLabelable(element)) return []
 


### PR DESCRIPTION

**What**: close #805 

<!-- Why are these changes necessary? -->

**Why**: it was an issue

<!-- How were these changes implemented? -->

**How**: as for spec https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels an hidden input will have `.labels` null and node an empty `NodeList`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
