### PR TITLE
Draft: added typescript types to waitfor functions

### DIFF
--- a/src/wait-for-dom-change.ts
+++ b/src/wait-for-dom-change.ts
@@ -1,3 +1,4 @@
+import {waitForOptions} from '../types'
 import {
   getWindowFromNode,
   getDocument,
@@ -22,7 +23,7 @@ function waitForDomChange({
     attributes: true,
     characterData: true,
   },
-} = {}) {
+}: waitForOptions = {}) {
   if (!hasWarned) {
     hasWarned = true
     console.warn(
@@ -37,17 +38,19 @@ function waitForDomChange({
       observer.observe(container, mutationObserverOptions),
     )
 
-    function onDone(error, result) {
-      clearTimeout(timer)
+    function onDone(error: Error | null, result: MutationRecord[] | null) {
+      ;(clearTimeout as (t: NodeJS.Timeout | number) => void)(timer)
       setImmediate(() => observer.disconnect())
       if (error) {
         reject(error)
       } else {
-        resolve(result)
+        // either error or result is null, so if error is null then result is not
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        resolve(result!)
       }
     }
 
-    function onMutation(mutationsList) {
+    function onMutation(mutationsList: MutationRecord[]) {
       onDone(null, mutationsList)
     }
 
@@ -57,8 +60,8 @@ function waitForDomChange({
   })
 }
 
-function waitForDomChangeWrapper(...args) {
-  return getConfig().asyncWrapper(() => waitForDomChange(...args))
+function waitForDomChangeWrapper(options?: waitForOptions) {
+  return getConfig().asyncWrapper(() => waitForDomChange(options))
 }
 
 export {waitForDomChangeWrapper as waitForDomChange}

--- a/src/wait-for-element-to-be-removed.ts
+++ b/src/wait-for-element-to-be-removed.ts
@@ -1,10 +1,14 @@
+import {waitForOptions} from '../types'
 import {waitFor} from './wait-for'
 
-const isRemoved = result => !result || (Array.isArray(result) && !result.length)
+type Result = (Node | null)[] | Node | null
+
+const isRemoved = (result: Result): boolean =>
+  !result || (Array.isArray(result) && !result.length)
 
 // Check if the element is not present.
 // As the name implies, waitForElementToBeRemoved should check `present` --> `removed`
-function initialCheck(elements) {
+function initialCheck(elements: Result): void {
   if (isRemoved(elements)) {
     throw new Error(
       'The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.',
@@ -12,20 +16,25 @@ function initialCheck(elements) {
   }
 }
 
-async function waitForElementToBeRemoved(callback, options) {
+async function waitForElementToBeRemoved(
+  arg: Result | (() => Result),
+  options?: waitForOptions,
+): Promise<void> {
   // created here so we get a nice stacktrace
   const timeoutError = new Error('Timed out in waitForElementToBeRemoved.')
-  if (typeof callback !== 'function') {
-    initialCheck(callback)
-    const elements = Array.isArray(callback) ? callback : [callback]
+
+  function handleArg(argument: Result): () => Result {
+    initialCheck(argument)
+    const elements = Array.isArray(argument) ? argument : [argument]
     const getRemainingElements = elements.map(element => {
-      let parent = element.parentElement
-      if (parent === null) return () => null
+      let parent = element?.parentElement
+      if (!parent) return () => null
       while (parent.parentElement) parent = parent.parentElement
-      return () => (parent.contains(element) ? element : null)
+      return () => (parent?.contains(element) ? element : null)
     })
-    callback = () => getRemainingElements.map(c => c()).filter(Boolean)
+    return () => getRemainingElements.map(c => c()).filter(Boolean)
   }
+  const callback = typeof arg === 'function' ? arg : handleArg(arg)
 
   initialCheck(callback())
 
@@ -33,8 +42,8 @@ async function waitForElementToBeRemoved(callback, options) {
     let result
     try {
       result = callback()
-    } catch (error) {
-      if (error.name === 'TestingLibraryElementError') {
+    } catch (error: unknown) {
+      if ((error as Error).name === 'TestingLibraryElementError') {
         return undefined
       }
       throw error

--- a/src/wait-for-element.ts
+++ b/src/wait-for-element.ts
@@ -1,3 +1,4 @@
+import {waitForOptions} from '../types'
 import {waitFor} from './wait-for'
 
 let hasWarned = false
@@ -5,13 +6,17 @@ let hasWarned = false
 // deprecated... TODO: remove this method. People should use a find* query or
 // wait instead the reasoning is that this doesn't really do anything useful
 // that you can't get from using find* or wait.
-async function waitForElement(callback, options) {
+async function waitForElement<T>(
+  callback: () => T,
+  options?: waitForOptions,
+): Promise<T> {
   if (!hasWarned) {
     hasWarned = true
     console.warn(
       `\`waitForElement\` has been deprecated. Use a \`find*\` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor`,
     )
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!callback) {
     throw new Error('waitForElement requires a callback as the first parameter')
   }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,15 +1,13 @@
 export interface Config {
   testIdAttribute: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  asyncWrapper(cb: (...args: any[]) => any): Promise<any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  eventWrapper(cb: (...args: any[]) => any): void
+  asyncWrapper<T>(cb: () => Promise<T>): Promise<T>
+  eventWrapper(cb: () => void): void
   asyncUtilTimeout: number
   computedStyleSupportsPseudoElements: boolean
   defaultHidden: boolean
   showOriginalStackTrace: boolean
   throwSuggestions: boolean
-  getElementError: (message: string | null, container: Element) => Error
+  getElementError: (message: string | null, container: Node) => Error
 }
 
 export interface ConfigFn {

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -1,25 +1,21 @@
 export type EventType =
-  | 'copy'
-  | 'cut'
-  | 'paste'
+  | 'abort'
+  | 'animationEnd'
+  | 'animationIteration'
+  | 'animationStart'
+  | 'blur'
+  | 'canPlay'
+  | 'canPlayThrough'
+  | 'change'
+  | 'click'
   | 'compositionEnd'
   | 'compositionStart'
   | 'compositionUpdate'
-  | 'keyDown'
-  | 'keyPress'
-  | 'keyUp'
-  | 'focus'
-  | 'blur'
-  | 'focusIn'
-  | 'focusOut'
-  | 'change'
-  | 'input'
-  | 'invalid'
-  | 'submit'
-  | 'reset'
-  | 'click'
   | 'contextMenu'
+  | 'copy'
+  | 'cut'
   | 'dblClick'
+  | 'doubleClick'
   | 'drag'
   | 'dragEnd'
   | 'dragEnter'
@@ -28,6 +24,25 @@ export type EventType =
   | 'dragOver'
   | 'dragStart'
   | 'drop'
+  | 'durationChange'
+  | 'emptied'
+  | 'encrypted'
+  | 'ended'
+  | 'error'
+  | 'focus'
+  | 'focusIn'
+  | 'focusOut'
+  | 'gotPointerCapture'
+  | 'input'
+  | 'invalid'
+  | 'keyDown'
+  | 'keyPress'
+  | 'keyUp'
+  | 'load'
+  | 'loadedData'
+  | 'loadedMetadata'
+  | 'loadStart'
+  | 'lostPointerCapture'
   | 'mouseDown'
   | 'mouseEnter'
   | 'mouseLeave'
@@ -35,76 +50,61 @@ export type EventType =
   | 'mouseOut'
   | 'mouseOver'
   | 'mouseUp'
+  | 'paste'
+  | 'pause'
+  | 'play'
+  | 'playing'
+  | 'pointerCancel'
+  | 'pointerDown'
+  | 'pointerEnter'
+  | 'pointerLeave'
+  | 'pointerMove'
+  | 'pointerOut'
+  | 'pointerOver'
+  | 'pointerUp'
   | 'popState'
+  | 'progress'
+  | 'rateChange'
+  | 'reset'
+  | 'scroll'
+  | 'seeked'
+  | 'seeking'
   | 'select'
+  | 'stalled'
+  | 'submit'
+  | 'suspend'
+  | 'timeUpdate'
   | 'touchCancel'
   | 'touchEnd'
   | 'touchMove'
   | 'touchStart'
-  | 'scroll'
-  | 'wheel'
-  | 'abort'
-  | 'canPlay'
-  | 'canPlayThrough'
-  | 'durationChange'
-  | 'emptied'
-  | 'encrypted'
-  | 'ended'
-  | 'loadedData'
-  | 'loadedMetadata'
-  | 'loadStart'
-  | 'pause'
-  | 'play'
-  | 'playing'
-  | 'progress'
-  | 'rateChange'
-  | 'seeked'
-  | 'seeking'
-  | 'stalled'
-  | 'suspend'
-  | 'timeUpdate'
+  | 'transitionEnd'
   | 'volumeChange'
   | 'waiting'
-  | 'load'
-  | 'error'
-  | 'animationStart'
-  | 'animationEnd'
-  | 'animationIteration'
-  | 'transitionEnd'
-  | 'doubleClick'
-  | 'pointerOver'
-  | 'pointerEnter'
-  | 'pointerDown'
-  | 'pointerMove'
-  | 'pointerUp'
-  | 'pointerCancel'
-  | 'pointerOut'
-  | 'pointerLeave'
-  | 'gotPointerCapture'
-  | 'lostPointerCapture'
+  | 'wheel'
 
 export type FireFunction = (
-  element: Document | Element | Window | Node,
+  element: Document | Element | Node | Window,
   event: Event,
 ) => boolean
 export type FireObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Node | Window,
     options?: {},
   ) => boolean
 }
 export type CreateFunction = (
   eventName: string,
-  node: Document | Element | Window | Node,
+  node: Document | Element | Node | Window,
   init?: {},
   options?: {EventType?: string; defaultInit?: {}},
 ) => Event
 export type CreateObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Node | Window,
     options?: {},
   ) => Event
 }
 
-export const createEvent: CreateObject & CreateFunction
+export const createEvent: CreateFunction & CreateObject
 export const fireEvent: FireFunction & FireObject

--- a/types/wait-for.d.ts
+++ b/types/wait-for.d.ts
@@ -1,9 +1,10 @@
 export interface waitForOptions {
-  container?: HTMLElement
+  container?: Node
   timeout?: number
   interval?: number
   onTimeout?: (error: Error) => Error
   mutationObserverOptions?: MutationObserverInit
+  showOriginalStackTrace?: boolean
 }
 
 export function waitFor<T>(


### PR DESCRIPTION
**What**:

Converted 5 files from `.js` to `.ts`.  All files relate the `waitFor` functions.

**Why**:

This PR continues the conversion of the codebase to TypeScript - issue #494 

**How**:

- Added type annotations to function arguments and return values.
- Used type assertions where the TS type is too broad to access the desired property, for example `(error as Error).name` and `(node as unknown) as Screen).debug`.
- Broadened existing types from `Element` or `HTMLElement` to `Node` in a few places in order to match the implementation, which shows that the container could be a `Document` as well.
- Typed the `node` argument in the `getWindowFromNode` function as an object that *maybe* has properties of a `Window`, `Document`, or `Element`.  This allows access to these properties without `as` assertion.
- Created interface for `timerApi` object to avoid TS errors when adding additional properties after the object has been created.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [ ] Ready to be merged

**Issues**

I'm considering this a draft because I still have lingering questions where I'm not sure of the desired behavior.

My biggest confusion is the `setTimeout` / `clearTimeout` functions.  The type for a timeout is a `number` in the DOM and a `NodeJS.Timeout` object in node.  **Which one is it at runtime?**  Can it be either, or can it be typed cleanly as just one?  The inferred type from using the global `clearTimeout` variable is that it's either a function which takes a `number` or a function that takes a `NodeJS.Timeout` object.  This creates an impossible function which cannot be called, as we don't know which of the two arguments it takes.  I've had to circumvent it with a nasty type assertion that allows the function to be called with either type.
```
(clearTimeout as (t: NodeJS.Timeout | number) => void)(timer)
```

I'm happy to explain the logic behind any of these changes.

There's a lot more assertions then I would normally make if I was writing this code from scratch.  I generally prefer type guard functions, which refine the type of the variable when `true`.  For example the `isPromise` function which I put in the `wait-for.ts` file would be better placed in utilities file where it can be exported and used in multiple places.  Then this mess in `helpers.ts` 
```
if (((node as unknown) as Promise<unknown>).then instanceof Function)
```
can be replaced with
```
if (isPromise(node))
``` 
Is that acceptable and/or desirable?  To me it seems like a no-brainer but I am trying to limit the scope of my changes as much as possible.