### PR TITLE
Tweak `waitFor` to not bottleneck async tasks

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -255,3 +255,27 @@ test('the real timers => fake timers error shows the original stack trace when c
 
   expect((await waitForError).stack).not.toMatch(__dirname)
 })
+
+test('allow further async tasks to complete after the MutationObserver callback fired', async () => {
+  jest.useRealTimers()
+  renderIntoDocument(`<div id="async">a</div>`)
+  let waitForCount = 0
+  const el = document.getElementById('async')
+  const update = () => {
+    setTimeout(() => {
+      el.textContent += 'a'
+    }, 1)
+  }
+
+  update()
+  update()
+  update()
+
+  await waitFor(() => {
+    waitForCount++
+    expect(el).toHaveTextContent('aaaa')
+  })
+
+  // initial sync check + mutation check
+  expect(waitForCount).toBe(2)
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I'm addressing issues with `waitFor` bottlenecking async tasks and ultimately timing out in some cases. Ref: https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-911629625

<!-- Why are these changes necessary? -->

**Why**: The `MutationObserver` callback can fire quite often, and if the check is slow/expensive, it can prevent async tasks from being run to completion in a timely manner, ultimately leading to `waitFor` timing out. Similarly, `setInterval` can queue a new task before the check is complete, so now the "interval" will be between the end of the previous check and the beginning of the next check, instead of between the start of two checks. The "interval" is where async work can actually run, so it's wise to relinquish the main thread to non-test code during that time.

<!-- How were these changes implemented? -->

**How**: Added a delay in the `MutationObserver` callback, swapped `setInterval` for `setTimeout`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
There are 2 non-covered lines now, let me know if you want me to try and add more tests to cover them.