### PR TITLE
feat: Improve error message when a node was expected

### DIFF
--- a/src/__tests__/helpers.js
+++ b/src/__tests__/helpers.js
@@ -24,7 +24,7 @@ describe('window retrieval throws when given something other than a node', () =>
   })
   test('unknown as node', () => {
     expect(() => getWindowFromNode({})).toThrowErrorMatchingInlineSnapshot(
-      `"Unable to find the \\"window\\" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new"`,
+      `"The given node is not an HTMLElement."`,
     )
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -105,11 +105,13 @@ function getWindowFromNode(node) {
     throw new Error(
       `It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`,
     )
-  } else {
-    // The user passed something unusual to a calling function
+  } else if (node instanceof HTMLElement) {
     throw new Error(
       `Unable to find the "window" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`,
     )
+  } else {
+    // The user passed something unusual to a calling function
+    throw new Error(`The given node is not an HTMLElement.`)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: bug

Closes https://github.com/testing-library/dom-testing-library/issues/863

<!-- Why are these changes necessary? -->

**Why**: yes, to get a more informative error message

<!-- How were these changes implemented? -->

**How**: added a new validation

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This commit is related to this open issue: 
https://github.com/testing-library/dom-testing-library/issues/863

- I extended the validation getWindowFromNode helper function, to check if the node argument object is an HTMLElement type, if not I'm throwing a new error message.

- Regarding the existing test I couldn't find a valid scenario to preserve the previous test, since if you create an HTML element it has an ownerDocument.defaultView, but the validation at the getWindowFromNode must be preserved since we can't know how will some project used framework would create the HTML element