### PR TITLE
Draft: feat(query-deep): Using a query selector that supports queries into the shadow dom of elements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
     ...watchPlugins,
     require.resolve('jest-watch-select-projects'),
   ],
+  transformIgnorePatterns: ['node_modules/(?!(query-selector-shadow-dom)/)'],
   projects: [
     require.resolve('./tests/jest.config.dom.js'),
     require.resolve('./tests/jest.config.node.js'),

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "chalk": "^4.1.0",
     "dom-accessibility-api": "^0.5.9",
     "lz-string": "^1.4.4",
-    "pretty-format": "^27.0.2"
+    "pretty-format": "^27.0.2",
+    "query-selector-shadow-dom": "^1.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",

--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -131,15 +131,15 @@ test('`selected: true` matches `aria-selected="true"` on supported roles', () =>
 
   expect(
     getAllByRole('columnheader', {selected: true}).map(({id}) => id),
-  ).toEqual(['selected-native-columnheader', 'selected-columnheader'])
+  ).toEqual(['selected-columnheader', 'selected-native-columnheader'])
 
   expect(getAllByRole('gridcell', {selected: true}).map(({id}) => id)).toEqual([
     'selected-gridcell',
   ])
 
   expect(getAllByRole('option', {selected: true}).map(({id}) => id)).toEqual([
-    'selected-native-option',
     'selected-listbox-option',
+    'selected-native-option',
   ])
 
   expect(getAllByRole('rowheader', {selected: true}).map(({id}) => id)).toEqual(
@@ -217,8 +217,8 @@ test('`level` matches elements with `heading` role', () => {
   ])
 
   expect(getAllByRole('heading', {level: 2}).map(({id}) => id)).toEqual([
-    'first-heading-two',
     'second-heading-two',
+    'first-heading-two',
   ])
 
   expect(getAllByRole('heading', {level: 3}).map(({id}) => id)).toEqual([

--- a/src/label-helpers.ts
+++ b/src/label-helpers.ts
@@ -1,3 +1,4 @@
+import {querySelector, querySelectorAll} from './queries/all-utils'
 import {TEXT_NODE} from './helpers'
 
 const labelledNodeNames = [
@@ -43,7 +44,7 @@ function getRealLabels(element: Element) {
 
   if (!isLabelable(element)) return []
 
-  const labels = element.ownerDocument.querySelectorAll('label')
+  const labels = querySelectorAll(element.ownerDocument, 'label')
   return Array.from(labels).filter(label => label.control === element)
 }
 
@@ -63,7 +64,8 @@ function getLabels(
   const labelsId = ariaLabelledBy ? ariaLabelledBy.split(' ') : []
   return labelsId.length
     ? labelsId.map(labelId => {
-        const labellingElement = container.querySelector<HTMLElement>(
+        const labellingElement = querySelector<Element, HTMLElement>(
+          container,
           `[id="${labelId}"]`,
         )
         return labellingElement

--- a/src/queries/display-value.ts
+++ b/src/queries/display-value.ts
@@ -7,6 +7,7 @@ import {
   MatcherOptions,
 } from '../../types'
 import {
+  querySelectorAll,
   getNodeText,
   matches,
   fuzzyMatches,
@@ -23,7 +24,10 @@ const queryAllByDisplayValue: AllByBoundAttribute = (
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(
-    container.querySelectorAll<HTMLElement>(`input,textarea,select`),
+    querySelectorAll<HTMLElement, HTMLElement>(
+      container,
+      `input,textarea,select`,
+    ),
   ).filter(node => {
     if (node.tagName === 'SELECT') {
       const selectedOptions = Array.from(

--- a/src/queries/label-text.ts
+++ b/src/queries/label-text.ts
@@ -17,12 +17,16 @@ import {
   makeSingleQuery,
   wrapAllByQueryWithSuggestion,
   wrapSingleQueryWithSuggestion,
+  querySelectorAll,
+  querySelector,
 } from './all-utils'
 
 function queryAllLabels(
   container: HTMLElement,
 ): {textToMatch: string | null; node: HTMLElement}[] {
-  return Array.from(container.querySelectorAll<HTMLElement>('label,input'))
+  return Array.from(
+    querySelectorAll<HTMLElement, HTMLElement>(container, 'label,input'),
+  )
     .map(node => {
       return {node, textToMatch: getLabelContent(node)}
     })
@@ -56,7 +60,7 @@ const queryAllByLabelText: AllByText = (
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   const matchingLabelledElements = Array.from(
-    container.querySelectorAll<HTMLElement>('*'),
+    querySelectorAll<HTMLElement, HTMLElement>(container, '*'),
   )
     .filter(element => {
       return (
@@ -169,7 +173,10 @@ function getTagNameOfElementAssociatedWithLabelViaFor(
     return null
   }
 
-  const element = container.querySelector(`[id="${htmlFor}"]`)
+  const element = querySelector<Element, HTMLElement>(
+    container,
+    `[id="${htmlFor}"]`,
+  )
   return element ? element.tagName.toLowerCase() : null
 }
 

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -20,6 +20,7 @@ import {
   getConfig,
   makeNormalizer,
   matches,
+  querySelectorAll,
 } from './all-utils'
 
 function queryAllByRole(
@@ -100,7 +101,8 @@ function queryAllByRole(
   }
 
   return Array.from(
-    container.querySelectorAll(
+    querySelectorAll(
+      container,
       // Only query elements that can be matched by the following filters
       makeRoleSelector(role, exact, normalizer ? matchNormalizer : undefined),
     ),

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -3,6 +3,7 @@ import {checkContainerType} from '../helpers'
 import {DEFAULT_IGNORE_TAGS} from '../shared'
 import {AllByText, GetErrorFunction} from '../../types'
 import {
+  querySelectorAll,
   fuzzyMatches,
   matches,
   makeNormalizer,
@@ -32,7 +33,9 @@ const queryAllByText: AllByText = (
   return (
     [
       ...baseArray,
-      ...Array.from(container.querySelectorAll<HTMLElement>(selector)),
+      ...Array.from(
+        querySelectorAll<HTMLElement, HTMLElement>(container, selector),
+      ),
     ]
       // TODO: `matches` according lib.dom.d.ts can get only `string` but according our code it can handle also boolean :)
       .filter(node => !ignore || !node.matches(ignore as string))

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -7,6 +7,7 @@ import {
   MatcherOptions,
 } from '../../types'
 import {
+  querySelectorAll,
   fuzzyMatches,
   matches,
   makeNormalizer,
@@ -27,7 +28,10 @@ const queryAllByTitle: AllByBoundAttribute = (
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(
-    container.querySelectorAll<HTMLElement>('[title], svg > title'),
+    querySelectorAll<HTMLElement, HTMLElement>(
+      container,
+      '[title], svg > title',
+    ),
   ).filter(
     node =>
       matcher(node.getAttribute('title'), node, text, matchNormalizer) ||

--- a/src/query-helpers.ts
+++ b/src/query-helpers.ts
@@ -2,6 +2,8 @@ import type {
   GetErrorFunction,
   Matcher,
   MatcherOptions,
+  QueryAllElements,
+  QueryElement,
   QueryMethod,
   Variant,
   waitForOptions as WaitForOptions,
@@ -11,6 +13,16 @@ import {getSuggestedQuery} from './suggestions'
 import {fuzzyMatches, matches, makeNormalizer} from './matches'
 import {waitFor} from './wait-for'
 import {getConfig} from './config'
+import * as querier from 'query-selector-shadow-dom'
+
+export const querySelector: QueryElement = <T extends Element>(
+  element: T,
+  selector: string,
+) => querier.querySelectorDeep(selector, element)
+export const querySelectorAll: QueryAllElements = <T extends Element>(
+  element: T,
+  selector: string,
+) => querier.querySelectorAllDeep(selector, element)
 
 function getElementError(message: string | null, container: HTMLElement) {
   return getConfig().getElementError(message, container)
@@ -35,7 +47,7 @@ function queryAllByAttribute(
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(
-    container.querySelectorAll<HTMLElement>(`[${attribute}]`),
+    querySelectorAll<HTMLElement, HTMLElement>(container, `[${attribute}]`),
   ).filter(node =>
     matcher(node.getAttribute(attribute), node, text, matchNormalizer),
   )

--- a/tests/jest.config.dom.js
+++ b/tests/jest.config.dom.js
@@ -10,5 +10,6 @@ module.exports = {
     '/__tests__/',
     '/__node_tests__/',
   ],
+  transformIgnorePatterns: ['node_modules/(?!(query-selector-shadow-dom)/)'],
   testEnvironment: 'jest-environment-jsdom',
 }

--- a/tests/jest.config.node.js
+++ b/tests/jest.config.node.js
@@ -11,5 +11,6 @@ module.exports = {
     '/__tests__/',
     '/__node_tests__/',
   ],
+  transformIgnorePatterns: ['node_modules/(?!(query-selector-shadow-dom)/)'],
   testMatch: ['**/__node_tests__/**.js'],
 }

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -72,3 +72,27 @@ export function buildQueries<Arguments extends any[]>(
   getMultipleError: GetErrorFunction<Arguments>,
   getMissingError: GetErrorFunction<Arguments>,
 ): BuiltQueryMethods<Arguments>
+
+export type QueryElement = {
+  <T, K extends keyof HTMLElementTagNameMap>(container: T, selectors: K):
+    | HTMLElementTagNameMap[K]
+    | null
+  <T, K extends keyof SVGElementTagNameMap>(container: T, selectors: K):
+    | SVGElementTagNameMap[K]
+    | null
+  <T, E extends Element = Element>(container: T, selectors: string): E | null
+}
+export type QueryAllElements = {
+  <T, K extends keyof HTMLElementTagNameMap>(
+    container: T,
+    selectors: K,
+  ): NodeListOf<HTMLElementTagNameMap[K]>
+  <T, K extends keyof SVGElementTagNameMap>(
+    container: T,
+    selectors: K,
+  ): NodeListOf<SVGElementTagNameMap[K]>
+  <T, E extends Element = Element>(
+    container: T,
+    selectors: string,
+  ): NodeListOf<E>
+}

--- a/types/query-selector-shadow-dom.d.ts
+++ b/types/query-selector-shadow-dom.d.ts
@@ -1,0 +1,4 @@
+declare module 'query-selector-shadow-dom' {
+  export const querySelectorAllDeep: QueryElement
+  export const querySelectorDeep: QueryAllElements
+}


### PR DESCRIPTION
**What**:

_This is the second RFC-PR for solving the shadow-dom problems. It is created as a follow up on #1054, this time showing a less generic approach - by building the shadow dom query functionality right into the framework, rather than opening it to consumers. After discussions, the goal would be to get a review for either of the two to merge it._

This commit will automatically resolve queries that have to reach into the shadow dom of any of the children to find requested elements. You can see an example in the test here: https://github.com/MatthiasKainer/dom-testing-library/commit/03e1477fcfb51633077d360d3911dc0bd8885fcb#diff-03031dc49abaa5227e8e4e13fd7459557e494345a85e4a29e7a78c10d7046cfeR87

This test would fail with the old version and works with this change. It will fix issues #742 & #413 and every other that's related to shadow dom.

**Why**:

In our project, we are using a design system built with web components (via stenciljs), and different projects in different frameworks (lit, react, vue) want to use this library. However, due to the issues already highlighted in #742 #413 and the fact that the current [workaround](https://github.com/testing-library/dom-testing-library/issues/742#issuecomment-674987855) is not really a long-term solution as it wraps an old version of this library, this change will solve this issue once and for all. 

**How**:

As said, unlike in  #1054, this change replaces the query mechanism of the core library. It uses the library [Georgegriff/query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom) - which, to my knowledge, is also the goto solution for other testing libraries that struggle with shadow-dom with 200k downloads a week. 

The change gravitates around the following lines of code: https://github.com/MatthiasKainer/dom-testing-library/commit/03e1477fcfb51633077d360d3911dc0bd8885fcb#diff-75da2f8ae17b208e9a92d6eee57458b0a5e95f89ced8e4c400bfeb5e0d66ee85R18 

It's a wrapper for the query method, that is to be used by the application rather than using the `querySelector` and `querySelectorAll` methods directly. 

Given it changes the query mechanism this might be considered a potentially breaking change. I lack the knowledge of all the use cases of this library, but one example can already be found in the adjustments in the node tests: https://github.com/MatthiasKainer/dom-testing-library/commit/03e1477fcfb51633077d360d3911dc0bd8885fcb#diff-03031dc49abaa5227e8e4e13fd7459557e494345a85e4a29e7a78c10d7046cfeR4

Basically, non-browser environments might have issues with this change as the library will need access to the document, and to the Node interface. The reason is performance optimisation (no need to search everything if no shadow element exists) and testing if an element is a node.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Pinging @eps1lon @alexkrolick to follow up on the discussions from #1054
