### PR TITLE
fix(setImmediate): make code resilient to setImmediate not existing

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,12 +16,16 @@ function runWithRealTimers(callback) {
 
 function runWithJestRealTimers(callback) {
   const timerAPI = {
-    clearImmediate,
     clearInterval,
     clearTimeout,
-    setImmediate,
     setInterval,
     setTimeout,
+  }
+  if (typeof setImmediate === 'function') {
+    timerAPI.setImmediate = setImmediate
+  }
+  if (typeof clearImmediate === 'function') {
+    timerAPI.clearImmediate = clearImmediate
   }
 
   jest.useRealTimers()

--- a/src/wait-for-dom-change.js
+++ b/src/wait-for-dom-change.js
@@ -1,7 +1,6 @@
 import {
   getWindowFromNode,
   getDocument,
-  setImmediate,
   setTimeout,
   clearTimeout,
   runWithRealTimers,
@@ -39,7 +38,7 @@ function waitForDomChange({
 
     function onDone(error, result) {
       clearTimeout(timer)
-      setImmediate(() => observer.disconnect())
+      setTimeout(() => observer.disconnect(), 0)
       if (error) {
         reject(error)
       } else {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Remove assumptions of `setImmediate` and `clearImmediate`  and make it resilient to `setImmediate` not existing

<!-- Why are these changes necessary? -->

**Why**:
Fix: #914
<!-- How were these changes implemented? -->

**How**:
 Asking if `setImmediate` is a function before adding it to `timerAPI` object and refactoring `waitForDomChange` function to use `setTimeout` in place of `setImmediate` 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
