### PR TITLE
chore: Fix missing codecov report in PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2
+        with:
+          # required by codecov/codecov-action
+          fetch-depth: 0
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v1
@@ -42,6 +45,9 @@ jobs:
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+          flags: node-${{ matrix.node }}
 
   release:
     needs: main


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes missing codecov reports in PRs

<!-- Why are these changes necessary? -->

**Why**:

These are required for PRs to be mergable. Right now only admins can merge.

**How**:

Set `fetch-depth` to `0` [as suggested](https://github.com/testing-library/dom-testing-library/pull/858/checks?check_run_id=1837616294#step:7:22)

I also changed the action so that it fails CI on failure. Otherwise it's not obvious why the check is missing.

Added `flags` while we're at it to know where coverage might be missing.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests (once we get the check)
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
