### PR TITLE
chore: upgrade all deps and fix the build

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,16 @@
 name: validate
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      [
+        '+([0-9])?(.{+([0-9]),x}).x',
+        'master',
+        'next',
+        'next-major',
+        'beta',
+        'alpha',
+      ]
+  pull_request: {}
 jobs:
   main:
     strategy:

--- a/package.json
+++ b/package.json
@@ -39,23 +39,24 @@
   ],
   "dependencies": {
     "@babel/code-frame": "^7.10.4",
-    "@babel/runtime": "^7.10.3",
+    "@babel/runtime": "^7.12.5",
     "@types/aria-query": "^4.2.0",
     "aria-query": "^4.2.2",
     "chalk": "^4.1.0",
-    "dom-accessibility-api": "^0.5.1",
+    "dom-accessibility-api": "^0.5.4",
     "lz-string": "^1.4.4",
-    "pretty-format": "^26.4.2"
+    "pretty-format": "^26.6.2"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.10.1",
-    "dtslint": "^3.6.12",
+    "@testing-library/jest-dom": "^5.11.5",
+    "@types/estree": "0.0.45",
+    "dtslint": "^4.0.5",
     "jest-in-case": "^1.0.2",
     "jest-serializer-ansi": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
-    "jsdom": "^16.2.2",
-    "kcd-scripts": "^6.2.3",
-    "typescript": "^3.9.5"
+    "jsdom": "^16.4.0",
+    "kcd-scripts": "^6.7.0",
+    "typescript": "^4.0.5"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["dtslint/dtslint.json"],
   "rules": {
+    "no-redundant-jsdoc": false,
     "no-useless-files": false,
     "no-relative-import-in-test": false,
     "semicolon": false,


### PR DESCRIPTION
**What**: This updates all deps and adds `@types/estree` to avoid dedup issues

**Why**: The build was broken. More info: https://github.com/rollup/plugins/pull/639

**How**: Update all deps and add `@types/estree` temporarily

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
