### PR TITLE
feat: Support all tags for alt-text

### DIFF
--- a/src/__tests__/text-matchers.js
+++ b/src/__tests__/text-matchers.js
@@ -34,6 +34,15 @@ cases(
       query: `Finding Nemo poster`,
       queryFn: `queryAllByAltText`,
     },
+    'queryAllByAltText (for amp-img)': {
+      dom: `
+        <amp-img
+          alt="Finding Nemo poster" 
+          src="/finding-nemo.png"
+        />`,
+      query: `Finding Nemo poster`,
+      queryFn: `queryAllByAltText`,
+    },
     queryAllByPlaceholderText: {
       dom: `<input placeholder="Dwayne 'The Rock' Johnson" />`,
       query: `Dwayne 'The Rock' Johnson`,
@@ -86,6 +95,16 @@ cases(
     queryAllByAltText: {
       dom: `
         <img
+          alt="
+            Finding Nemo poster " 
+          src="/finding-nemo.png"
+        />`,
+      query: /^Finding Nemo poster$/,
+      queryFn: `queryAllByAltText`,
+    },
+    'queryAllByAltText (for amp-img)': {
+      dom: `
+        <amp-img
           alt="
             Finding Nemo poster " 
           src="/finding-nemo.png"
@@ -198,6 +217,15 @@ cases(
       query: `Finding Nemo poster`,
       queryFn: `queryAllByAltText`,
     },
+    'queryAllByAltText (for amp-img)': {
+      dom: `
+        <amp-img
+          alt="Finding Nemo poster" 
+          src="/finding-nemo.png"
+        />`,
+      query: `Finding Nemo poster`,
+      queryFn: `queryAllByAltText`,
+    },
   },
 )
 
@@ -249,6 +277,10 @@ cases(
     },
     queryAllByAltText: {
       dom: `<img alt="User ${LRM}name" src="username.jpg" />`,
+      queryFn: 'queryAllByAltText',
+    },
+    'queryAllByAltText (for amp-img)': {
+      dom: `<amp-img alt="User ${LRM}name" src="username.jpg" />`,
       queryFn: 'queryAllByAltText',
     },
     queryAllByTitle: {

--- a/src/queries/alt-text.ts
+++ b/src/queries/alt-text.ts
@@ -1,21 +1,22 @@
-import {wrapAllByQueryWithSuggestion} from '../query-helpers'
+import {
+  queryAllByAttribute,
+  wrapAllByQueryWithSuggestion,
+} from '../query-helpers'
 import {checkContainerType} from '../helpers'
-import {AllByBoundAttribute, GetErrorFunction} from '../../types'
-import {matches, fuzzyMatches, makeNormalizer, buildQueries} from './all-utils'
+import {
+  AllByBoundAttribute,
+  GetErrorFunction,
+  MatcherOptions,
+} from '../../types'
+import {buildQueries} from './all-utils'
 
 const queryAllByAltText: AllByBoundAttribute = (
   container,
   alt,
-  {exact = true, collapseWhitespace, trim, normalizer} = {},
+  options: MatcherOptions = {},
 ) => {
   checkContainerType(container)
-  const matcher = exact ? matches : fuzzyMatches
-  const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  return Array.from(
-    container.querySelectorAll<HTMLElement>('img,input,area'),
-  ).filter(node =>
-    matcher(node.getAttribute('alt'), node, alt, matchNormalizer),
-  )
+  return queryAllByAttribute('alt', container, alt, options)
 }
 
 const getMultipleError: GetErrorFunction<[unknown]> = (c, alt) =>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Made the ByAltText methods tag-agnostic

<!-- Why are these changes necessary? -->

**Why**: ByAltText does currently not support `<amp-img>` (and possibly other custom-elements).

<!-- How were these changes implemented? -->

**How**: by using the existing `queryAllByAttribute` function and thus dropping the limitation to only 'img,input,area' tags.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] TypeScript definitions updated (no changes required)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Note:**
`queryAllByAltText` and `queryAllByAttribute` are mostly identical, so I chose to just call `queryAllByAttribute`.
However queryAllByAltText had an additional call to `checkContainerType`, which I left in place. Not sure why `queryAllByAttribute` does not have this check.

Alternatively, I could leave the old logic in place and simply add the tag amp-img to the allowed list, but I think this way is better.

I will create an update PR for the docs when it's clear, that this will be merged.