### PR TITLE
Check if observer is undefined before attempting to disconnect

### DIFF
--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -109,7 +109,7 @@ function waitFor(
 
       if (!usingJestFakeTimers) {
         clearInterval(intervalId)
-        observer.disconnect()
+        observer && observer.disconnect()
       }
 
       if (error) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: We are not checking if MutationObserver is still defined. In some cases, the method that calls the waitFor can be overwritten, causing the attempt to disconnect to be null.

<!-- Why are these changes necessary? -->

**Why**: We are now checking if the observer is still defined before attempting to disconnect.

<!-- How were these changes implemented? -->

**How**:  I added a truthy check for calling the disconnect method and ran test coverage. (not sure what to write here)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
