### PR TITLE
fix(within): Add extra type paramater to allow reassigning in TypeScript

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -258,6 +258,8 @@ export async function testWithin() {
   let withinQueries = within(document.body)
   withinQueries = within(document.body)
   withinQueries.getByRole<HTMLButtonElement>('button', {name: /click me/i})
+  withinQueries = within(document.body)
+  withinQueries.getByRole<HTMLButtonElement>('button', {name: /click me/i})
 }
 
 /*

--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -254,6 +254,10 @@ export async function testWithin() {
 
   await container.findByRole('button', {name: /click me/i})
   container.getByRole<HTMLButtonElement>('button', {name: /click me/i})
+
+  let withinQueries = within(document.body)
+  withinQueries = within(document.body)
+  withinQueries.getByRole<HTMLButtonElement>('button', {name: /click me/i})
 }
 
 /*

--- a/types/get-queries-for-element.d.ts
+++ b/types/get-queries-for-element.d.ts
@@ -176,6 +176,7 @@ export interface Queries {
 }
 
 export function getQueriesForElement<
-  T extends Queries = typeof queries,
-  K extends T = T,
->(element: HTMLElement, queriesToBind?: K): BoundFunctions<K>
+  QueriesToBind extends Queries = typeof queries,
+  // Extra type parameter required for reassignment.
+  T extends QueriesToBind = QueriesToBind,
+>(element: HTMLElement, queriesToBind?: T): BoundFunctions<T>

--- a/types/get-queries-for-element.d.ts
+++ b/types/get-queries-for-element.d.ts
@@ -175,7 +175,7 @@ export interface Queries {
   [T: string]: Query
 }
 
-export function getQueriesForElement<T extends Queries = typeof queries>(
-  element: HTMLElement,
-  queriesToBind?: T,
-): BoundFunctions<T>
+export function getQueriesForElement<
+  T extends Queries = typeof queries,
+  K extends T = T,
+>(element: HTMLElement, queriesToBind?: K): BoundFunctions<K>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/react-testing-library/issues/979

TS error occurs when reassigning the return value of `within`

```typescript
import { screen, within } from "@testing-library/dom";
import "@types/jest";
import "@testing-library/jest-dom";

const navigation = screen.getByRole("navigation");
let breadcrumbs = within(navigation);
expect(breadcrumbs.getByRole("link", { name: /home/i })).toBeInTheDocument();
// ts error occurs
breadcrumbs = within(navigation);
```


https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgZwMZQKYYHYBo4DuwMAFsNnAL5wBmUEIcARAAIwbIzkDmAtADbAARlACGUAJ4B6ACYMmAbgBQoSLGZsJYDlIBWHGIpXho8Vu048BwsZL0HeckEaWoI2TnGyiAbsG6iXO5wALwo6FjYAHTcGDAAQhIAShD8GAAUTN5+AUHYTACUymnwIhiiMugAriBCyKGExGTY6dn+gcDuRUoYAB7aqDDpZRXVtcgxcYkpaZmC2ADWTPhI3iAYAFxwUiQMGFLAVAUFUTAQ8RgAktgAKiQYACIQqDU4Q90jlVA1dQ1EpORWr52nkikA

<!-- Why are these changes necessary? -->

**Why**:

To avoid TS error or type-casting.

<!-- How were these changes implemented? -->

**How**:

The type error happens because TS tries to infer `T` from  the variable `breadcrumbs`(`BoundFunctions<T>`) in the demo above. This is fixed by adding another generic variable `K`.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
