### PR TITLE
feature: add support for filtering roles by nodeText

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -572,3 +572,9 @@ test('should find the input using type property instead of attribute', () => {
   const {getByRole} = render('<input type="124">')
   expect(getByRole('textbox')).not.toBeNull()
 })
+
+test('can be filtered by text node', () => {})
+
+test('text node comparison is case sensitive', () => {})
+
+test('text node filter implements TextMatch', () => {})

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -17,6 +17,7 @@ import {
   buildQueries,
   fuzzyMatches,
   getConfig,
+  getNodeText,
   makeNormalizer,
   matches,
 } from './all-utils'
@@ -37,6 +38,7 @@ function queryAllByRole(
     pressed,
     level,
     expanded,
+    nodeText,
   } = {},
 ) {
   checkContainerType(container)
@@ -141,6 +143,9 @@ function queryAllByRole(
         : true
     })
     .filter(element => {
+      if (nodeText !== undefined) {
+        return matches(getNodeText(element), element, name, text => text)
+      }
       if (name === undefined) {
         // Don't care
         return true

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -111,6 +111,16 @@ export interface ByRoleOptions extends MatcherOptions {
     | RegExp
     | string
     | ((accessibleName: string, element: Element) => boolean)
+
+  /**
+   * Only considers elements with the specified text value.
+   * For example, *ByRole('button', {nodeText: 'Cancel'})` will find <button>Cancel</button>`.
+   * Generally the `name` option is preferred, however `nodeText` can be used if `name` is causing
+   * performance concerns.
+   *
+   * If `exact` is specified, casing will be considered.
+   */
+  nodeText?: Matcher
 }
 
 export type AllByRole = (


### PR DESCRIPTION
**What**:

Adds filtering by textNode to `*ByRole` queries.

**Why**:

See the discussion here: https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-901339981

**How**:

- Followed patterns used in the ByText query
- Scaffolded tests based on `*ByRole` name filters.  Tests to be implemented once the idea has been approved.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
