### PR TITLE
fix: Consider `<output />` labelable

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/aria-query": "^4.2.0",
     "aria-query": "^4.2.2",
     "chalk": "^4.1.0",
-    "dom-accessibility-api": "^0.5.5",
+    "dom-accessibility-api": "^0.5.6",
     "lz-string": "^1.4.4",
     "pretty-format": "^26.6.2"
   },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/dom-testing-library/issues/866

**Why**:

`<output />` is labelable

**How**:

Bump `dom-accessibility-api` to include https://github.com/eps1lon/dom-accessibility-api/pull/666

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests (tested in https://github.com/eps1lon/dom-accessibility-api/pull/666)
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
