### PR TITLE
Restore prettyDOM logging for Cypress

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1,10 +1,6 @@
 import {configure} from '../config'
 import {render, renderIntoDocument} from './helpers/test-utils'
 
-beforeEach(() => {
-  document.defaultView.Cypress = null
-})
-
 test('query can return null', () => {
   const {
     queryByLabelText,
@@ -1059,46 +1055,6 @@ test('the debug helper prints the dom state here', () => {
 
   //all good replacing it with old value
   process.env.DEBUG_PRINT_LIMIT = originalDebugPrintLimit
-})
-
-test('get throws a useful error message without DOM in Cypress', () => {
-  document.defaultView.Cypress = {}
-  const {
-    getByLabelText,
-    getByPlaceholderText,
-    getByText,
-    getByTestId,
-    getByAltText,
-    getByTitle,
-    getByDisplayValue,
-  } = render('<div />')
-  expect(() =>
-    getByLabelText('LucyRicardo'),
-  ).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find a label with the text of: LucyRicardo`,
-  )
-  expect(() =>
-    getByPlaceholderText('LucyRicardo'),
-  ).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element with the placeholder text of: LucyRicardo`,
-  )
-  expect(() => getByText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.`,
-  )
-  expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element by: [data-testid="LucyRicardo"]`,
-  )
-  expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element with the alt text: LucyRicardo`,
-  )
-  expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element with the title: LucyRicardo.`,
-  )
-  expect(() =>
-    getByDisplayValue('LucyRicardo'),
-  ).toThrowErrorMatchingInlineSnapshot(
-    `Unable to find an element with the display value: LucyRicardo.`,
-  )
 })
 
 test('getByText ignores script tags by default', () => {

--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -26,6 +26,14 @@ test('prettyDOM prints out the given DOM element tree', () => {
 test('prettyDOM supports truncating the output length', () => {
   const {container} = render('<div>Hello World!</div>')
   expect(prettyDOM(container, 5)).toMatch(/\.\.\./)
+  expect(prettyDOM(container, 0)).toMatch('')
+  expect(prettyDOM(container, Number.POSITIVE_INFINITY)).toMatchInlineSnapshot(`
+    "<div>
+      <div>
+        Hello World!
+      </div>
+    </div>"
+  `)
 })
 
 test('prettyDOM defaults to document.body', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,11 +35,7 @@ let config: InternalConfig = {
     const error = new Error(
       [
         message,
-        prettifiedDOM.length > 0
-          ? `Ignored nodes: comments, <script />, <style />\n${prettyDOM(
-              container,
-            )}`
-          : null,
+        `Ignored nodes: comments, <script />, <style />\n${prettifiedDOM}`,
       ]
         .filter(Boolean)
         .join('\n\n'),

--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -4,24 +4,10 @@ import {getUserCodeFrame} from './get-user-code-frame'
 import {getDocument} from './helpers'
 import {DEFAULT_IGNORE_TAGS} from './shared'
 
-function inCypress(dom) {
-  const window =
-    (dom.ownerDocument && dom.ownerDocument.defaultView) || undefined
-  return (
-    (typeof global !== 'undefined' && global.Cypress) ||
-    (typeof window !== 'undefined' && window.Cypress)
-  )
-}
-
 const inNode = () =>
   typeof process !== 'undefined' &&
   process.versions !== undefined &&
   process.versions.node !== undefined
-
-const getMaxLength = dom =>
-  inCypress(dom)
-    ? 0
-    : (typeof process !== 'undefined' && process.env.DEBUG_PRINT_LIMIT) || 7000
 
 const {DOMCollection} = prettyFormat.plugins
 
@@ -43,7 +29,8 @@ function prettyDOM(dom, maxLength, options = {}) {
     dom = getDocument().body
   }
   if (typeof maxLength !== 'number') {
-    maxLength = getMaxLength(dom)
+    maxLength =
+      (typeof process !== 'undefined' && process.env.DEBUG_PRINT_LIMIT) || 7000
   }
 
   if (maxLength === 0) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR brings back the `prettyDOM` logging when the library is used within a cypress test (including from within cypress-testing-library)
<!-- Why are these changes necessary? -->

**Why**:
https://github.com/testing-library/cypress-testing-library/issues/172

Back in 2018, a decision was made to remove prettyDOM logging when used within a Cypress test. This was done because Cypress's default subject is the full document, and pretty-printing the `outerHTML` of the entire document would occasionally cause memory errors. 

This change was made here- https://github.com/testing-library/dom-testing-library/pull/336/files#diff-2a50dc385b740f1ed6423e95977cc8dcccced5b7d8088e1dd7a02d062872cf1eR18-R19

Discussion around the decision is here - https://github.com/testing-library/dom-testing-library/issues/44#issuecomment-392287703

Since then, a number of changes have been made to the prettyDOM function that removes (lessens?) this risk. Most importantly, there is now a default max length on these error messages of 7000 characters.

Users also have the ability to opt into defining their own messages printed from the library by passing a `getElementError(message, container)` function when performing the initial configuration for the cypress-testing-library.

<!-- How were these changes implemented? -->

**How**:
Via extensive use of `DEL` key
I've removed the Cypress-specific checks that were implemented in prettyDOM, and removed the test checking for this behavior.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] TypeScript definitions updated N/A
- [x] Ready to be merged 
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
