### PR TITLE
feat: Improve error message when passing an Array while a single Element is expected

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -17,6 +17,11 @@ describe('window retrieval throws when given something other than a node', () =>
       `"It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?"`,
     )
   })
+  test('Array as node', () => {
+    expect(() => getWindowFromNode([])).toThrowErrorMatchingInlineSnapshot(
+      `"It looks like you passed an Array object instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?"`,
+    )
+  })
   test('unknown as node', () => {
     expect(() => getWindowFromNode({})).toThrowErrorMatchingInlineSnapshot(
       `"Unable to find the \\"window\\" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new"`,

--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -19,7 +19,7 @@ describe('window retrieval throws when given something other than a node', () =>
   })
   test('Array as node', () => {
     expect(() => getWindowFromNode([])).toThrowErrorMatchingInlineSnapshot(
-      `"It looks like you passed an Array object instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?"`,
+      `"It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?"`,
     )
   })
   test('unknown as node', () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -94,7 +94,7 @@ function getWindowFromNode(node) {
     )
   } else if (node instanceof Array) {
     throw new Error(
-      `It looks like you passed an Array object instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`,
+      `It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`,
     )
   } else {
     // The user passed something unusual to a calling function

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -92,6 +92,10 @@ function getWindowFromNode(node) {
     throw new Error(
       `It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?`,
     )
+  } else if (node instanceof Array) {
+    throw new Error(
+      `It looks like you passed an Array object instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`,
+    )
   } else {
     // The user passed something unusual to a calling function
     throw new Error(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -92,7 +92,7 @@ function getWindowFromNode(node) {
     throw new Error(
       `It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?`,
     )
-  } else if (node instanceof Array) {
+  } else if (Array.isArray(node)) {
     throw new Error(
       `It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`,
     )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: New error message when passing an Array.

<!-- Why are these changes necessary? -->

**Why**: This can be a quick typo when using `screen.getAll*` or `screen.queryAll*` queries. 

<!-- How were these changes implemented? -->

**How**: Type checking for `Array`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
