### PR TITLE
fix: support getting text of inputs of type `reset`

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -133,15 +133,17 @@ test('can get elements by matching their text across adjacent text nodes', () =>
   expect(queryByText('£24.99')).toBeTruthy()
 })
 
-test('can get input elements with type submit or button', () => {
+test('can get input elements with type submit, button, or reset', () => {
   const {queryByText} = render(`
     <div>
       <input type="submit" value="Send data"/>
+      <input type="reset" value="Clear EVERYTHING"/>
       <input type="button" value="Push me!"/>
       <input type="text" value="user data" />
     </div>
   `)
   expect(queryByText('Send data')).toBeTruthy()
+  expect(queryByText('Clear EVERYTHING')).toBeTruthy()
   expect(queryByText('Push me!')).toBeTruthy()
   expect(queryByText('user data')).toBeFalsy()
 })

--- a/src/get-node-text.ts
+++ b/src/get-node-text.ts
@@ -1,7 +1,9 @@
 import {TEXT_NODE} from './helpers'
 
 function getNodeText(node: HTMLElement): string {
-  if (node.matches('input[type=submit], input[type=button]')) {
+  if (
+    node.matches('input[type=submit], input[type=button], input[type=reset]')
+  ) {
     return (node as HTMLInputElement).value
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Currently doing `screen.getByText('Reset')` results in an error about being unable to find the text if you're testing for an input like so:

```
export const Form: React.FC<Props> = props => (
  <form onSubmit={props.onSubmit} onReset={props.onReset}>
    {props.children}
    <br />
    <input type="submit" value="Submit" />
    {props.onReset && <input type="reset" value="Reset" />}
  </form>
);
```

But this works fine if you try and select the "submit" input in the same manner: `screen.getByText('Submit')`

**Why**:

<!-- How were these changes implemented? -->

https://github.com/testing-library/dom-testing-library/pull/185 added support for treating inputs of type `submit` & `button` as if they have text, but it left out `reset` which is the third "type" that has this behaviour.

**How**:

<!-- Have you done all of these things?  -->

I've adjusted the query to include `type=reset`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A I think (I couldn't find docs on this specific behaviour)
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->