### PR TITLE
fix: export pretty format

### DIFF
--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -71,4 +71,4 @@ const logDOM = (...args) => {
   }
 }
 
-export {prettyDOM, logDOM}
+export {prettyDOM, logDOM, prettyFormat}

--- a/types/pretty-dom.d.ts
+++ b/types/pretty-dom.d.ts
@@ -1,4 +1,13 @@
-import { OptionsReceived } from 'pretty-format';
+import * as prettyFormat from 'pretty-format'
 
-export function prettyDOM(dom?: Element | HTMLDocument, maxLength?: number, options?: OptionsReceived): string | false;
-export function logDOM(dom?: Element | HTMLDocument, maxLength?: number, options?: OptionsReceived): void;
+export function prettyDOM(
+  dom?: Element | HTMLDocument,
+  maxLength?: number,
+  options?: prettyFormat.OptionsReceived,
+): string | false
+export function logDOM(
+  dom?: Element | HTMLDocument,
+  maxLength?: number,
+  options?: prettyFormat.OptionsReceived,
+): void
+export {prettyFormat}


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: referring to this issue https://github.com/testing-library/react-testing-library/issues/694 I have exported `pretty-format` from this library

<!-- Why are these changes necessary? -->

**Why**: Because we can then import in `@testing-library/react`

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [X] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
