### PR TITLE
fix: Use syntax compatible with older TypeScript versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       # Otherwise we would not know if the problem is tied to the Node.js version
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, '^16.9.1']
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -3,7 +3,7 @@ import {waitForOptions} from './wait-for'
 
 export type WithSuggest = {suggest?: boolean}
 
-export type GetErrorFunction<Arguments extends any[] = [alt: string]> = (
+export type GetErrorFunction<Arguments extends any[] = [string]> = (
   c: Element | null,
   ...args: Arguments
 ) => string


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/dom-testing-library/issues/1025

**Why**:

https://github.com/testing-library/dom-testing-library/pull/1016 introduce syntax that's not compatible with older TypeScript versions.

**How**:

Don't label tuple members.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
