### PR TITLE
fix(types): missing ignore parameter for SelectorMatcherOptions

### DIFF
--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -3,6 +3,7 @@ import {waitForOptions} from './wait-for'
 
 export interface SelectorMatcherOptions extends MatcherOptions {
   selector?: string
+  ignore?: string | boolean
 }
 
 export type QueryByAttribute = (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add missing `ignore` parameter definition in type `SelectorMatcherOptions`. 
From the [docs](https://testing-library.com/docs/queries/bytext/#ignore) and the codebase it looks like it can either be a string or a boolean.

<!-- Why are these changes necessary? -->

**Why**: Resolves https://github.com/testing-library/dom-testing-library/issues/921

<!-- How were these changes implemented? -->

**How**: Added the missing parameter manually.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
