### PR TITLE
feat: Prioritize accessible names check higher than inaccessibility check in `byRole` queries

### DIFF
--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -154,13 +154,6 @@ function queryAllByRole(
       return true
     })
     .filter(element => {
-      return hidden === false
-        ? isInaccessible(element, {
-            isSubtreeInaccessible: cachedIsSubtreeInaccessible,
-          }) === false
-        : true
-    })
-    .filter(element => {
       if (name === undefined) {
         // Don't care
         return true
@@ -175,6 +168,13 @@ function queryAllByRole(
         name,
         text => text,
       )
+    })
+    .filter(element => {
+      return hidden === false
+        ? isInaccessible(element, {
+            isSubtreeInaccessible: cachedIsSubtreeInaccessible,
+          }) === false
+        : true
     })
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Related to https://github.com/testing-library/dom-testing-library/issues/698 and https://github.com/testing-library/dom-testing-library/issues/820.

`*ByRole` queries are filtering inaccessibility (`hidden: false`) earlier than accessible names. This PR changes that by prioritizing accessible names over inaccessibility. Hopefully to achieve better performance in most cases.

<!-- Why are these changes necessary? -->

**Why**:

As stated in https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-726936225, one of the _escape hatches_ to improve the performance of the `*ByRole` queries is to pass `hidden: true` to the options. The reason is that the visibility check is more expensive in most cases. People are already using this technique to improve their queries' performance by setting the default options to true globally. The downside of this technique is obviously that we'd lose the visibility check for better and predictable queries.

What if instead of removing the inaccessibility check altogether, we just have to move the order lower? Since the query is really just a set of filter functions, if we can run the faster filter first and short-circuiting most of the candidates, then hopefully we don't have to run the slower inaccessibility check on so many elements.

For a naive test with 1000 buttons all with different names in jsdom environment, selecting the last element takes around 2 seconds. After applying this changes, it only takes around 1 second in average on my machine. It's not a lot but seems like a free win to me.

```js
const {getByRole} = render(
  Array.from({length: 1000})
    .map((_, index) => `<button>${index}</button>`)
    .join(''),
)
expect(getByRole('button', {name: '999'})).not.toBeNull()
```

Obviously it doesn't reflect the real world usage, but I'd expect the usage of accessible names check are more frequent than the inaccessibility check. It'd only be slower if there are multiple elements with the same name but only a part of them are accessible/visible. I can't think of a case where this would be a common scenario in testing. Additionally, people are already opting-out of the inaccessibility check globally, this should have little impact for them.

Preferably, it'd be nice to have it tested in some real world repos to see if it actually improves the performance though.

<!-- How were these changes implemented? -->

**How**:

Move the inaccessibility check lower to the last.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) (I don't think this needs to be added to the documentation site. A record in changelog should be fine?)
- [ ] Tests (N/A)
- [ ] TypeScript definitions updated (N/A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
