### PR TITLE
fix(within): Types should list custom and base queries

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -117,6 +117,21 @@ export async function testQueryHelpers() {
   await findByAutomationId(element, ['id', 'id'], {})
   await findAllByAutomationId(element, ['id', 'id'])
   await findByAutomationId(element, ['id', 'id'])
+
+  const screenWithCustomQueries = within(document.body, {
+    ...queries,
+    queryByAutomationId,
+    getAllByAutomationId,
+    getByAutomationId,
+    findAllByAutomationId,
+    findByAutomationId,
+  })
+
+  screenWithCustomQueries.queryByAutomationId('id')
+  screenWithCustomQueries.getAllByAutomationId('id')
+  screenWithCustomQueries.getByAutomationId(['id', 'automationId'])
+  await screenWithCustomQueries.findAllByAutomationId('id', {}, {timeout: 1000})
+  await screenWithCustomQueries.findByAutomationId('id', {}, {timeout: 1000})
 }
 
 export function testBoundFunctions() {

--- a/types/get-queries-for-element.d.ts
+++ b/types/get-queries-for-element.d.ts
@@ -153,6 +153,8 @@ export type BoundFunctions<Q> = Q extends typeof queries
       findAllByTestId<T extends HTMLElement = HTMLElement>(
         ...args: Parameters<BoundFunction<queries.FindAllByBoundAttribute<T>>>
       ): ReturnType<queries.FindAllByBoundAttribute<T>>
+    } & {
+      [P in keyof Q]: BoundFunction<Q[P]>
     }
   : {
       [P in keyof Q]: BoundFunction<Q[P]>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds custom query types if `within` adds custom and base (`queries`) queries.

**Why**:

https://github.com/testing-library/dom-testing-library/pull/1034 broke the previous untested behavor.

**How**:

Intersect with custom queries.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
