### PR TITLE
chore: Remove unused Nullish type

### DIFF
--- a/src/label-helpers.ts
+++ b/src/label-helpers.ts
@@ -1,4 +1,3 @@
-import {Nullish} from '../types'
 import {TEXT_NODE} from './helpers'
 
 const labelledNodeNames = [
@@ -25,7 +24,7 @@ function getTextContent(
     .join('')
 }
 
-function getLabelContent(element: Element): Nullish<string> {
+function getLabelContent(element: Element): string | null {
   let textContent: string | null
   if (element.tagName.toLowerCase() === 'label') {
     textContent = getTextContent(element)
@@ -59,7 +58,7 @@ function getLabels(
   container: Element,
   element: Element,
   {selector = '*'} = {},
-): {content: Nullish<string>; formControl: Nullish<HTMLElement>}[] {
+): {content: string | null; formControl: HTMLElement | null}[] {
   const ariaLabelledBy = element.getAttribute('aria-labelledby')
   const labelsId = ariaLabelledBy ? ariaLabelledBy.split(' ') : []
   return labelsId.length

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -5,8 +5,6 @@ import {
   DefaultNormalizerOptions,
 } from '../types'
 
-type Nullish<T> = T | null | undefined
-
 function assertNotNullOrUndefined<T>(
   matcher: T,
 ): asserts matcher is NonNullable<T> {
@@ -19,9 +17,9 @@ function assertNotNullOrUndefined<T>(
 }
 
 function fuzzyMatches(
-  textToMatch: Nullish<string>,
-  node: Nullish<Element>,
-  matcher: Nullish<Matcher>,
+  textToMatch: string | null,
+  node: Element | null,
+  matcher: Matcher | null,
   normalizer: NormalizerFn,
 ) {
   if (typeof textToMatch !== 'string') {
@@ -43,9 +41,9 @@ function fuzzyMatches(
 }
 
 function matches(
-  textToMatch: Nullish<string>,
-  node: Nullish<Element>,
-  matcher: Nullish<Matcher>,
+  textToMatch: string | null,
+  node: Element | null,
+  matcher: Matcher | null,
   normalizer: NormalizerFn,
 ) {
   if (typeof textToMatch !== 'string') {

--- a/src/queries/label-text.ts
+++ b/src/queries/label-text.ts
@@ -1,7 +1,7 @@
 import {getConfig} from '../config'
 import {checkContainerType} from '../helpers'
 import {getLabels, getRealLabels, getLabelContent} from '../label-helpers'
-import {AllByText, GetErrorFunction, Nullish} from '../../types'
+import {AllByText, GetErrorFunction} from '../../types'
 import {
   fuzzyMatches,
   matches,
@@ -15,7 +15,7 @@ import {
 
 function queryAllLabels(
   container: HTMLElement,
-): {textToMatch: Nullish<string>; node: HTMLElement}[] {
+): {textToMatch: string | null; node: HTMLElement}[] {
   return Array.from(container.querySelectorAll<HTMLElement>('label,input'))
     .map(node => {
       return {node, textToMatch: getLabelContent(node)}
@@ -160,7 +160,7 @@ const getAllByLabelText: AllByText = (container, text, ...rest) => {
 function getTagNameOfElementAssociatedWithLabelViaFor(
   container: Element,
   label: Element,
-): Nullish<string> {
+): string | null {
   const htmlFor = label.getAttribute('for')
   if (!htmlFor) {
     return null

--- a/types/matches.d.ts
+++ b/types/matches.d.ts
@@ -1,10 +1,8 @@
 import {ARIARole} from 'aria-query'
 
-type Nullish<T> = T | null | undefined
-
 export type MatcherFunction = (
   content: string,
-  element: Nullish<Element>,
+  element: Element | null,
 ) => boolean
 export type Matcher = MatcherFunction | RegExp | number | string
 

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -1,7 +1,7 @@
-import {Matcher, MatcherOptions, Nullish} from './matches'
+import {Matcher, MatcherOptions} from './matches'
 import {waitForOptions} from './wait-for'
 
-export type GetErrorFunction = (c: Nullish<Element>, alt: string) => string
+export type GetErrorFunction = (c: Element | null, alt: string) => string
 
 export interface SelectorMatcherOptions extends MatcherOptions {
   selector?: string


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Remove `Nullish` helper type

**Why**:

Seems to be unused. So if we don't need the helper type let's remove the indirection.

**How**:

Replace usage of `Nullish<T>` with `T | null`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
