### PR TITLE
docs: remove outdated pre-commit instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,6 @@ Please make sure to run the tests before you commit your changes. You can run
 `npm run test:update` which will update any snapshots that need updating. Make
 sure to include those changes (if they exist) in your commit.
 
-### opt into git hooks
-
-There are git hooks set up with this project that are automatically installed
-when you install dependencies. They're really handy, but are turned off by
-default (so as to not hinder new contributors). You can opt into these by
-creating a file called `.opt-in` at the root of the project and putting this
-inside:
-
-```
-pre-commit
-```
-
 ## Help needed
 
 Please checkout the [the open issues][issues]


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Removes out-dated instructions about `.opt-in` file. 

<!-- Why are these changes necessary? -->

**Why**:

Support for `.opt-in` was droppped in `kcd-scripts@5.0.0`: https://github.com/kentcdodds/kcd-scripts/pull/119.
This section should have been removed in https://github.com/testing-library/dom-testing-library/pull/447.

<!-- How were these changes implemented? -->

**How**:
\- 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the N/A
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Ran into this issue when studying why pre-commit hooks of all testing-library repositories get stuck in my environment. This wasn't the root cause though - I'll keep debugging. 