### PR TITLE
fix: delete type checking of globalObj.setTimeout.clock in getJestFakeTimersType

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -35,10 +35,7 @@ function getJestFakeTimersType() {
     return 'legacy'
   }
 
-  if (
-    typeof globalObj.setTimeout.clock !== 'undefined' &&
-    typeof jest.getRealSystemTime !== 'undefined'
-  ) {
+  if (typeof jest.getRealSystemTime !== 'undefined') {
     try {
       // jest.getRealSystemTime is only supported for Jest's `modern` fake timers and otherwise throws
       jest.getRealSystemTime()

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -31,8 +31,10 @@ function fuzzyMatches(
 
   const normalizedText = normalizer(textToMatch)
 
-  if (typeof matcher === 'string') {
-    return normalizedText.toLowerCase().includes(matcher.toLowerCase())
+  if (typeof matcher === 'string' || typeof matcher === 'number') {
+    return normalizedText
+      .toLowerCase()
+      .includes(matcher.toString().toLowerCase())
   } else if (typeof matcher === 'function') {
     return matcher(normalizedText, node)
   } else {

--- a/types/matches.d.ts
+++ b/types/matches.d.ts
@@ -6,7 +6,7 @@ export type MatcherFunction = (
   content: string,
   element: Nullish<Element>,
 ) => boolean
-export type Matcher = MatcherFunction | RegExp | string
+export type Matcher = MatcherFunction | RegExp | string | number
 
 // Get autocomplete for ARIARole union types, while still supporting another string
 // Ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {"@testing-library/dom": ["."]}
+  }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I deleted the type checking of `globalObj.setTimeout.clock` in `getJestFakeTimersType`.

```diff
-  if (
-     typeof globalObj.setTimeout.clock !== 'undefined' &&
-     typeof jest.getRealSystemTime !== 'undefined'
-   ) {
+   if (typeof jest.getRealSystemTime !== 'undefined') {
```

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
