### PR TITLE
test: Run full matrix even if a single job fails

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,8 @@ jobs:
     # ignore all-contributors PRs
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
+      # Otherwise we would not know if the problem is tied to the Node.js version
+      fail-fast: false
       matrix:
         node: [12, 14, 16]
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The validate pipeline previously immediately stopped once a single job failed. Now we complete every job even if another fails.

**Why**:

This made it impossible to know if an issue is invariant across the test matrix or tied to a specific value.

**How**:

Disable `fail-fast`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
