### PR TITLE
fix(suggestions): only warn about inaccessible elements when actually showing the suggestion

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -33,7 +33,6 @@ function makeSuggestion(queryName, element, content, {variant, name}) {
     warning = `Element is inaccessible. This means that the element and all its children are invisible to screen readers.
     If you are using the aria-hidden prop, make sure this is the right choice for your case.
     `
-    console.warn(warning)
   }
   if (Object.keys(queryOptions).length > 0) {
     queryArgs.push(queryOptions)
@@ -48,6 +47,9 @@ function makeSuggestion(queryName, element, content, {variant, name}) {
     variant,
     warning,
     toString() {
+      if (warning) {
+        console.warn(warning)
+      }
       let [text, options] = queryArgs
 
       text = typeof text === 'string' ? `'${text}'` : text


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Console warnings are being emitted, even when they shouldn't be.  For example, if you're using getByRole, you shouldn't see a warning about it, only when the suggestion is actually used.
<!-- Why are these changes necessary? -->

**Why**:

causes noise in test runs.
<!-- How were these changes implemented? -->

**How**:
by moving the console.warn into the toString() which is only used when the suggestion is thrown.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->