### PR TITLE
feat: add isInstanceOfElement helper

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -100,6 +100,36 @@ function getWindowFromNode(node) {
   }
 }
 
+/**
+ * Check if an element is of a given type.
+ *
+ * @param Element The element to test
+ * @param string Constructor name. E.g. 'HTMLSelectElement'
+ */
+function isInstanceOfElement(element, elementType) {
+  try {
+    const window = getWindowFromNode(element)
+    // Window usually has the element constructors as properties but is not required to do so per specs
+    if (typeof window[elementType] === 'function') {
+      return element instanceof window[elementType]
+    }
+  } catch (e) {
+    // The document might not be associated with a window
+  }
+
+  // Fall back to the constructor name as workaround for test environments that
+  // a) not associate the document with a window
+  // b) not provide the constructor as property of window
+  if (/^HTML(\w+)Element$/.test(element.constructor.name)) {
+    return element.constructor.name === elementType
+  }
+
+  // The user passed some node that is not created in a browser-like environment
+  throw new Error(
+    `Unable to verify if element is instance of ${elementType}. Please file an issue describing your test environment: https://github.com/testing-library/dom-testing-library/issues/new`,
+  )
+}
+
 function checkContainerType(container) {
   if (
     !container ||
@@ -131,4 +161,5 @@ export {
   checkContainerType,
   jestFakeTimersAreEnabled,
   TEXT_NODE,
+  isInstanceOfElement,
 }


### PR DESCRIPTION
Add a helper to verify the element type across libraries using `testing-library/dom` under the hood.

**What**:

Export a helper in `@testing-library/dist/helpers` to determine if an element is an instance of a specific `HTMLElement` type.

**Why**:

`@testing-library/user-event` [requires a better way to determine the element type](https://github.com/testing-library/user-event/pull/550).
As the requirement is not specific to `user-event`, I think it would be the cleaner solution to add it here.

**How**:

The helper tries to find the element constructor on the window.

As the window is neither required to be associated with the observed document nor is it required to provide any element constructors, the helper provides a fallback for other environments than Jest+JSDOM.

**Checklist**:

- N/A Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- N/A? Typescript definitions updated
There are no typescript definitions for internal methods at the moment.
- [x] Ready to be merged
