### PR TITLE
feat: Improve performance of findBy*/findAllBy* by not generating informative error messages

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -1,5 +1,6 @@
 import {configure, getConfig} from '../config'
 import {getQueriesForElement} from '../get-queries-for-element'
+import {waitFor} from '../wait-for'
 import {render, renderIntoDocument} from './helpers/test-utils'
 
 test('by default logs accessible roles when it fails', () => {
@@ -356,11 +357,11 @@ test('does not include the container in the queryable roles', () => {
 })
 
 test('has no useful error message in findBy', async () => {
-  const {findByRole} = render(`<li />`)
+  const {getByRole} = render(`<li />`)
 
-  await expect(findByRole('option', {timeout: 1})).rejects.toThrow(
-    'Unable to find role="option"',
-  )
+  await expect(
+    waitFor(() => getByRole('option'), {timeout: 1}),
+  ).rejects.toThrow('Unable to find role="option"')
 })
 
 test('explicit role is most specific', () => {

--- a/src/queries/label-text.ts
+++ b/src/queries/label-text.ts
@@ -191,12 +191,34 @@ const findAllByLabelText = makeFindQuery(
     // @ts-expect-error -- See `wrapAllByQueryWithSuggestion` Argument constraint comment
     [labelText: Matcher, options?: SelectorMatcherOptions]
   >(getAllByLabelText, getAllByLabelText.name, 'findAll'),
+  wrapAllByQueryWithSuggestion(
+    (container, text, options) => {
+      const elements = queryAllByLabelText(container, text, options)
+      if (elements.length === 0) {
+        throw new Error('no element found')
+      }
+      return elements
+    },
+    getAllByLabelText.name,
+    'findAll',
+  ),
 )
 const findByLabelText = makeFindQuery(
   wrapSingleQueryWithSuggestion<
     // @ts-expect-error -- See `wrapAllByQueryWithSuggestion` Argument constraint comment
     [labelText: Matcher, options?: SelectorMatcherOptions]
   >(getByLabelText, getAllByLabelText.name, 'find'),
+  wrapSingleQueryWithSuggestion(
+    (container, text, options) => {
+      const elements = queryAllByLabelText(container, text, options)
+      if (elements.length !== 1) {
+        throw new Error('no element or more than one elements found')
+      }
+      return elements[0]
+    },
+    getAllByLabelText.name,
+    'find',
+  ),
 )
 
 const getAllByLabelTextWithSuggestions = wrapAllByQueryWithSuggestion<


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Improve performance of findBy*/findAllBy* by not generating informative error messages in the function passed to waitFor. The work of generating these error messages almost entirely wasted because all of them, except possibly the last one (if the test is red), will be discarded by waitFor. Instead, if the call to waitFor failed, another attempt to find the element(s) is made, this time generating a useful error message if it also fails.

<!-- Why are these changes necessary? -->

**Why**: I've noticed that in the codebase I am working on, significant CPU time is spent generating useful error messages that are later discarded. In particular, I've found that in one particular test suite the function `prettyDOM` takes approximately ~100ms per execution. (The tested React component has a lot of DOM nodes since it embeds an instance of [AG Grid](https://www.ag-grid.com/).)

<!-- How were these changes implemented? -->

**How**: I've added a second argument to `makeFindQuery` which is supposed to be a getter function just like the first argument, but may not provide useful error messages in the case of failure, which is used in the call to `waitFor`. For backwards compatibility I'm using the first argument as a default. If the call to `waitFor` fails, then the first argument is used instead.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests (no new tests necessary)
- [x] TypeScript definitions updated (they don't need updating)
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
**Alternative**: This PR implements just one possible approach to avoid the unnecessary work of generating informative error messages only for them to be discarded later. Another approach could build on `_disableExpensiveErrorDiagnostics` (introduced in #590):

* Only generate the potentially expensive parts (e.g. `prettyDOM`) of error messages if `_disableExpensiveErrorDiagnostics=false`.
* Adapt `waitFor` to use a strategy similar as implemented for `findBy*`/`findAllBy*` in this PR: First try calling `runWithExpensiveErrorDiagnosticsDisabled(callback)` and see whether this terminates without an error, but after the timeout occurs try once more without `runWithExpensiveErrorDiagnosticsDisabled` to get an informative error message in case of failure.

One advantage of this alternate approach would be that this would also decrease CPU usage when using `getBy`/`getAllBy` inside `waitFor`, like in the following code:

```typescript
await waitFor(() => {
  expect(getByTestId("foo")).toHaveAttribute("href", "https://example.com");
});
```