### PR TITLE
test(fake-timers): raf is now mocked in legacy fake timers

### DIFF
--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -80,8 +80,7 @@ test('recursive timers do not cause issues', async () => {
   recurse = false
 })
 
-// TODO: Should fail i.e. work the same as with "modern fake timers" once https://github.com/facebook/jest/pull/11567 is released.
-test('legacy fake timers do not waitFor requestAnimationFrame', async () => {
+test('legacy fake timers do waitFor requestAnimationFrame', async () => {
   jest.useFakeTimers('legacy')
 
   let exited = false
@@ -89,22 +88,9 @@ test('legacy fake timers do not waitFor requestAnimationFrame', async () => {
     exited = true
   })
 
-  await expect(async () => {
-    await waitFor(() => {
-      expect(exited).toBe(true)
-    })
-  }).rejects.toThrowErrorMatchingInlineSnapshot(`
-          "expect(received).toBe(expected) // Object.is equality
-
-          Expected: true
-          Received: false
-
-          Ignored nodes: comments, <script />, <style />
-          <html>
-            <head />
-            <body />
-          </html>"
-        `)
+  await waitFor(() => {
+    expect(exited).toBe(true)
+  })
 })
 
 test('modern fake timers do waitFor requestAnimationFrame', async () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix tests.

**Why**:

To be able to release

**How**:

Normalize requestAnimationFrame related tests across legacy and modern timers after https://github.com/facebook/jest/pull/11567 was released

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
