### PR TITLE
test: enable modern jest timers test

### DIFF
--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -1,20 +1,26 @@
 import {waitFor, waitForElementToBeRemoved} from '..'
 import {render} from './helpers/test-utils'
 
-async function runWaitFor({time = 300} = {}, options) {
+async function runWaitFor({time = 300, advanceTimers = true} = {}, options) {
   const response = 'data'
   const doAsyncThing = () =>
     new Promise(r => setTimeout(() => r(response), time))
   let result
   doAsyncThing().then(r => (result = r))
-
+  if (advanceTimers) {
+    jest.advanceTimersByTime(time)
+  }
   await waitFor(() => expect(result).toBe(response), options)
 }
+
+afterEach(() => {
+  jest.useRealTimers()
+})
 
 test('real timers', async () => {
   // the only difference when not using fake timers is this test will
   // have to wait the full length of the timeout
-  await runWaitFor()
+  await runWaitFor({advanceTimers: false})
 })
 
 test('legacy', async () => {
@@ -23,7 +29,7 @@ test('legacy', async () => {
 })
 
 test('modern', async () => {
-  jest.useFakeTimers()
+  jest.useFakeTimers('modern')
   await runWaitFor()
 })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Explicit set jest's faker timers to `modern`.

**Why**:

Because in Jest 26.x the default is `legacy`. 
https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers

**How**:

Changed the modern test  by passing `modern` as the options.
I also had to advance the timers, and had to "clear" the timers after the test.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
