### PR TITLE
feat: Drop support for node 10

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["github/kentcdodds/react-testing-library-examples"]
+  "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
+  "node": "12"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
       matrix:
-        node: [10.14.2, 12, 14, 15, 16]
+        node: [12, 14, 16]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",
   "license": "MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",


### PR DESCRIPTION
BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.

**What**:

Closes https://github.com/testing-library/dom-testing-library/pull/975
Closes https://github.com/testing-library/dom-testing-library/issues/957

**Why**:

Reduces maintenance burden

**How**:

Change `engines` field to require `node>=12`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
	 Will do once we release the alpha
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged

