### PR TITLE
fix(buildQuery): get*Error functions receive same Arguments type as queryAllBy parameter

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -68,6 +68,22 @@ export async function testQueryHelpers() {
           : includesAutomationId(content, automationId),
       options,
     )
+
+  const createIdRelatedErrorHandler =
+    (errorMessage: string, defaultErrorMessage: string) =>
+    <T>(container: Element | null, ...args: T[]) => {
+      const [key, value] = args
+      if (!container) {
+        return 'Container element not specified'
+      }
+      if (key && value) {
+        return errorMessage
+          .replace('[key]', String(key))
+          .replace('[value]', String(value))
+      }
+      return defaultErrorMessage
+    }
+
   const [
     queryByAutomationId,
     getAllByAutomationId,
@@ -76,8 +92,14 @@ export async function testQueryHelpers() {
     findByAutomationId,
   ] = buildQueries(
     queryAllByAutomationId,
-    () => 'Multiple Error',
-    () => 'Missing Error',
+    createIdRelatedErrorHandler(
+      `Found multiple with key [key] and value [value]`,
+      'Multiple error',
+    ),
+    createIdRelatedErrorHandler(
+      `Unable to find an element with the [key] attribute of: [value]`,
+      'Missing error',
+    ),
   )
   queryByAutomationId(element, 'id')
   getAllByAutomationId(element, 'id')
@@ -89,6 +111,11 @@ export async function testQueryHelpers() {
   await findByAutomationId(element, 'id', {})
   await findAllByAutomationId(element, 'id')
   await findByAutomationId(element, 'id')
+
+  await findAllByAutomationId(element, ['id', 'id'], {})
+  await findByAutomationId(element, ['id', 'id'], {})
+  await findAllByAutomationId(element, ['id', 'id'])
+  await findByAutomationId(element, ['id', 'id'])
 }
 
 export function testBoundFunctions() {

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -69,6 +69,6 @@ export type BuiltQueryMethods<Arguments extends any[]> = [
 
 export function buildQueries<Arguments extends any[]>(
   queryAllBy: GetAllBy<Arguments>,
-  getMultipleError: GetErrorFunction,
-  getMissingError: GetErrorFunction,
+  getMultipleError: GetErrorFunction<Arguments>,
+  getMissingError: GetErrorFunction<Arguments>,
 ): BuiltQueryMethods<Arguments>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

> The types for the arguments to GetErrorFunction are stuck at the default. At runtime, you can log `...args` and see that the expected key and value are passed.

<!-- Why are these changes necessary? -->

**Why**:

Described in [this issue](https://github.com/testing-library/dom-testing-library/issues/1037).

<!-- How were these changes implemented? -->

**How**:

Passed `Argument` generic to `GetErrorFunction` in `buildQueries` type definitions

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
