### PR TITLE
feat: allow TextMatch to be any non-nullable type

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -144,6 +144,11 @@ test('matches case with RegExp matcher', () => {
   expect(queryByText(/Step 1 of 4/)).not.toBeTruthy()
 })
 
+test('queryByText matches case with non-string matcher', () => {
+  const {queryByText} = render(`<span>1</span>`)
+  expect(queryByText(1)).toBeTruthy()
+})
+
 test('can get form controls by label text', () => {
   const {getByLabelText} = render(`
     <div>
@@ -336,6 +341,11 @@ test('get can get form controls by placeholder', () => {
     <input id="username-id" placeholder="username" />,
   `)
   expect(getByPlaceholderText('username').id).toBe('username-id')
+})
+
+test('queryByPlaceholderText matches case with non-string matcher', () => {
+  const {queryByPlaceholderText} = render(`<input placeholder="1" />`)
+  expect(queryByPlaceholderText(1)).toBeTruthy()
 })
 
 test('label with no form control', () => {
@@ -535,6 +545,11 @@ test('getByLabelText with aria-label', () => {
   expect(queryByLabelText(/bat/)).toBeTruthy()
 })
 
+test('queryByLabelText matches case with non-string matcher', () => {
+  const {queryByLabelText} = render(`<input aria-label="1" />`)
+  expect(queryByLabelText(1)).toBeTruthy()
+})
+
 test('get element by its alt text', () => {
   const {getByAltText} = render(`
     <div>
@@ -543,6 +558,11 @@ test('get element by its alt text', () => {
     </div>,
   `)
   expect(getByAltText(/fin.*nem.*poster$/i).src).toContain('/finding-nemo.png')
+})
+
+test('queryByAltText matches case with non-string matcher', () => {
+  const {queryByAltText} = render(`<img alt="1" src="/finding-nemo.png" />`)
+  expect(queryByAltText(1)).toBeTruthy()
 })
 
 test('query/get element by its title', () => {
@@ -575,6 +595,11 @@ test('query/get title element of SVG', () => {
 
   expect(getByTitle('Close').id).toEqual('svg-title')
   expect(queryByTitle('Close').id).toEqual('svg-title')
+})
+
+test('queryByTitle matches case with non-string matcher', () => {
+  const {queryByTitle} = render(`<span title="1" />`)
+  expect(queryByTitle(1)).toBeTruthy()
 })
 
 test('query/get element by its value', () => {
@@ -632,6 +657,15 @@ test('query/get select by text with multiple options selected', () => {
   expect(queryByDisplayValue('Alaska').id).toEqual('state-select')
 })
 
+test('queryByDisplayValue matches case with non-string matcher', () => {
+  const {queryByDisplayValue} = render(`
+  <select multiple id="state-select">
+    <option selected value="one">1</option>
+  </select>
+  `)
+  expect(queryByDisplayValue(1)).toBeTruthy()
+})
+
 describe('query by test id', () => {
   afterEach(() => {
     // Restore the default test id attribute
@@ -649,6 +683,11 @@ describe('query by test id', () => {
     expect(queryByTestId('first')).not.toBeTruthy()
     expect(queryByTestId('firstNamePlusMore')).not.toBeTruthy()
     expect(queryByTestId('first-name')).not.toBeTruthy()
+  })
+
+  test('queryByTestId matches case with non-string matcher', () => {
+    const {queryByTestId} = render(`<span data-testid="1" />`)
+    expect(queryByTestId(1)).toBeTruthy()
   })
 
   test('can override test id attribute', () => {
@@ -730,6 +769,11 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
   expect(queryAllByRole('combobox')).toHaveLength(1)
   expect(queryAllByRole('listbox')).toHaveLength(1)
+})
+
+test('queryByRole matches case with non-string matcher', () => {
+  const {queryByRole} = render(`<span role="1" />`)
+  expect(queryByRole(1)).toBeTruthy()
 })
 
 test('getAll* matchers return an array', () => {

--- a/src/matches.js
+++ b/src/matches.js
@@ -31,12 +31,12 @@ function matches(textToMatch, node, matcher, normalizer) {
   assertNotNullOrUndefined(matcher)
 
   const normalizedText = normalizer(textToMatch)
-  if (typeof matcher === 'string') {
-    return normalizedText === matcher
-  } else if (typeof matcher === 'function') {
+  if (matcher instanceof Function) {
     return matcher(normalizedText, node)
-  } else {
+  } else if (matcher instanceof RegExp) {
     return matcher.test(normalizedText)
+  } else {
+    return normalizedText === String(matcher)
   }
 }
 

--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -27,6 +27,7 @@ export async function testQueries() {
   // element queries
   const element = document.createElement('div')
   getByText(element, 'foo')
+  getByText(element, 1)
   queryByText(element, 'foo')
   await findByText(element, 'foo')
   await findByText(element, 'foo', undefined, {timeout: 10})

--- a/types/matches.d.ts
+++ b/types/matches.d.ts
@@ -1,11 +1,11 @@
 import {ARIARole} from 'aria-query'
 
 export type MatcherFunction = (content: string, element: HTMLElement) => boolean
-export type Matcher = string | RegExp | MatcherFunction
+export type Matcher = MatcherFunction | {}
 
 // Get autocomplete for ARIARole union types, while still supporting another string
 // Ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
-export type ByRoleMatcher = ARIARole | (string & {}) | RegExp | MatcherFunction
+export type ByRoleMatcher = ARIARole | MatcherFunction | {}
 
 export type NormalizerFn = (text: string) => string
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: TextMatch is allowed to be of any non-nullable type (`any` except `undefined` and `null`)

<!-- Why are these changes necessary? -->

**Why**: Error messages show confusing failed method calls instead of attempting to treat the TextMatch as a string implicitly (fixes #826)

<!-- How were these changes implemented? -->

**How**: Call `String()` whenever the TextMatch matcher isn't a `RegExp` or `Function` (allowing it to be `any` instead of `string`)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
