### PR TITLE
fix(ByRole): Ensure valid query selectors in all transpilation targets

### DIFF
--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -187,11 +187,17 @@ function makeRoleSelector(role, exact, customNormalizer) {
   const explicitRoleSelector =
     exact && !customNormalizer ? `*[role~="${role}"]` : '*[role]'
 
-  const roleRelations = roleElements.get(role)
-  const implicitRoleSelectors =
-    roleRelations && new Set(Array.from(roleRelations).map(({name}) => name))
+  const roleRelations = roleElements.get(role) ?? new Set()
+  const implicitRoleSelectors = new Set(
+    Array.from(roleRelations).map(({name}) => name),
+  )
 
-  return [explicitRoleSelector, ...(implicitRoleSelectors ?? [])].join(',')
+  // Current transpilation config sometimes assumes `...` is always applied to arrays.
+  // `...` is equivalent to `Array.prototype.concat` for arrays.
+  // If you replace this code with `[explicitRoleSelector, ...implicitRoleSelectors]`, make sure every transpilation target retains the `...` in favor of `Array.prototype.concat`.
+  return [explicitRoleSelector]
+    .concat(Array.from(implicitRoleSelectors))
+    .join(',')
 }
 
 const getMultipleError = (c, role, {name} = {}) => {


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes erros like "'*[role~="textbox"],[object Set]' is not a valid selector" when using `module` entrypoints.

**Why**:

I only reviewed the transpiled node code in https://github.com/testing-library/dom-testing-library/pull/1046 which didn't transpile `...` away. The `module` entrypoint does though.

Example failure: https://app.circleci.com/pipelines/github/mui-org/material-ui/53629/workflows/6c71e957-ee1c-4e20-8ea4-cd856f7e27d8/jobs/305270

Bad transpilation: 
`return [explicitRoleSelector].concat(implicitRoleSelectors != null ? implicitRoleSelectors : []).join(',');`
-- https://unpkg.com/@testing-library/dom@8.9.0/dist/@testing-library/dom.esm.js

This is equiavalent to `['[role="button"]'].concat(new Set(['button']))` which evaluates to `['[role="button"]', new Set(['button'])]` instead of the intended `['[role="button"]', 'button']`

The `module` entrypoint targets old browsers without support for spread syntax. We assume that every `...` target is an array which means `...` can be transpiled using `Array.prototype.concat`. However, this breaks for any other iterable (here: `Set`). In other words, we're transpiling with `@babel/plugin-transform-spread` enabling `loose` mode (https://babeljs.io/docs/en/babel-plugin-transform-spread#loose).

**How**:

Directly use `concat` and leave a comment about using `...`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests (built this PRs `module` entrypoint, pasted into local fork of mui-org/material-ui and run successfully `yarn test:karma` which was failing without this change)
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
