### PR TITLE
chore: Format codebase with prettier

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,6 +31,7 @@ supported version.
 Relevant code or config
 
 ```js
+
 ```
 
 What you did:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           useLockFile: false
 
+      # TODO: Can be removed if https://github.com/kentcdodds/kcd-scripts/pull/146 is released
+      - name: Verify format (`npm run format` committed?)
+        run: npm run format -- --check
+
       - name: ▶️ Run validate script
         run: npm run validate
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
 
       # TODO: Can be removed if https://github.com/kentcdodds/kcd-scripts/pull/146 is released
       - name: Verify format (`npm run format` committed?)
-        run: npm run format -- --check
+        run: npm run format -- --check --no-write
 
       - name: ▶️ Run validate script
         run: npm run validate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2.  Run `npm run setup` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `main` branch pointing at the original repository and make
-> pull requests from branches on your fork. To do this, run:
+> Tip: Keep your `main` branch pointing at the original repository and make pull
+> requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/testing-library/dom-testing-library.git
@@ -21,10 +21,10 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `main`
-> branch to use the upstream main branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `main` branch.
-> Whenever you want to update your version of `main`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main` branch
+> to use the upstream main branch whenever you run `git pull`. Then you can make
+> all of your pull request branches based on this `main` branch. Whenever you
+> want to update your version of `main`, do a regular `git pull`.
 
 ## Committing and Pushing changes
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
+    "format": "kcd-scripts format",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",

--- a/src/event-map.js
+++ b/src/event-map.js
@@ -1,350 +1,350 @@
 export const eventMap = {
-    // Clipboard Events
-    copy: {
-      EventType: 'ClipboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    cut: {
-      EventType: 'ClipboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    paste: {
-      EventType: 'ClipboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    // Composition Events
-    compositionEnd: {
-      EventType: 'CompositionEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    compositionStart: {
-      EventType: 'CompositionEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    compositionUpdate: {
-      EventType: 'CompositionEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    // Keyboard Events
-    keyDown: {
-      EventType: 'KeyboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
-    },
-    keyPress: {
-      EventType: 'KeyboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
-    },
-    keyUp: {
-      EventType: 'KeyboardEvent',
-      defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
-    },
-    // Focus Events
-    focus: {
-      EventType: 'FocusEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
-    },
-    blur: {
-      EventType: 'FocusEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
-    },
-    focusIn: {
-      EventType: 'FocusEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    focusOut: {
-      EventType: 'FocusEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    // Form Events
-    change: {
-      EventType: 'Event',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-    input: {
-      EventType: 'InputEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    invalid: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: true},
-    },
-    submit: {
-      EventType: 'Event',
-      defaultInit: {bubbles: true, cancelable: true},
-    },
-    reset: {
-      EventType: 'Event',
-      defaultInit: {bubbles: true, cancelable: true},
-    },
-    // Mouse Events
-    click: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, button: 0, composed: true},
-    },
-    contextMenu: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    dblClick: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    drag: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    dragEnd: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    dragEnter: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    dragExit: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    dragLeave: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    dragOver: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    dragStart: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    drop: {
-      EventType: 'DragEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    mouseDown: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    mouseEnter: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
-    },
-    mouseLeave: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: false, cancelable: false, composed: true},
-    },
-    mouseMove: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    mouseOut: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    mouseOver: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    mouseUp: {
-      EventType: 'MouseEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    // Selection Events
-    select: {
-      EventType: 'Event',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-    // Touch Events
-    touchCancel: {
-      EventType: 'TouchEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    touchEnd: {
-      EventType: 'TouchEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    touchMove: {
-      EventType: 'TouchEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    touchStart: {
-      EventType: 'TouchEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    // UI Events
-    scroll: {
-      EventType: 'UIEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    // Wheel Events
-    wheel: {
-      EventType: 'WheelEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    // Media Events
-    abort: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    canPlay: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    canPlayThrough: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    durationChange: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    emptied: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    encrypted: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    ended: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    loadedData: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    loadedMetadata: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    loadStart: {
-      EventType: 'ProgressEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    pause: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    play: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    playing: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    progress: {
-      EventType: 'ProgressEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    rateChange: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    seeked: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    seeking: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    stalled: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    suspend: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    timeUpdate: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    volumeChange: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    waiting: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    // Image Events
-    load: {
-      EventType: 'UIEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    error: {
-      EventType: 'Event',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    // Animation Events
-    animationStart: {
-      EventType: 'AnimationEvent',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-    animationEnd: {
-      EventType: 'AnimationEvent',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-    animationIteration: {
-      EventType: 'AnimationEvent',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-    // Transition Events
-    transitionEnd: {
-      EventType: 'TransitionEvent',
-      defaultInit: {bubbles: true, cancelable: true},
-    },
-    // pointer events
-    pointerOver: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    pointerEnter: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    pointerDown: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    pointerMove: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    pointerUp: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    pointerCancel: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    pointerOut: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: true, composed: true},
-    },
-    pointerLeave: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: false, cancelable: false},
-    },
-    gotPointerCapture: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    lostPointerCapture: {
-      EventType: 'PointerEvent',
-      defaultInit: {bubbles: true, cancelable: false, composed: true},
-    },
-    // history events
-    popState: {
-      EventType: 'PopStateEvent',
-      defaultInit: {bubbles: true, cancelable: false},
-    },
-  }
-  
-  export const eventAliasMap = {
-    doubleClick: 'dblClick',
-  }
+  // Clipboard Events
+  copy: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  cut: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  paste: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  // Composition Events
+  compositionEnd: {
+    EventType: 'CompositionEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  compositionStart: {
+    EventType: 'CompositionEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  compositionUpdate: {
+    EventType: 'CompositionEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  // Keyboard Events
+  keyDown: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
+  },
+  keyPress: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
+  },
+  keyUp: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {bubbles: true, cancelable: true, charCode: 0, composed: true},
+  },
+  // Focus Events
+  focus: {
+    EventType: 'FocusEvent',
+    defaultInit: {bubbles: false, cancelable: false, composed: true},
+  },
+  blur: {
+    EventType: 'FocusEvent',
+    defaultInit: {bubbles: false, cancelable: false, composed: true},
+  },
+  focusIn: {
+    EventType: 'FocusEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  focusOut: {
+    EventType: 'FocusEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  // Form Events
+  change: {
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+  input: {
+    EventType: 'InputEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  invalid: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: true},
+  },
+  submit: {
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: true},
+  },
+  reset: {
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: true},
+  },
+  // Mouse Events
+  click: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, button: 0, composed: true},
+  },
+  contextMenu: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  dblClick: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  drag: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  dragEnd: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  dragEnter: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  dragExit: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  dragLeave: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  dragOver: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  dragStart: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  drop: {
+    EventType: 'DragEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  mouseDown: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  mouseEnter: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: false, cancelable: false, composed: true},
+  },
+  mouseLeave: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: false, cancelable: false, composed: true},
+  },
+  mouseMove: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  mouseOut: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  mouseOver: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  mouseUp: {
+    EventType: 'MouseEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  // Selection Events
+  select: {
+    EventType: 'Event',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+  // Touch Events
+  touchCancel: {
+    EventType: 'TouchEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  touchEnd: {
+    EventType: 'TouchEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  touchMove: {
+    EventType: 'TouchEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  touchStart: {
+    EventType: 'TouchEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  // UI Events
+  scroll: {
+    EventType: 'UIEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  // Wheel Events
+  wheel: {
+    EventType: 'WheelEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  // Media Events
+  abort: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  canPlay: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  canPlayThrough: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  durationChange: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  emptied: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  encrypted: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  ended: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  loadedData: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  loadedMetadata: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  loadStart: {
+    EventType: 'ProgressEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  pause: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  play: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  playing: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  progress: {
+    EventType: 'ProgressEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  rateChange: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  seeked: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  seeking: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  stalled: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  suspend: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  timeUpdate: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  volumeChange: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  waiting: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  // Image Events
+  load: {
+    EventType: 'UIEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  error: {
+    EventType: 'Event',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  // Animation Events
+  animationStart: {
+    EventType: 'AnimationEvent',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+  animationEnd: {
+    EventType: 'AnimationEvent',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+  animationIteration: {
+    EventType: 'AnimationEvent',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+  // Transition Events
+  transitionEnd: {
+    EventType: 'TransitionEvent',
+    defaultInit: {bubbles: true, cancelable: true},
+  },
+  // pointer events
+  pointerOver: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  pointerEnter: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  pointerDown: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  pointerMove: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  pointerUp: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  pointerCancel: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  pointerOut: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: true, composed: true},
+  },
+  pointerLeave: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
+  gotPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  lostPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {bubbles: true, cancelable: false, composed: true},
+  },
+  // history events
+  popState: {
+    EventType: 'PopStateEvent',
+    defaultInit: {bubbles: true, cancelable: false},
+  },
+}
+
+export const eventAliasMap = {
+  doubleClick: 'dblClick',
+}

--- a/src/wait-for-element-to-be-removed.js
+++ b/src/wait-for-element-to-be-removed.js
@@ -20,7 +20,7 @@ async function waitForElementToBeRemoved(callback, options) {
     const elements = Array.isArray(callback) ? callback : [callback]
     const getRemainingElements = elements.map(element => {
       let parent = element.parentElement
-      if(parent === null) return () => null
+      if (parent === null) return () => null
       while (parent.parentElement) parent = parent.parentElement
       return () => (parent.contains(element) ? element : null)
     })

--- a/types/get-node-text.d.ts
+++ b/types/get-node-text.d.ts
@@ -1,1 +1,1 @@
-export function getNodeText(node: HTMLElement): string;
+export function getNodeText(node: HTMLElement): string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,25 +1,25 @@
 // TypeScript Version: 3.8
 
-import { getQueriesForElement } from './get-queries-for-element';
-import * as queries from './queries';
-import * as queryHelpers from './query-helpers';
+import {getQueriesForElement} from './get-queries-for-element'
+import * as queries from './queries'
+import * as queryHelpers from './query-helpers'
 
-declare const within: typeof getQueriesForElement;
-export { queries, queryHelpers, within };
+declare const within: typeof getQueriesForElement
+export {queries, queryHelpers, within}
 
-export * from './queries';
-export * from './query-helpers';
-export * from './screen';
-export * from './wait';
-export * from './wait-for';
-export * from './wait-for-dom-change';
-export * from './wait-for-element';
-export * from './wait-for-element-to-be-removed';
-export * from './matches';
-export * from './get-node-text';
-export * from './events';
-export * from './get-queries-for-element';
-export * from './pretty-dom';
-export * from './role-helpers';
-export * from './config';
-export * from './suggestions';
+export * from './queries'
+export * from './query-helpers'
+export * from './screen'
+export * from './wait'
+export * from './wait-for'
+export * from './wait-for-dom-change'
+export * from './wait-for-element'
+export * from './wait-for-element-to-be-removed'
+export * from './matches'
+export * from './get-node-text'
+export * from './events'
+export * from './get-queries-for-element'
+export * from './pretty-dom'
+export * from './role-helpers'
+export * from './config'
+export * from './suggestions'

--- a/types/wait-for-dom-change.d.ts
+++ b/types/wait-for-dom-change.d.ts
@@ -1,7 +1,7 @@
-import { waitForOptions } from "./wait-for";
+import {waitForOptions} from './wait-for'
 
 /**
  * @deprecated `waitForDomChange` has been deprecated.
  * Use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.
  */
-export function waitForDomChange(options?: waitForOptions): Promise<any>;
+export function waitForDomChange(options?: waitForOptions): Promise<any>

--- a/types/wait-for-element.d.ts
+++ b/types/wait-for-element.d.ts
@@ -1,8 +1,11 @@
-import { waitForOptions } from "./wait-for";
+import {waitForOptions} from './wait-for'
 
 /**
  * @deprecated `waitForElement` has been deprecated.
  * Use a `find*` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby)
  * or use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor
  */
-export function waitForElement<T>(callback: () => T, options?: waitForOptions): Promise<T>;
+export function waitForElement<T>(
+  callback: () => T,
+  options?: waitForOptions,
+): Promise<T>

--- a/types/wait.d.ts
+++ b/types/wait.d.ts
@@ -4,9 +4,9 @@
  * Learn more: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.
  */
 export function wait(
-    callback?: () => void,
-    options?: {
-        timeout?: number;
-        interval?: number;
-    },
-): Promise<void>;
+  callback?: () => void,
+  options?: {
+    timeout?: number
+    interval?: number
+  },
+): Promise<void>


### PR DESCRIPTION


**What**:

- format codebase 
- fail CI if changed code isn't formatted (proof-of-concept: https://github.com/testing-library/dom-testing-library/runs/2519546268)

**Why**:

Codeformat is beginning to drift. It adds noise to PRs if unrelated code looks like it changed at first glance.

**How**:

- `npm run kcd-scripts format` locally
- `npm run kcd-scripts format -- --check` in CI

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
