### PR TITLE
fix: add number support for matches

### DIFF
--- a/src/matches.ts
+++ b/src/matches.ts
@@ -31,8 +31,10 @@ function fuzzyMatches(
 
   const normalizedText = normalizer(textToMatch)
 
-  if (typeof matcher === 'string') {
-    return normalizedText.toLowerCase().includes(matcher.toLowerCase())
+  if (typeof matcher === 'string' || typeof matcher === 'number') {
+    return normalizedText
+      .toLowerCase()
+      .includes(matcher.toString().toLowerCase())
   } else if (typeof matcher === 'function') {
     return matcher(normalizedText, node)
   } else {

--- a/types/matches.d.ts
+++ b/types/matches.d.ts
@@ -6,7 +6,7 @@ export type MatcherFunction = (
   content: string,
   element: Nullish<Element>,
 ) => boolean
-export type Matcher = MatcherFunction | RegExp | string
+export type Matcher = MatcherFunction | RegExp | string | number
 
 // Get autocomplete for ARIARole union types, while still supporting another string
 // Ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {"@testing-library/dom": ["."]}
+  }
 }


### PR DESCRIPTION

**What**:add number support for matches

<!-- Why are these changes necessary? -->

**Why**: because of an issue with typescript configuration I have dropped the support in #848 

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
