### PR TITLE
fix(wait-for): Don't queue microtasks after condition is met

### DIFF
--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -82,6 +82,10 @@ function waitFor(
         // an entire day banging my head against a wall on this.
         checkCallback()
 
+        if (finished) {
+          break
+        }
+
         // In this rare case, we *need* to wait for in-flight promises
         // to resolve before continuing. We don't need to take advantage
         // of parallelization so we're fine.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes integration with of `@testing-library/react@alpha` in React Spectrum when using React 18.

**Why**:

Otherwise context restoration in `unstable_advanceTimersWrapper` becomes unpredictable leading to fixes like [`d375ff3` (#2526)](https://github.com/adobe/react-spectrum/pull/2526/commits/d375ff359347d7818ed4902f3e37281bb7b5d61e#diff-c19475ebc27556f4091d71e843529459da93e9ebe0179c9650978422ec3b2942L2099-R2099) that seemingly have nothing to do with the test/implemenation but magically fix tests.

The implementation change fixed 
```js
it('should handle when a non drop target element is added', async () => {
      let setShowInput2;
      let Test = () => {
        let [showInput2, _setShowInput2] = React.useState(false);
        setShowInput2 = _setShowInput2;
        return (<>
          <Draggable />
          <input />
          <Droppable />
          {showInput2 &&
            <input />
          }
        </>);
      };

      let tree = render(<Test />);

      let draggable = tree.getByText('Drag me');

      expect(tree.getAllByRole('textbox')).toHaveLength(1);

      fireEvent.focus(draggable);
      fireEvent.click(draggable);
      act(() => jest.runAllTimers());

      expect(() => tree.getAllByRole('textbox')).toThrow();

      act(() => setShowInput2(true));
      // MutationObserver is async
      await waitFor(() => expect(() => tree.getAllByRole('textbox')).toThrow());

      fireEvent.click(draggable);
      expect(tree.getAllByRole('textbox')).toHaveLength(2);
    });
```
-- https://github.com/adobe/react-spectrum/blob/8dc33dcdab3bb41518daf023c18939e844e843eb/packages/%40react-aria/dnd/test/dnd.test.js#L2072-L2105

**How**:

Exit the loop once the callback no longer throws instead of unconditionally queuing another microtask.

This may be an issue with how `@testing-library/react` uses `unstable_advanceTimersWrapper`. 
Alternatively, we could flush microtasks before we check the callback. But this was intentionall though we don't have any test/repro for that at the moment /cc @kentcdodds 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
