### PR TITLE
Fix getByRole using matcher and normalizer on accessible names

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -1,5 +1,6 @@
 import {configure, getConfig} from '../config'
 import {getQueriesForElement} from '../get-queries-for-element'
+import {getDefaultNormalizer} from '../'
 import {render, renderIntoDocument} from './helpers/test-utils'
 
 test('by default logs accessible roles when it fails', () => {
@@ -279,6 +280,19 @@ test('accessible name obeys exact: false', () => {
   // subset using exact: false
   expect(getByRole('heading', {name: 'gn u', exact: false})).not.toBeNull()
 });
+
+test('accessible name obeys text normalizer', () => {
+  const {getByRole} = render(
+    `<h1>Sign \u2068up\u2069</h1>`,
+  )
+
+  // match using a normalizer
+  expect(getByRole('heading', {
+    name: /gn u/,
+    // Remove all isolation characters
+    normalizer: str => getDefaultNormalizer()(str).replace(/[\u2066-\u2069]+/g, ''),
+  })).not.toBeNull()
+})
 
 test('TextMatch serialization in error message', () => {
   const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -271,6 +271,15 @@ test('accessible name filter implements TextMatch', () => {
   ).not.toBeNull()
 })
 
+test('accessible name obeys exact: false', () => {
+  const {getByRole} = render(
+    `<h1>Sign <em>up</em></h1><h2>Details</h2><h2>Your Signature</h2>`,
+  )
+
+  // subset using exact: false
+  expect(getByRole('heading', {name: 'gn u', exact: false})).not.toBeNull()
+});
+
 test('TextMatch serialization in error message', () => {
   const {getByRole} = render(`<h1>Sign <em>up</em></h1>`)
 

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -153,7 +153,7 @@ function queryAllByRole(
         }),
         element,
         name,
-        text => text,
+        matchNormalizer,
       )
     })
 }

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -146,7 +146,7 @@ function queryAllByRole(
         return true
       }
 
-      return matches(
+      return matcher(
         computeAccessibleName(element, {
           computedStyleSupportsPseudoElements: getConfig()
             .computedStyleSupportsPseudoElements,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: While studying the source code I realized that we weren't using the normal matcher and normalizer when matching the accessible name in `getByRole`. I believe this is a mistake.

<!-- Why are these changes necessary? -->

**Why**: This removes some functionality, and is surprising tot he user.

<!-- How were these changes implemented? -->

**How**: I only reused existing objects.
Note: I've added 2 commits, solving separately the 2 issues I've seen, with tests.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [X] Tests
- [ ] Typescript definitions updated N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

While looking at the code, I've seen that the role matching also uses the full matcher and the normalizer, for example:
https://github.com/testing-library/dom-testing-library/blob/f7b5c33c44632fba1579cb44f9f175be1ec46087/src/queries/role.js#L97-L100
I find it somewhat weird that we can normalize roles, or look for inexact roles. But I haven't changed that because this might cause breakage in your users, and didn't want to risk delaying this patch either.

Thanks!