### PR TITLE
feat(roleHelpers): compute tree implicit arialevel

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -3,6 +3,7 @@ import {
   logRoles,
   getImplicitAriaRoles,
   isInaccessible,
+  computeAriaLevel,
 } from '../role-helpers'
 import {render} from './helpers/test-utils'
 
@@ -72,6 +73,28 @@ function setup() {
     <dd data-testid="a-dd">Definition</dd>
    </dl>
 </section>
+
+    <ul role="tree" data-testid="a-tree">
+      <li role="treeitem" aria-expanded="false" tabIndex="0">
+        <span className="">Projects</span>
+        <ul role="group">
+          <li role="treeitem" className="doc" tabIndex="-1">
+            project-1.docx
+          </li>
+          <li role="treeitem" className="doc" tabIndex="-1">
+            project-2.docx
+          </li>
+          <li role="treeitem" aria-expanded="true" tabIndex="-1" data-testid="level2-treeitem">
+            <span className="">Project 3</span>
+            <ul role="group">
+              <li role="treeitem" className="doc" tabIndex="-1" data-testid="level3-treeitem">
+                project-3A.docx
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
   `)
 
   return {
@@ -107,6 +130,9 @@ function setup() {
     dt: getByTestId('a-dt'),
     dd: getByTestId('a-dd'),
     header: getByTestId('a-header'),
+    tree: getByTestId('a-tree'),
+    treeItem2: getByTestId('level2-treeitem'),
+    treeItem3: getByTestId('level3-treeitem'),
   }
 }
 
@@ -199,4 +225,10 @@ test.each([
   container.firstChild.appendChild(document.createElement('button'))
 
   expect(isInaccessible(container.querySelector('button'))).toBe(expected)
+})
+
+test('computeAriaLevel', () => {
+  const {treeItem2, treeItem3} = setup()
+  expect(computeAriaLevel(treeItem2)).toBe(2)
+  expect(computeAriaLevel(treeItem3)).toBe(3)
 })

--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -228,7 +228,10 @@ test.each([
 })
 
 test('computeAriaLevel', () => {
-  const {treeItem2, treeItem3} = setup()
+  const {treeItem2, treeItem3, h1, h2, h3} = setup()
   expect(computeAriaLevel(treeItem2)).toBe(2)
   expect(computeAriaLevel(treeItem3)).toBe(3)
+  expect(computeAriaLevel(h1)).toBe(1)
+  expect(computeAriaLevel(h2)).toBe(2)
+  expect(computeAriaLevel(h3)).toBe(3)
 })

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -6,7 +6,7 @@ import {
   computeAriaPressed,
   computeAriaCurrent,
   computeAriaExpanded,
-  computeHeadingLevel,
+  computeAriaLevel,
   getImplicitAriaRoles,
   prettyRoles,
   isInaccessible,
@@ -148,7 +148,7 @@ function queryAllByRole(
         return expanded === computeAriaExpanded(element)
       }
       if (level !== undefined) {
-        return level === computeHeadingLevel(element)
+        return level === computeAriaLevel(element)
       }
       // don't care if aria attributes are unspecified
       return true

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -284,6 +284,50 @@ function checkBooleanAttribute(element, attribute) {
  * @param {Element} element -
  * @returns {number | undefined} - number if implicit heading or aria-level present, otherwise undefined
  */
+function computeTreeItemLevel(element, level) {
+  // https://www.w3.org/TR/wai-aria-1.1/#treeitem
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-level
+  if (element.getAttribute('role') === 'tree') {
+    return level
+  }
+
+  if (element.getAttribute('role') === 'treeitem') {
+    level += 1
+  }
+
+  if (element.parentElement) {
+    return computeTreeItemLevel(element.parentElement, level)
+  }
+
+  return undefined
+}
+
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} - number if implicit aria-level can be inferred or aria-level present, otherwise undefined
+ */
+function computeAriaLevel(element) {
+  // implicit aria-level
+  if (element.getAttribute('role') === 'treeitem') {
+    return computeTreeItemLevel(element, 0)
+  }
+  if (getImplicitAriaRoles(element).includes('heading')) {
+    return computeHeadingLevel(element)
+  }
+
+  // explicit aria-level value
+  // https://www.w3.org/TR/wai-aria-1.2/#aria-level
+  const ariaLevelAttribute =
+    element.getAttribute('aria-level') &&
+    Number(element.getAttribute('aria-level'))
+
+  return ariaLevelAttribute
+}
+
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} - number if implicit heading or aria-level present, otherwise undefined
+ */
 function computeHeadingLevel(element) {
   // https://w3c.github.io/html-aam/#el-h1-h6
   // https://w3c.github.io/html-aam/#el-h1-h6
@@ -295,13 +339,8 @@ function computeHeadingLevel(element) {
     H5: 5,
     H6: 6,
   }
-  // explicit aria-level value
-  // https://www.w3.org/TR/wai-aria-1.2/#aria-level
-  const ariaLevelAttribute =
-    element.getAttribute('aria-level') &&
-    Number(element.getAttribute('aria-level'))
 
-  return ariaLevelAttribute || implicitHeadingLevels[element.tagName]
+  return implicitHeadingLevels[element.tagName]
 }
 
 export {
@@ -316,5 +355,5 @@ export {
   computeAriaPressed,
   computeAriaCurrent,
   computeAriaExpanded,
-  computeHeadingLevel,
+  computeAriaLevel,
 }


### PR DESCRIPTION
**What**: Adding the option to implicitly get the `aria-level` of a `treeitem`

**Why**: Resolves https://github.com/testing-library/dom-testing-library/issues/980

**How**: At the moment, I'm using the naive approach and climb up the tree until I reach a node with explicit role `tree`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
