### PR TITLE
feat: warn when the test environment fake timers change unexpectedly

### DIFF
--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -1,14 +1,6 @@
 import {waitFor, waitForElementToBeRemoved} from '..'
 import {render} from './helpers/test-utils'
 
-beforeAll(() => {
-  jest.useFakeTimers()
-})
-
-afterAll(() => {
-  jest.useRealTimers()
-})
-
 async function runWaitFor({time = 300} = {}, options) {
   const response = 'data'
   const doAsyncThing = () =>
@@ -48,6 +40,7 @@ test('fake timer timeout', async () => {
 })
 
 test('times out after 1000ms by default', async () => {
+  jest.useFakeTimers()
   const {container} = render(`<div></div>`)
   const start = performance.now()
   // there's a bug with this rule here...
@@ -66,6 +59,7 @@ test('times out after 1000ms by default', async () => {
 })
 
 test('recursive timers do not cause issues', async () => {
+  jest.useFakeTimers()
   let recurse = true
   function startTimer() {
     setTimeout(() => {

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -36,6 +36,12 @@ beforeAll(() => {
   })
 })
 
+afterEach(() => {
+  if (jest.isMockFunction(global.setTimeout)) {
+    jest.useRealTimers()
+  }
+})
+
 afterAll(() => {
   jest.restoreAllMocks()
 })


### PR DESCRIPTION
**What**: feat: warn when the test environment fake timers change unexpectedly

<!-- Why are these changes necessary? -->

**Why**: Closes: #830 

<!-- How were these changes implemented? -->

**How**: For every iteration of waitFor, it checks whether the state of fake timers has changed and if it has, it rejects with an error. Also supports the `showOriginalStackTrace` config option.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
