### PR TITLE
feat: Make findBy/getBy return an non-empty array

### DIFF
--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -2,6 +2,8 @@ import {ByRoleMatcher, Matcher, MatcherOptions} from './matches'
 import {SelectorMatcherOptions} from './query-helpers'
 import {waitForOptions} from './wait-for'
 
+type NonEmptyArray<T> = [T, ...T[]]
+
 export type QueryByBoundAttribute<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
   id: Matcher,
@@ -12,14 +14,14 @@ export type AllByBoundAttribute<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
-) => T[]
+) => NonEmptyArray<T>
 
 export type FindAllByBoundAttribute<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: waitForOptions,
-) => Promise<T[]>
+) => Promise<NonEmptyArray<T>>
 
 export type GetByBoundAttribute<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
@@ -44,14 +46,14 @@ export type AllByText<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
-) => T[]
+) => NonEmptyArray<T>
 
 export type FindAllByText<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
   id: Matcher,
   options?: SelectorMatcherOptions,
   waitForElementOptions?: waitForOptions,
-) => Promise<T[]>
+) => Promise<NonEmptyArray<T>>
 
 export type GetByText<T extends HTMLElement = HTMLElement> = (
   container: HTMLElement,
@@ -147,7 +149,7 @@ export type FindAllByRole<T extends HTMLElement = HTMLElement> = (
   role: ByRoleMatcher,
   options?: ByRoleOptions,
   waitForElementOptions?: waitForOptions,
-) => Promise<T[]>
+) => Promise<NonEmptyArray<T>>
 
 export function getByLabelText<T extends HTMLElement = HTMLElement>(
   ...args: Parameters<GetByText<T>>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Make `findAllBy`/`getAllBy` return type a "non-empty" array.
<!-- Why are these changes necessary? -->

**Why**:

These methods will blow if no element is found, so they already return
a non-empty array. The types don't match though. If you enable
`noUncheckedIndexedAccess` you have to manually check the first element
if you want to act upon it.
<!-- How were these changes implemented? -->

**How**:
Defining an array as `[T, ...T[]]` typescript considers the first element to be always defined.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->


I'm not sure how/if this has to be tested and if I need to update any documentation.
<!-- feel free to add additional comments -->
