### PR TITLE
feat(fireEvent): Add resize event

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -167,6 +167,14 @@ eventTypes.forEach(({type, events, elementType}) => {
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
+
+    it('fires resize', () => {
+      const node = document.defaultView
+      const spy = jest.fn()
+      node.addEventListener('resize', spy, {once: true})
+      fireEvent.resize(node)
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
   })
 })
 

--- a/src/event-map.js
+++ b/src/event-map.js
@@ -172,6 +172,10 @@ export const eventMap = {
     defaultInit: {bubbles: true, cancelable: true, composed: true},
   },
   // UI Events
+  resize: {
+    EventType: 'UIEvent',
+    defaultInit: {bubbles: false, cancelable: false},
+  },
   scroll: {
     EventType: 'UIEvent',
     defaultInit: {bubbles: false, cancelable: false},

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -41,6 +41,7 @@ export type EventType =
   | 'touchEnd'
   | 'touchMove'
   | 'touchStart'
+  | 'resize'
   | 'scroll'
   | 'wheel'
   | 'abort'


### PR DESCRIPTION


**What**:

Closes https://github.com/testing-library/dom-testing-library/issues/179 (was closed without adding resize event)

**Why**:

Enables automatic wrapping of resize events with `act` in /react via `fireEvent.resize`.

**How**:

Add the appropriate config. There's no verification for the event target since we never check if the event target is valid.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) (Documentation points to source)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
