### PR TITLE
feat: simplified the getByText error message

### DIFF
--- a/src/__tests__/__snapshots__/get-by-errors.js.snap
+++ b/src/__tests__/__snapshots__/get-by-errors.js.snap
@@ -2,4 +2,4 @@
 
 exports[`getByLabelText query will throw the custom error returned by config.getElementError 1`] = `"My custom error: Unable to find a label with the text of: TEST QUERY"`;
 
-exports[`getByText query will throw the custom error returned by config.getElementError 1`] = `"My custom error: Unable to find an element with the text: TEST QUERY. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`;
+exports[`getByText query will throw the custom error returned by config.getElementError 1`] = `"My custom error: Unable to find an element using the provided matcher.The matcher is - TEST QUERY This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`;

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -35,65 +35,65 @@ test('get throws a useful error message', () => {
   } = render('<div />')
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find a label with the text of: LucyRicardo
+    "Unable to find a label with the text of: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByPlaceholderText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the placeholder text of: LucyRicardo
+    "Unable to find an element with the placeholder text of: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+    "Unable to find an element using the provided matcher.The matcher is - LucyRicardo This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element by: [data-testid="LucyRicardo"]
+    "Unable to find an element by: [data-testid="LucyRicardo"]
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the alt text: LucyRicardo
+    "Unable to find an element with the alt text: LucyRicardo
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the title: LucyRicardo.
+    "Unable to find an element with the title: LucyRicardo.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByDisplayValue('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the display value: LucyRicardo.
+    "Unable to find an element with the display value: LucyRicardo.
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "LucyRicardo"
+    "Unable to find an accessible element with the role "LucyRicardo"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-<div>
-  <div />
-</div>"
-`)
+    <div>
+      <div />
+    </div>"
+  `)
 })
 
 test('can get elements by matching their text content', () => {
@@ -352,14 +352,14 @@ test('label with no form control', () => {
   const {getByLabelText, queryByLabelText} = render(`<label>All alone</label>`)
   expect(queryByLabelText(/alone/)).toBeNull()
   expect(() => getByLabelText(/alone/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label>
-    All alone
-  </label>
-</div>"
-`)
+    <div>
+      <label>
+        All alone
+      </label>
+    </div>"
+  `)
 })
 
 test('label with "for" attribute but no form control and fuzzy matcher', () => {
@@ -369,16 +369,16 @@ test('label with "for" attribute but no form control and fuzzy matcher', () => {
   expect(queryByLabelText('alone', {exact: false})).toBeNull()
   expect(() => getByLabelText('alone', {exact: false}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label
-    for="foo"
-  >
-    All alone label
-  </label>
-</div>"
-`)
+    <div>
+      <label
+        for="foo"
+      >
+        All alone label
+      </label>
+    </div>"
+  `)
 })
 
 test('label with children with no form control', () => {
@@ -391,32 +391,32 @@ test('label with children with no form control', () => {
   expect(queryByLabelText(/alone/, {selector: 'input'})).toBeNull()
   expect(() => getByLabelText(/alone/, {selector: 'input'}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  
-  
-  <label>
-    
-    All alone but with children
-    
-    <textarea>
-      Hello
-    </textarea>
-    
-    
-    <select>
-      <option
-        value="0"
-      >
-        zero
-      </option>
-    </select>
-    
-  
-  </label>
-</div>"
-`)
+    <div>
+      
+      
+      <label>
+        
+        All alone but with children
+        
+        <textarea>
+          Hello
+        </textarea>
+        
+        
+        <select>
+          <option
+            value="0"
+          >
+            zero
+          </option>
+        </select>
+        
+      
+      </label>
+    </div>"
+  `)
 })
 
 test('label with non-labellable element', () => {
@@ -431,35 +431,35 @@ test('label with non-labellable element', () => {
 
   expect(queryByLabelText(/Label/)).toBeNull()
   expect(() => getByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
+    "Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
 
-<div>
-  
-  
-  <div>
-    
-    
-    <label
-      for="div1"
-    >
-      Label 1
-    </label>
-    
-    
-    <div
-      id="div1"
-    >
+    <div>
       
-      Hello
-    
-    </div>
-    
-  
-  </div>
-  
-  
-</div>"
-`)
+      
+      <div>
+        
+        
+        <label
+          for="div1"
+        >
+          Label 1
+        </label>
+        
+        
+        <div
+          id="div1"
+        >
+          
+          Hello
+        
+        </div>
+        
+      
+      </div>
+      
+      
+    </div>"
+  `)
 })
 
 test('multiple labels with non-labellable elements', () => {
@@ -478,65 +478,65 @@ test('multiple labels with non-labellable elements', () => {
 
   expect(queryAllByLabelText(/Label/)).toEqual([])
   expect(() => getAllByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
+    "Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
 
-Found a label with the text of: /Label/, however the element associated with this label (<p />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <p />, you can use aria-label or aria-labelledby instead.
+    Found a label with the text of: /Label/, however the element associated with this label (<p />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <p />, you can use aria-label or aria-labelledby instead.
 
-<div>
-  
-  
-  <div>
-    
-    
-    <label
-      for="span1"
-    >
-      Label 1
-    </label>
-    
-    
-    <span
-      id="span1"
-    >
+    <div>
       
-      Hello
-    
-    </span>
-    
-    
-    <label
-      for="p1"
-    >
-      Label 2
-    </label>
-    
-    
-    <p
-      id="p1"
-    >
       
-      World
-    
-    </p>
-    
-  
-  </div>
-  
-  
-</div>"
-`)
+      <div>
+        
+        
+        <label
+          for="span1"
+        >
+          Label 1
+        </label>
+        
+        
+        <span
+          id="span1"
+        >
+          
+          Hello
+        
+        </span>
+        
+        
+        <label
+          for="p1"
+        >
+          Label 2
+        </label>
+        
+        
+        <p
+          id="p1"
+        >
+          
+          World
+        
+        </p>
+        
+      
+      </div>
+      
+      
+    </div>"
+  `)
 })
 
 test('totally empty label', () => {
   const {getByLabelText, queryByLabelText} = render(`<label />`)
   expect(queryByLabelText('')).toBeNull()
   expect(() => getByLabelText('')).toThrowErrorMatchingInlineSnapshot(`
-"Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    "Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
-<div>
-  <label />
-</div>"
-`)
+    <div>
+      <label />
+    </div>"
+  `)
 })
 
 test('getByLabelText with aria-label', () => {
@@ -1066,7 +1066,7 @@ test('get throws a useful error message without DOM in Cypress', () => {
     `"Unable to find an element with the placeholder text of: LucyRicardo"`,
   )
   expect(() => getByText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
-    `"Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`,
+    `"Unable to find an element using the provided matcher.The matcher is - LucyRicardo This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible."`,
   )
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
     `"Unable to find an element by: [data-testid=\\"LucyRicardo\\"]"`,
@@ -1219,14 +1219,14 @@ test('return a proper error message when no label is found and there is an aria-
 
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find a label with the text of: LucyRicardo
+    "Unable to find a label with the text of: LucyRicardo
 
-<div>
-  <input
-    aria-labelledby="not-existing-label"
-  />
-</div>"
-`)
+    <div>
+      <input
+        aria-labelledby="not-existing-label"
+      />
+    </div>"
+  `)
 })
 
 // https://github.com/testing-library/dom-testing-library/issues/723

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -115,7 +115,13 @@ test('find rejects when something cannot be found', async () => {
   await expect(findAllByPlaceholderText('x', qo, wo)).rejects.toThrow('x')
 
   await expect(findByText('x', qo, wo)).rejects.toThrow('x')
-  await expect(findAllByText('x', qo, wo)).rejects.toThrow('x')
+  await expect(findByText(() => {}, qo, wo)).rejects.toThrow(
+    'Unable to find an element using the provided matcher',
+  )
+  await expect(findAllByText('x2', qo, wo)).rejects.toThrow('x')
+  await expect(findAllByText(() => {}, qo, wo)).rejects.toThrow(
+    'Unable to find an element using the provided matcher',
+  )
 
   await expect(findByAltText('x', qo, wo)).rejects.toThrow('x')
   await expect(findAllByAltText('x', qo, wo)).rejects.toThrow('x')

--- a/src/__tests__/queries.find.js
+++ b/src/__tests__/queries.find.js
@@ -118,7 +118,7 @@ test('find rejects when something cannot be found', async () => {
   await expect(findByText(() => {}, qo, wo)).rejects.toThrow(
     'Unable to find an element using the provided matcher',
   )
-  await expect(findAllByText('x2', qo, wo)).rejects.toThrow('x')
+  await expect(findAllByText('x', qo, wo)).rejects.toThrow('x')
   await expect(findAllByText(() => {}, qo, wo)).rejects.toThrow(
     'Unable to find an element using the provided matcher',
   )

--- a/src/queries/text.js
+++ b/src/queries/text.js
@@ -35,8 +35,14 @@ function queryAllByText(
 
 const getMultipleError = (c, text) =>
   `Found multiple elements with the text: ${text}`
-const getMissingError = (c, text) =>
-  `Unable to find an element with the text: ${text}. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.`
+const getMissingError = (c, text) => {
+  const errorMsgBase = `Unable to find an element using the provided matcher.`
+  let errorMsgExtnd = ''
+  if (typeof text !== 'function') {
+    errorMsgExtnd = `The matcher is - ${text} This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.`
+  }
+  return errorMsgBase.concat(errorMsgExtnd)
+}
 
 const queryAllByTextWithSuggestions = wrapAllByQueryWithSuggestion(
   queryAllByText,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Updated the error message returned from the getByText query to be more descriptive 
https://github.com/testing-library/dom-testing-library/issues/732

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
