### PR TITLE
fix(suggestions): don't suggest byLabelText when using byLabelText

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -232,6 +232,16 @@ test('should suggest getByLabelText when no role available', () => {
   )
 })
 
+it('should not suggest by label when using by label', async () => {
+  renderIntoDocument(
+    `<label><span>bar</span><input type="password" title="foo" /></label>`,
+  )
+
+  // if a suggestion is made, this call will throw, thus failing the test.
+  const password = await screen.findByLabelText(/bar/i)
+  expect(password).toHaveAttribute('type', 'password')
+})
+
 test(`should suggest getByLabel on non form elements`, () => {
   renderIntoDocument(`
   <div data-testid="foo" aria-labelledby="section-one-header">

--- a/src/queries/label-text.js
+++ b/src/queries/label-text.js
@@ -169,7 +169,7 @@ const findAllByLabelText = makeFindQuery(
   ),
 )
 const findByLabelText = makeFindQuery(
-  wrapSingleQueryWithSuggestion(getByLabelText, getByLabelText.name, 'find'),
+  wrapSingleQueryWithSuggestion(getByLabelText, getAllByLabelText.name, 'find'),
 )
 
 const getAllByLabelTextWithSuggestions = wrapAllByQueryWithSuggestion(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: a bug fix on suggestions for findByLabelText

<!-- Why are these changes necessary? -->

**Why**: when using findByLabelText, you would get a suggestion even if you're already using findByLabelText.

<!-- How were these changes implemented? -->

**How**:  use the right function when passing the name of the method.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the N/A
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->