### PR TITLE
fix: prevent crashing on elements without parentElement

### DIFF
--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -42,6 +42,20 @@ test('requires an element to exist first', () => {
   )
 })
 
+test("requires element's parent to exist first", () => {
+  const {getByTestId} = renderIntoDocument(`
+  <div data-testid="div">asd</div>
+`)
+  const div = getByTestId('div')
+  div.parentElement.removeChild(div)
+
+  return expect(
+    waitForElementToBeRemoved(div),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
+  )
+})
+
 test('requires an unempty array of elements to exist first', () => {
   return expect(
     waitForElementToBeRemoved([]),

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -20,7 +20,7 @@ async function waitForElementToBeRemoved(callback, options) {
     const elements = Array.isArray(callback) ? callback : [callback]
     const getRemainingElements = elements.map(element => {
       let parent = element.parentElement
-      if(!parent) return () => null
+      if(parent === null) return () => null
       while (parent.parentElement) parent = parent.parentElement
       return () => (parent.contains(element) ? element : null)
     })

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -20,6 +20,7 @@ async function waitForElementToBeRemoved(callback, options) {
     const elements = Array.isArray(callback) ? callback : [callback]
     const getRemainingElements = elements.map(element => {
       let parent = element.parentElement
+      if(!parent) return () => null
       while (parent.parentElement) parent = parent.parentElement
       return () => (parent.contains(element) ? element : null)
     })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixes #870. 

<!-- Why are these changes necessary? -->

**Why**:
Utility method `waitForElementToBeRemoved` should not crash when given element is already removed from its parent element. It should handle these cases and clearly report element is already removed. 

<!-- How were these changes implemented? -->

**How**:
Check whether element has `.parentElement` before accessing it. Prevents unexpected null pointer. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the N/A
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I was unable to use the pre-commit hook. The `kcd-scripts test --findRelatedTests` keeps running forever. After 10-15mins I cancelled it and commited with `--no-verify`. Same thing has happened to me before with `@testing-library/eslint-plugin-jest-dom` repository.

Here's output of the test case **without the fix applied** just to indicate the error is same as in #870.
<details>
    <summary>Test case error</summary>

```
 FAIL   dom  src/__tests__/wait-for-element-to-be-removed.js
  ✕ requires element's parent to exist first (8 ms)

  ● requires element's parent to exist first

    expect(received).rejects.toThrowErrorMatchingInlineSnapshot(snapshot)

    Snapshot name: `requires element's parent to exist first 1`

    Snapshot: "The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."
    Received: "Cannot read property 'parentElement' of null"

      54 |   return expect(
      55 |     waitForElementToBeRemoved(div),
    > 56 |   ).rejects.toThrowErrorMatchingInlineSnapshot(
         |             ^
      57 |     `"The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal."`,
      58 |   )
      59 | })

      at Object.toThrowErrorMatchingInlineSnapshot (node_modules/expect/build/index.js:241:20)
      at Object.<anonymous> (src/__tests__/wait-for-element-to-be-removed.js:56:13)
```
</details>