### PR TITLE
chore(validate): Update validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
     needs: main
     runs-on: ubuntu-latest
     if:
-      ${{
+      ${{ github.repository == 'testing-library/dom-testing-library' &&
       contains('refs/heads/master,refs/heads/beta,refs/heads/next,refs/heads/alpha',
       github.ref) && github.event_name == 'push' }}
     steps:
@@ -54,7 +54,7 @@ jobs:
       - name: 🚀 Release
         uses: cycjimmy/semantic-release-action@v2
         with:
-          semantic_version: 16
+          semantic_version: 17
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Contributions of any kind welcome!
 
 [npm]: https://www.npmjs.com/
 [node]: https://nodejs.org
-[build-badge]: https://img.shields.io/github/workflow/status/testing-library/dom-testing-library/validate/master?logo=github&style=flat-square
+[build-badge]: https://img.shields.io/github/workflow/status/testing-library/dom-testing-library/validate?logo=github&style=flat-square
 [build]: https://github.com/testing-library/dom-testing-library/actions?query=workflow%3Avalidate
 [coverage-badge]: https://img.shields.io/codecov/c/github/testing-library/dom-testing-library.svg?style=flat-square
 [coverage]: https://codecov.io/github/testing-library/dom-testing-library


### PR DESCRIPTION
- Don't run release on forks
- Use `semantic-release@17.x`