### PR TITLE
fix: remove side-effect from runWithRealTimers

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -53,7 +53,9 @@ describe('run with real timers', () => {
   const realSetTimeout = global.setTimeout
 
   afterEach(() => {
+    // restore timers replaced by jest.useFakeTimers()
     jest.useRealTimers()
+    // restore setTimeout replaced by assignment
     global.setTimeout = realSetTimeout
   })
 
@@ -61,7 +63,7 @@ describe('run with real timers', () => {
     // legacy timers use mocks and do not rely on a clock instance
     jest.useFakeTimers('legacy')
     runWithRealTimers(() => {
-      expect(global.setTimeout).toEqual(realSetTimeout)
+      expect(global.setTimeout).toBe(realSetTimeout)
     })
     expect(global.setTimeout._isMockFunction).toBe(true)
     expect(global.setTimeout.clock).toBeUndefined()
@@ -71,7 +73,7 @@ describe('run with real timers', () => {
     // modern timers use a clock instance instead of a mock
     jest.useFakeTimers('modern')
     runWithRealTimers(() => {
-      expect(global.setTimeout).toEqual(realSetTimeout)
+      expect(global.setTimeout).toBe(realSetTimeout)
     })
     expect(global.setTimeout._isMockFunction).toBeUndefined()
     expect(global.setTimeout.clock).toBeDefined()
@@ -86,7 +88,8 @@ describe('run with real timers', () => {
     global.setTimeout = fakedSetTimeout
 
     runWithRealTimers(() => {
-      expect(global.setTimeout).toEqual(fakedSetTimeout)
+      expect(global.setTimeout).toBe(fakedSetTimeout)
     })
+    expect(global.setTimeout).toBe(fakedSetTimeout)
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,17 +18,16 @@ function _runWithRealTimers(callback) {
     setTimeout,
   }
 
-  try {
+  // istanbul ignore else
+  if (typeof jest !== 'undefined') {
     jest.useRealTimers()
-  } catch (e) {
-    // not running in jest environment
   }
 
   const callbackReturnValue = callback()
 
-  const usedJestFakeTimers = Object.keys(timerAPI).filter(
-    k => timerAPI[k] !== globalObj[k],
-  ).length
+  const usedJestFakeTimers = Object.entries(timerAPI).some(
+    ([name, func]) => func !== globalObj[name],
+  )
 
   if (usedJestFakeTimers) {
     jest.useFakeTimers(timerAPI.setTimeout?.clock ? 'modern' : 'legacy')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,9 +18,10 @@ function _runWithRealTimers(callback) {
     setTimeout,
   }
 
-  // istanbul ignore else
-  if (jest) {
+  try {
     jest.useRealTimers()
+  } catch (e) {
+    // not running in jest environment
   }
 
   const callbackReturnValue = callback()

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,52 +5,42 @@ const TEXT_NODE = 3
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
-  const fakeTimersType = getJestFakeTimersType()
-  if (fakeTimersType) {
+  return _runWithRealTimers(callback).callbackReturnValue
+}
+
+function _runWithRealTimers(callback) {
+  const timerAPI = {
+    clearImmediate,
+    clearInterval,
+    clearTimeout,
+    setImmediate,
+    setInterval,
+    setTimeout,
+  }
+
+  // istanbul ignore else
+  if (jest) {
     jest.useRealTimers()
   }
 
   const callbackReturnValue = callback()
 
-  if (fakeTimersType) {
-    jest.useFakeTimers(fakeTimersType)
+  const usedJestFakeTimers = Object.keys(timerAPI).filter(
+    k => timerAPI[k] !== globalObj[k],
+  ).length
+
+  if (usedJestFakeTimers) {
+    jest.useFakeTimers(timerAPI.setTimeout?.clock ? 'modern' : 'legacy')
   }
 
-  return callbackReturnValue
+  return {
+    callbackReturnValue,
+    usedJestFakeTimers,
+  }
 }
 
-function getJestFakeTimersType() {
-  // istanbul ignore if
-  if (
-    typeof jest === 'undefined' ||
-    typeof globalObj.setTimeout === 'undefined'
-  ) {
-    return null
-  }
-
-  if (
-    typeof globalObj.setTimeout._isMockFunction !== 'undefined' &&
-    globalObj.setTimeout._isMockFunction
-  ) {
-    return 'legacy'
-  }
-
-  if (
-    typeof globalObj.setTimeout.clock !== 'undefined' &&
-    typeof jest.getRealSystemTime !== 'undefined'
-  ) {
-    try {
-      // jest.getRealSystemTime is only supported for Jest's `modern` fake timers and otherwise throws
-      jest.getRealSystemTime()
-      return 'modern'
-    } catch {
-      // not using Jest's modern fake timers
-    }
-  }
-  return null
-}
-
-const jestFakeTimersAreEnabled = () => Boolean(getJestFakeTimersType())
+const jestFakeTimersAreEnabled = () =>
+  Boolean(_runWithRealTimers(() => {}).usedJestFakeTimers)
 
 // we only run our tests in node, and setImmediate is supported in node.
 // istanbul ignore next


### PR DESCRIPTION
**What**:

Rewritten `runWithRealTimers` and the related tests.

**Why**:

`runWithRealTimers` activated fake timers when a `jest.useFakeTimers('modern')` has been used in any test before.
The tests leaked `setTimeout`.

See #884 and #886

**How**:

Call `jest.useRealTimers` and check if any timer functions changed to determine if fake timers have been active.

**Checklist**:
- N/A Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- N/A Typescript definitions updated
- [x] Ready to be merged
