### PR TITLE
chore: PrettyFormatOptions -> PrettyDOMOptions

### DIFF
--- a/types/pretty-dom.d.ts
+++ b/types/pretty-dom.d.ts
@@ -1,6 +1,6 @@
 import * as prettyFormat from 'pretty-format'
 
-export interface PrettyFormatOptions extends prettyFormat.OptionsReceived {
+export interface PrettyDOMOptions extends prettyFormat.OptionsReceived {
   /**
    * Given a `Node` return `false` if you wish to ignore that node in the output.
    * By default, ignores `<style />`, `<script />` and comment nodes.
@@ -11,11 +11,11 @@ export interface PrettyFormatOptions extends prettyFormat.OptionsReceived {
 export function prettyDOM(
   dom?: Element | HTMLDocument,
   maxLength?: number,
-  options?: PrettyFormatOptions,
+  options?: PrettyDOMOptions,
 ): string | false
 export function logDOM(
   dom?: Element | HTMLDocument,
   maxLength?: number,
-  options?: PrettyFormatOptions,
+  options?: PrettyDOMOptions,
 ): void
 export {prettyFormat}


### PR DESCRIPTION

**What**:

In response to https://github.com/testing-library/dom-testing-library/pull/979#issuecomment-862974030. Follow-up to https://github.com/testing-library/dom-testing-library/pull/907

**Why**:

These options are passed to `prettyDOM` not `pretty-format`

**How**:

Rename PrettyFormatOptions -> PrettyDOMOptions

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
