### PR TITLE
test: Fix inline snapshot mismatch on certain machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/lz-string": "^1.3.34",
     "jest-in-case": "^1.0.2",
-    "jest-serializer-ansi": "^1.0.3",
+    "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.4.0",
     "kcd-scripts": "^11.0.0",

--- a/src/__tests__/__snapshots__/role-helpers.js.snap
+++ b/src/__tests__/__snapshots__/role-helpers.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`logRoles calls console.log with output from prettyRoles 1`] = `
-"region:
+region:
 
 Name "a region":
 <section
@@ -200,5 +200,5 @@ Name "":
   data-testid="a-textarea"
 />
 
---------------------------------------------------"
+--------------------------------------------------
 `;

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -33,72 +33,72 @@ test('get throws a useful error message', () => {
   )
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find a label with the text of: LucyRicardo
+    Unable to find a label with the text of: LucyRicardo
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByPlaceholderText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the placeholder text of: LucyRicardo
+    Unable to find an element with the placeholder text of: LucyRicardo
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+    Unable to find an element with the text: LucyRicardo. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByTestId('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element by: [data-testid="LucyRicardo"]
+    Unable to find an element by: [data-testid="LucyRicardo"]
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByAltText('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the alt text: LucyRicardo
+    Unable to find an element with the alt text: LucyRicardo
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByTitle('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the title: LucyRicardo.
+    Unable to find an element with the title: LucyRicardo.
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByDisplayValue('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the display value: LucyRicardo.
+    Unable to find an element with the display value: LucyRicardo.
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
   expect(() => getByRole('LucyRicardo')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an accessible element with the role "LucyRicardo"
+    Unable to find an accessible element with the role "LucyRicardo"
 
     There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <div />
-    </div>"
+    </div>
   `)
 })
 
@@ -360,14 +360,14 @@ test('label with no form control', () => {
   const {getByLabelText, queryByLabelText} = render(`<label>All alone</label>`)
   expect(queryByLabelText(/alone/)).toBeNull()
   expect(() => getByLabelText(/alone/)).toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <label>
         All alone
       </label>
-    </div>"
+    </div>
   `)
 })
 
@@ -378,7 +378,7 @@ test('label with "for" attribute but no form control and fuzzy matcher', () => {
   expect(queryByLabelText('alone', {exact: false})).toBeNull()
   expect(() => getByLabelText('alone', {exact: false}))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    Found a label with the text of: alone, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
     Ignored nodes: comments, <script />, <style />
     <div>
@@ -387,7 +387,7 @@ test('label with "for" attribute but no form control and fuzzy matcher', () => {
       >
         All alone label
       </label>
-    </div>"
+    </div>
   `)
 })
 
@@ -401,7 +401,7 @@ test('label with children with no form control', () => {
   expect(queryByLabelText(/alone/, {selector: 'input'})).toBeNull()
   expect(() => getByLabelText(/alone/, {selector: 'input'}))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    Found a label with the text of: /alone/, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
     Ignored nodes: comments, <script />, <style />
     <div>
@@ -426,7 +426,7 @@ test('label with children with no form control', () => {
         
       
       </label>
-    </div>"
+    </div>
   `)
 })
 
@@ -442,7 +442,7 @@ test('label with non-labellable element', () => {
 
   expect(queryByLabelText(/Label/)).toBeNull()
   expect(() => getByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
+    Found a label with the text of: /Label/, however the element associated with this label (<div />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <div />, you can use aria-label or aria-labelledby instead.
 
     Ignored nodes: comments, <script />, <style />
     <div>
@@ -470,7 +470,7 @@ test('label with non-labellable element', () => {
       </div>
       
       
-    </div>"
+    </div>
   `)
 })
 
@@ -490,7 +490,7 @@ test('multiple labels with non-labellable elements', () => {
 
   expect(queryAllByLabelText(/Label/)).toEqual([])
   expect(() => getAllByLabelText(/Label/)).toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
+    Found a label with the text of: /Label/, however the element associated with this label (<span />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <span />, you can use aria-label or aria-labelledby instead.
 
     Found a label with the text of: /Label/, however the element associated with this label (<p />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <p />, you can use aria-label or aria-labelledby instead.
 
@@ -536,7 +536,7 @@ test('multiple labels with non-labellable elements', () => {
       </div>
       
       
-    </div>"
+    </div>
   `)
 })
 
@@ -544,12 +544,12 @@ test('totally empty label', () => {
   const {getByLabelText, queryByLabelText} = render(`<label />`)
   expect(queryByLabelText('')).toBeNull()
   expect(() => getByLabelText('')).toThrowErrorMatchingInlineSnapshot(`
-    "Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
+    Found a label with the text of: , however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <label />
-    </div>"
+    </div>
   `)
 })
 
@@ -1183,14 +1183,14 @@ test('return a proper error message when no label is found and there is an aria-
 
   expect(() => getByLabelText('LucyRicardo'))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find a label with the text of: LucyRicardo
+    Unable to find a label with the text of: LucyRicardo
 
     Ignored nodes: comments, <script />, <style />
     <div>
       <input
         aria-labelledby="not-existing-label"
       />
-    </div>"
+    </div>
   `)
 })
 
@@ -1253,7 +1253,7 @@ test('ByText error message ignores not the same elements as configured in `ignor
   expect(() =>
     getByText('.css-selector', {selector: 'style', ignore: 'script'}),
   ).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with the text: .css-selector. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
+    Unable to find an element with the text: .css-selector. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.
 
     Ignored nodes: comments, <script />, <style />
     <body>
@@ -1266,6 +1266,6 @@ test('ByText error message ignores not the same elements as configured in `ignor
       />
       
       
-    </body>"
+    </body>
   `)
 })

--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -15,11 +15,11 @@ afterEach(() => {
 test('prettyDOM prints out the given DOM element tree', () => {
   const {container} = render('<div>Hello World!</div>')
   expect(prettyDOM(container)).toMatchInlineSnapshot(`
-    "<div>
+    <div>
       <div>
         Hello World!
       </div>
-    </div>"
+    </div>
   `)
 })
 
@@ -28,11 +28,11 @@ test('prettyDOM supports truncating the output length', () => {
   expect(prettyDOM(container, 5)).toMatch(/\.\.\./)
   expect(prettyDOM(container, 0)).toMatch('')
   expect(prettyDOM(container, Number.POSITIVE_INFINITY)).toMatchInlineSnapshot(`
-    "<div>
+    <div>
       <div>
         Hello World!
       </div>
-    </div>"
+    </div>
   `)
 })
 
@@ -45,16 +45,34 @@ test('prettyDOM defaults to document.body', () => {
   </body>"
 `
   renderIntoDocument('<div>Hello World!</div>')
-  expect(prettyDOM()).toMatchInlineSnapshot(defaultInlineSnapshot)
-  expect(prettyDOM(null)).toMatchInlineSnapshot(defaultInlineSnapshot)
+  expect(prettyDOM()).toMatchInlineSnapshot(
+    defaultInlineSnapshot,
+    `
+    <body>
+      <div>
+        Hello World!
+      </div>
+    </body>
+  `,
+  )
+  expect(prettyDOM(null)).toMatchInlineSnapshot(
+    defaultInlineSnapshot,
+    `
+    <body>
+      <div>
+        Hello World!
+      </div>
+    </body>
+  `,
+  )
 })
 
 test('prettyDOM supports receiving the document element', () => {
   expect(prettyDOM(document)).toMatchInlineSnapshot(`
-    "<html>
+    <html>
       <head />
       <body />
-    </html>"
+    </html>
   `)
 })
 
@@ -63,11 +81,11 @@ test('logDOM logs prettyDOM to the console', () => {
   logDOM(container)
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "<div>
+    <div>
       <div>
         Hello World!
       </div>
-    </div>"
+    </div>
   `)
 })
 
@@ -85,7 +103,7 @@ test('logDOM logs prettyDOM with code frame to the console', () => {
   logDOM(container)
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "<div>
+    <div>
       <div>
         Hello World!
       </div>
@@ -97,7 +115,7 @@ test('logDOM logs prettyDOM with code frame to the console', () => {
         > 7 |       screen.debug()
             |              ^
         "
-      "
+      
   `)
 })
 
@@ -125,11 +143,11 @@ test('prettyDOM ignores script elements and comments nodes by default', () => {
   )
 
   expect(prettyDOM(container)).toMatchInlineSnapshot(`
-    "<body>
+    <body>
       <p>
         Hello, Dave
       </p>
-    </body>"
+    </body>
   `)
 })
 
@@ -141,7 +159,7 @@ test('prettyDOM can include all elements with a custom filter', () => {
   expect(
     prettyDOM(container, Number.POSITIVE_INFINITY, {filterNode: () => true}),
   ).toMatchInlineSnapshot(`
-    "<body>
+    <body>
       <script
         src="context.js"
       />
@@ -149,6 +167,6 @@ test('prettyDOM can include all elements with a custom filter', () => {
       <p>
         Hello, Dave
       </p>
-    </body>"
+    </body>
   `)
 })

--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -38,33 +38,15 @@ test('prettyDOM supports truncating the output length', () => {
 
 test('prettyDOM defaults to document.body', () => {
   const defaultInlineSnapshot = `
-  "<body>
+  <body>
     <div>
       Hello World!
     </div>
-  </body>"
+  </body>
 `
   renderIntoDocument('<div>Hello World!</div>')
-  expect(prettyDOM()).toMatchInlineSnapshot(
-    defaultInlineSnapshot,
-    `
-    <body>
-      <div>
-        Hello World!
-      </div>
-    </body>
-  `,
-  )
-  expect(prettyDOM(null)).toMatchInlineSnapshot(
-    defaultInlineSnapshot,
-    `
-    <body>
-      <div>
-        Hello World!
-      </div>
-    </body>
-  `,
-  )
+  expect(prettyDOM()).toMatchInlineSnapshot(defaultInlineSnapshot)
+  expect(prettyDOM(null)).toMatchInlineSnapshot(defaultInlineSnapshot)
 })
 
 test('prettyDOM supports receiving the document element', () => {

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -5,100 +5,100 @@ import {render, renderIntoDocument} from './helpers/test-utils'
 test('by default logs accessible roles when it fails', () => {
   const {getByRole} = render(`<h1>Hi</h1>`)
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "article"
+    Unable to find an accessible element with the role "article"
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  heading:
+      heading:
 
-  Name "Hi":
-  <h1 />
+      Name "Hi":
+      <h1 />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <h1>
-    Hi
-  </h1>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <h1>
+        Hi
+      </h1>
+    </div>
+  `)
 })
 
 test('when hidden: true logs available roles when it fails', () => {
   const {getByRole} = render(`<div hidden><h1>Hi</h1></div>`)
   expect(() => getByRole('article', {hidden: true}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "article"
+    Unable to find an element with the role "article"
 
-Here are the available roles:
+    Here are the available roles:
 
-  heading:
+      heading:
 
-  Name "Hi":
-  <h1 />
+      Name "Hi":
+      <h1 />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div
-    hidden=""
-  >
-    <h1>
-      Hi
-    </h1>
-  </div>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div
+        hidden=""
+      >
+        <h1>
+          Hi
+        </h1>
+      </div>
+    </div>
+  `)
 })
 
 test('logs error when there are no accessible roles', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "article"
+    Unable to find an accessible element with the role "article"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div />
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div />
+    </div>
+  `)
 })
 
 test('logs a different error if inaccessible roles should be included', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article', {hidden: true}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an element with the role "article"
+    Unable to find an element with the role "article"
 
-There are no available roles.
+    There are no available roles.
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div />
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div />
+    </div>
+  `)
 })
 
 test('by default excludes elements that have the html hidden attribute or any of their parents', () => {
   const {getByRole} = render('<div hidden><ul /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "list"
+    Unable to find an accessible element with the role "list"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div
-    hidden=""
-  >
-    <ul />
-  </div>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div
+        hidden=""
+      >
+        <ul />
+      </div>
+    </div>
+  `)
 })
 
 test('by default excludes elements which have display: none or any of their parents', () => {
@@ -107,21 +107,21 @@ test('by default excludes elements which have display: none or any of their pare
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "list"
+    Unable to find an accessible element with the role "list"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div
-    style="display: none;"
-  >
-    <ul
-      style="display: block;"
-    />
-  </div>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div
+        style="display: none;"
+      >
+        <ul
+          style="display: block;"
+        />
+      </div>
+    </div>
+  `)
 })
 
 test('by default excludes elements which have visibility hidden', () => {
@@ -130,19 +130,19 @@ test('by default excludes elements which have visibility hidden', () => {
   const {getByRole} = render('<div><ul style="visibility: hidden;" /></div>')
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "list"
+    Unable to find an accessible element with the role "list"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div>
-    <ul
-      style="visibility: hidden;"
-    />
-  </div>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div>
+        <ul
+          style="visibility: hidden;"
+        />
+      </div>
+    </div>
+  `)
 })
 
 test('by default excludes elements which have aria-hidden="true" or any of their parents', () => {
@@ -155,21 +155,21 @@ test('by default excludes elements which have aria-hidden="true" or any of their
   )
 
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "list"
+    Unable to find an accessible element with the role "list"
 
-There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <div
-    aria-hidden="true"
-  >
-    <ul
-      aria-hidden="false"
-    />
-  </div>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <div
+        aria-hidden="true"
+      >
+        <ul
+          aria-hidden="false"
+        />
+      </div>
+    </div>
+  `)
 })
 
 test('considers the computed visibility style not the parent', () => {
@@ -238,27 +238,27 @@ test('accessible name comparison is case sensitive', () => {
 
   expect(() => getByRole('heading', {name: 'something that does not match'}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "heading" and name "something that does not match"
+    Unable to find an accessible element with the role "heading" and name "something that does not match"
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  heading:
+      heading:
 
-  Name "Sign up":
-  <h1 />
+      Name "Sign up":
+      <h1 />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <h1>
-    Sign 
-    <em>
-      up
-    </em>
-  </h1>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <h1>
+        Sign 
+        <em>
+          up
+        </em>
+      </h1>
+    </div>
+  `)
 })
 
 test('accessible name filter implements TextMatch', () => {
@@ -285,51 +285,51 @@ test('TextMatch serialization in error message', () => {
 
   expect(() => getByRole('heading', {name: /something that does not match/}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "heading" and name \`/something that does not match/\`
+    Unable to find an accessible element with the role "heading" and name \`/something that does not match/\`
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  heading:
+      heading:
 
-  Name "Sign up":
-  <h1 />
+      Name "Sign up":
+      <h1 />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <h1>
-    Sign 
-    <em>
-      up
-    </em>
-  </h1>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <h1>
+        Sign 
+        <em>
+          up
+        </em>
+      </h1>
+    </div>
+  `)
 
   expect(() => getByRole('heading', {name: () => false}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "heading" and name \`() => false\`
+    Unable to find an accessible element with the role "heading" and name \`() => false\`
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  heading:
+      heading:
 
-  Name "Sign up":
-  <h1 />
+      Name "Sign up":
+      <h1 />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <h1>
-    Sign 
-    <em>
-      up
-    </em>
-  </h1>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <h1>
+        Sign 
+        <em>
+          up
+        </em>
+      </h1>
+    </div>
+  `)
 })
 
 test('does not include the container in the queryable roles', () => {
@@ -337,22 +337,22 @@ test('does not include the container in the queryable roles', () => {
     container: document.createElement('ul'),
   })
   expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "list"
+    Unable to find an accessible element with the role "list"
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  listitem:
+      listitem:
 
-  Name "":
-  <li />
+      Name "":
+      <li />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<ul>
-  <li />
-</ul>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <ul>
+      <li />
+    </ul>
+  `)
 })
 
 test('has no useful error message in findBy', async () => {
@@ -369,28 +369,28 @@ test('explicit role is most specific', () => {
   )
 
   expect(() => getByRole('button')).toThrowErrorMatchingInlineSnapshot(`
-"Unable to find an accessible element with the role "button"
+    Unable to find an accessible element with the role "button"
 
-Here are the accessible roles:
+    Here are the accessible roles:
 
-  tab:
+      tab:
 
-  Name "my-tab":
-  <button
-    aria-label="my-tab"
-    role="tab"
-  />
+      Name "my-tab":
+      <button
+        aria-label="my-tab"
+        role="tab"
+      />
 
-  --------------------------------------------------
+      --------------------------------------------------
 
-Ignored nodes: comments, <script />, <style />
-<body>
-  <button
-    aria-label="my-tab"
-    role="tab"
-  />
-</body>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      <button
+        aria-label="my-tab"
+        role="tab"
+      />
+    </body>
+  `)
 })
 
 test('accessible regex name in error message for multiple found', () => {
@@ -403,40 +403,40 @@ test('accessible regex name in error message for multiple found', () => {
 
   expect(() => getByRole('button', {name: /value/i}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found multiple elements with the role "button" and name \`/value/i\`
+    Found multiple elements with the role "button" and name \`/value/i\`
 
-Here are the matching elements:
+    Here are the matching elements:
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Increment value
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Increment value
+    </button>
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Decrement value
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Decrement value
+    </button>
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Reset value
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Reset value
+    </button>
 
-(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+    (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <button>
-    Increment value
-  </button>
-  <button>
-    Decrement value
-  </button>
-  <button>
-    Reset value
-  </button>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <button>
+        Increment value
+      </button>
+      <button>
+        Decrement value
+      </button>
+      <button>
+        Reset value
+      </button>
+    </div>
+  `)
 })
 
 test('accessible string name in error message for multiple found', () => {
@@ -449,40 +449,40 @@ test('accessible string name in error message for multiple found', () => {
 
   expect(() => getByRole('button', {name: 'Submit'}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found multiple elements with the role "button" and name "Submit"
+    Found multiple elements with the role "button" and name "Submit"
 
-Here are the matching elements:
+    Here are the matching elements:
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Submit
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Submit
+    </button>
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Submit
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Submit
+    </button>
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Submit
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Submit
+    </button>
 
-(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+    (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <button>
-    Submit
-  </button>
-  <button>
-    Submit
-  </button>
-  <button>
-    Submit
-  </button>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <button>
+        Submit
+      </button>
+      <button>
+        Submit
+      </button>
+      <button>
+        Submit
+      </button>
+    </div>
+  `)
 })
 
 test('matching elements in error for multiple found', () => {
@@ -496,38 +496,38 @@ test('matching elements in error for multiple found', () => {
 
   expect(() => getByRole('button', {name: /value/i}))
     .toThrowErrorMatchingInlineSnapshot(`
-"Found multiple elements with the role "button" and name \`/value/i\`
+    Found multiple elements with the role "button" and name \`/value/i\`
 
-Here are the matching elements:
+    Here are the matching elements:
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Increment value
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Increment value
+    </button>
 
-Ignored nodes: comments, <script />, <style />
-<button>
-  Reset value
-</button>
+    Ignored nodes: comments, <script />, <style />
+    <button>
+      Reset value
+    </button>
 
-(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
+    (If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).
 
-Ignored nodes: comments, <script />, <style />
-<div>
-  <button>
-    Increment value
-  </button>
-  <button>
-    Different label
-  </button>
-  <p>
-    Wrong role
-  </p>
-  <button>
-    Reset value
-  </button>
-</div>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <div>
+      <button>
+        Increment value
+      </button>
+      <button>
+        Different label
+      </button>
+      <p>
+        Wrong role
+      </p>
+      <button>
+        Reset value
+      </button>
+    </div>
+  `)
 })
 
 describe('configuration', () => {

--- a/src/__tests__/screen.js
+++ b/src/__tests__/screen.js
@@ -72,40 +72,40 @@ test('exposes debug method', () => {
   screen.debug()
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "<body>
-      <button>
-        test
-      </button>
-      <span>
-        multi-test
-      </span>
-      <div>
-        multi-test
-      </div>
-    </body>"
-  `)
+<body>
+  <button>
+    test
+  </button>
+  <span>
+    multi-test
+  </span>
+  <div>
+    multi-test
+  </div>
+</body>
+`)
   console.log.mockClear()
   // log single element
   screen.debug(screen.getByText('test', {selector: 'button'}))
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "<button>
-      test
-    </button>"
-  `)
+<button>
+  test
+</button>
+`)
   console.log.mockClear()
   // log multiple elements
   screen.debug(screen.getAllByText('multi-test'))
   expect(console.log).toHaveBeenCalledTimes(2)
   expect(console.log.mock.calls[0][0]).toMatchInlineSnapshot(`
-    "<span>
-      multi-test
-    </span>"
-  `)
+<span>
+  multi-test
+</span>
+`)
   expect(console.log.mock.calls[1][0]).toMatchInlineSnapshot(`
-    "<div>
-      multi-test
-    </div>"
-  `)
+<div>
+  multi-test
+</div>
+`)
   console.log.mockClear()
 })

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -107,19 +107,19 @@ test('should suggest getByRole when used with getBy', () => {
   renderIntoDocument(`<button data-testid="foo">submit</button>`)
 
   expect(() => screen.getByTestId('foo')).toThrowErrorMatchingInlineSnapshot(`
-"A better query is available, try this:
-getByRole('button', { name: /submit/i })
+    A better query is available, try this:
+    getByRole('button', { name: /submit/i })
 
 
-Ignored nodes: comments, <script />, <style />
-<body>
-  <button
-    data-testid="foo"
-  >
-    submit
-  </button>
-</body>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      <button
+        data-testid="foo"
+      >
+        submit
+      </button>
+    </body>
+  `)
 })
 
 test('should suggest getAllByRole when used with getAllByTestId', () => {
@@ -129,28 +129,28 @@ test('should suggest getAllByRole when used with getAllByTestId', () => {
 
   expect(() => screen.getAllByTestId('foo'))
     .toThrowErrorMatchingInlineSnapshot(`
-"A better query is available, try this:
-getAllByRole('button', { name: /submit/i })
+    A better query is available, try this:
+    getAllByRole('button', { name: /submit/i })
 
 
-Ignored nodes: comments, <script />, <style />
-<body>
-  
-    
-  <button
-    data-testid="foo"
-  >
-    submit
-  </button>
-  
-    
-  <button
-    data-testid="foo"
-  >
-    submit
-  </button>
-</body>"
-`)
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      
+        
+      <button
+        data-testid="foo"
+      >
+        submit
+      </button>
+      
+        
+      <button
+        data-testid="foo"
+      >
+        submit
+      </button>
+    </body>
+  `)
 })
 test('should suggest findByRole when used with findByTestId', async () => {
   renderIntoDocument(`

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -121,20 +121,20 @@ test('timeout logs a pretty DOM', async () => {
     {timeout: 1},
   ).catch(e => e)
   expect(error.message).toMatchInlineSnapshot(`
-    "always throws
+always throws
 
-    Ignored nodes: comments, <script />, <style />
-    <html>
-      <head />
-      <body>
-        <div
-          id="pretty"
-        >
-          how pretty
-        </div>
-      </body>
-    </html>"
-  `)
+Ignored nodes: comments, <script />, <style />
+<html>
+  <head />
+  <body>
+    <div
+      id="pretty"
+    >
+      how pretty
+    </div>
+  </body>
+</html>
+`)
 })
 
 test('should delegate to config.getElementError', async () => {
@@ -185,14 +185,14 @@ test('when a promise is returned, if that is not resolved within the timeout, th
   await sleep(5)
 
   expect((await waitForError).message).toMatchInlineSnapshot(`
-    "Timed out in waitFor.
+Timed out in waitFor.
 
-    Ignored nodes: comments, <script />, <style />
-    <html>
-      <head />
-      <body />
-    </html>"
-  `)
+Ignored nodes: comments, <script />, <style />
+<html>
+  <head />
+  <body />
+</html>
+`)
 })
 
 test('if you switch from fake timers to real timers during the wait period you get an error', async () => {

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/extend-expect'
-import jestSerializerAnsi from 'jest-serializer-ansi'
+import jestSnapshotSerializerAnsi from 'jest-snapshot-serializer-ansi'
 
-expect.addSnapshotSerializer(jestSerializerAnsi)
+expect.addSnapshotSerializer(jestSnapshotSerializerAnsi)
 // add serializer for MutationRecord
 expect.addSnapshotSerializer({
   print: (record, serialize) => {


### PR DESCRIPTION
**What**:

Two snapshot tests were failing locally while passing on CI, this change fixes it so that tests are green on CI as well as locally.
 
The replaced library was appending extra double quotes at the begging and end of the string.

https://github.com/joaogranado/jest-serializer-ansi/blob/c8c5e8cbc0f804f9fe195dfd27625ea0b3d2a062/index.js#L13-L16

**How**:

Replacing jest-serializer-ansi library with jest-snapshot-serializer-ansi.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged

