### PR TITLE
fix: Don't assume mocked timers imply jest fake timers

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,9 +25,9 @@ function _runWithRealTimers(callback) {
 
   const callbackReturnValue = callback()
 
-  const usedJestFakeTimers = Object.entries(timerAPI).some(
-    ([name, func]) => func !== globalObj[name],
-  )
+  const usedJestFakeTimers =
+    typeof jest !== 'undefined' &&
+    Object.entries(timerAPI).some(([name, func]) => func !== globalObj[name])
 
   if (usedJestFakeTimers) {
     jest.useFakeTimers(timerAPI.setTimeout?.clock ? 'modern' : 'legacy')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,8 +41,13 @@ function runWithJestRealTimers(callback) {
   }
 }
 
-const jestFakeTimersAreEnabled = () =>
-  typeof jest !== 'undefined' && runWithJestRealTimers(() => {}).usedFakeTimers
+function jestFakeTimersAreEnabled() {
+  // istanbul ignore else
+  if (typeof jest !== 'undefined') {
+    return runWithJestRealTimers(() => {}).usedFakeTimers
+  }
+  return false
+}
 
 // we only run our tests in node, and setImmediate is supported in node.
 // istanbul ignore next

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,6 +10,7 @@ function runWithRealTimers(callback) {
     return runWithJestRealTimers(callback).callbackReturnValue
   }
 
+  // istanbul ignore next
   return callback()
 }
 
@@ -46,6 +47,8 @@ function jestFakeTimersAreEnabled() {
   if (typeof jest !== 'undefined') {
     return runWithJestRealTimers(() => {}).usedFakeTimers
   }
+
+  // istanbul ignore next
   return false
 }
 

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -52,8 +52,8 @@ function waitFor(
 
     const overallTimeoutTimer = setTimeout(handleTimeout, timeout)
 
-    const usingFakeTimers = jestFakeTimersAreEnabled()
-    if (usingFakeTimers) {
+    const usingJestFakeTimers = jestFakeTimersAreEnabled()
+    if (usingJestFakeTimers) {
       checkCallback()
       // this is a dangerous rule to disable because it could lead to an
       // infinite loop. However, eslint isn't smart enough to know that we're
@@ -107,7 +107,7 @@ function waitFor(
       finished = true
       clearTimeout(overallTimeoutTimer)
 
-      if (!usingFakeTimers) {
+      if (!usingJestFakeTimers) {
         clearInterval(intervalId)
         observer.disconnect()
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes #898

<!-- Why are these changes necessary? -->

**Why**:

`callback` might mock timers or timers might be mocked in another way. 

<!-- How were these changes implemented? -->

**How**:

Check if we're in a `jest`-like environment via `typeof jest !== 'undefined'`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
