### PR TITLE
test(waitFor): Add current behavior for legacy fake timers and requestAnimationFrame

### DIFF
--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -79,3 +79,42 @@ test('recursive timers do not cause issues', async () => {
 
   recurse = false
 })
+
+test('legacy fake timers do not waitFor requestAnimationFrame', async () => {
+  jest.useFakeTimers('legacy')
+
+  let exited = false
+  requestAnimationFrame(() => {
+    exited = true
+  })
+
+  await expect(async () => {
+    await waitFor(() => {
+      expect(exited).toBe(true)
+    })
+  }).rejects.toThrowErrorMatchingInlineSnapshot(`
+          "expect(received).toBe(expected) // Object.is equality
+
+          Expected: true
+          Received: false
+
+          Ignored nodes: comments, <script />, <style />
+          <html>
+            <head />
+            <body />
+          </html>"
+        `)
+})
+
+test('modern fake timers do waitFor requestAnimationFrame', async () => {
+  jest.useFakeTimers('modern')
+
+  let exited = false
+  requestAnimationFrame(() => {
+    exited = true
+  })
+
+  await waitFor(() => {
+    expect(exited).toBe(true)
+  })
+})

--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -80,6 +80,7 @@ test('recursive timers do not cause issues', async () => {
   recurse = false
 })
 
+// TODO: Should fail i.e. work the same as with "modern fake timers" once https://github.com/facebook/jest/pull/11567 is released.
 test('legacy fake timers do not waitFor requestAnimationFrame', async () => {
   jest.useFakeTimers('legacy')
 


### PR DESCRIPTION
Identified the bug when trying out v8 alpha in react-spectrum. Waiting for release of https://github.com/facebook/jest/pull/11567

**What**:

Add a test for a bug caused by https://github.com/facebook/jest/issues/11565

**Why**:

Hoping that we can work around this bug in any way. Would appreciate if anybody got some insight.

**How**:

Add a test when where we `waitFor` `requestAnimationFrame`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
