### PR TITLE
fix(types): exclude tsconfig from types folder in publish flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "files": [
     "dist",
-    "types"
+    "types/*.d.ts"
   ],
   "dependencies": {
     "@babel/code-frame": "^7.10.4",


### PR DESCRIPTION
Port of https://github.com/testing-library/react-testing-library/pull/893
