### PR TITLE
fix: use node property instead of selector for type=text input

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -543,3 +543,8 @@ describe('configuration', () => {
     }
   })
 })
+
+test('should find the input using type property instead of attribute', () => {
+  const {getByRole} = render('<input type="124">')
+  expect(getByRole('textbox')).not.toBeNull()
+})

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -75,7 +75,7 @@ function getImplicitAriaRoles(currentNode) {
 }
 
 function buildElementRoleList(elementRolesMap) {
-  function makeElementSelector({name, attributes = []}) {
+  function makeElementSelector({name, attributes}) {
     return `${name}${attributes
       .map(({name: attributeName, value, constraints = []}) => {
         const shouldNotExist = constraints.indexOf('undefined') !== -1

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -65,8 +65,8 @@ function isInaccessible(element, options = {}) {
 function getImplicitAriaRoles(currentNode) {
   // eslint bug here:
   // eslint-disable-next-line no-unused-vars
-  for (const {selector, roles} of elementRoleList) {
-    if (currentNode.matches(selector)) {
+  for (const {match, roles} of elementRoleList) {
+    if (match(currentNode)) {
       return [...roles]
     }
   }
@@ -101,6 +101,31 @@ function buildElementRoleList(elementRolesMap) {
     return rightSpecificity - leftSpecificity
   }
 
+  function match(element) {
+    return node => {
+      let {attributes = []} = element
+      // https://github.com/testing-library/dom-testing-library/issues/814
+      const typeTextIndex = attributes.findIndex(
+        attribute =>
+          attribute.value &&
+          attribute.name === 'type' &&
+          attribute.value === 'text',
+      )
+      if (typeTextIndex >= 0) {
+        // not using splice to not mutate the attributes array
+        attributes = [
+          ...attributes.slice(0, typeTextIndex),
+          ...attributes.slice(typeTextIndex + 1),
+        ]
+        if (node.type !== 'text') {
+          return false
+        }
+      }
+
+      return node.matches(makeElementSelector({...element, attributes}))
+    }
+  }
+
   let result = []
 
   // eslint bug here:
@@ -109,7 +134,7 @@ function buildElementRoleList(elementRolesMap) {
     result = [
       ...result,
       {
-        selector: makeElementSelector(element),
+        match: match(element),
         roles: Array.from(roles),
         specificity: getSelectorSpecificity(element),
       },


### PR DESCRIPTION

**What**: close #814 

<!-- Why are these changes necessary? -->

**Why**: It was a bug

<!-- How were these changes implemented? -->

**How**: Adding an exception for type=text.
Instead of using the selector I have used the node property.
 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
