### PR TITLE
fix: Guard against `jest.useRealTimers` not existing

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,13 +5,18 @@ const TEXT_NODE = 3
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback) {
-  // istanbul ignore else
-  if (typeof jest !== 'undefined') {
-    return runWithJestRealTimers(callback).callbackReturnValue
-  }
+  return hasJestTimers()
+    ? runWithJestRealTimers(callback).callbackReturnValue
+    : // istanbul ignore next
+      callback()
+}
 
-  // istanbul ignore next
-  return callback()
+function hasJestTimers() {
+  return (
+    jest !== undefined &&
+    jest !== null &&
+    typeof jest.useRealTimers === 'function'
+  )
 }
 
 function runWithJestRealTimers(callback) {
@@ -50,13 +55,10 @@ function runWithJestRealTimers(callback) {
 }
 
 function jestFakeTimersAreEnabled() {
-  // istanbul ignore else
-  if (typeof jest !== 'undefined') {
-    return runWithJestRealTimers(() => {}).usedFakeTimers
-  }
-
-  // istanbul ignore next
-  return false
+  return hasJestTimers()
+    ? runWithJestRealTimers(() => {}).usedFakeTimers
+    : // istanbul ignore next
+      false
 }
 
 // we only run our tests in node, and setImmediate is supported in node.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,7 @@ function runWithRealTimers(callback) {
 
 function hasJestTimers() {
   return (
-    jest !== undefined &&
+    typeof jest !== 'undefined' &&
     jest !== null &&
     typeof jest.useRealTimers === 'function'
   )


### PR DESCRIPTION
**What**:

Check if `jest.useRealTimers` is a function before calling it.
Closes #905 

**Why**:

In some environments (e.g. codesandbox) `jest` exists but is either `null` or the `useRealTimers` and `useFakeTimers` don't exist.

**Checklist**:

- N/A Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- N/A Tests
- N/A Typescript definitions updated
- [x] Ready to be merged
