### PR TITLE
test: move resize test outside of forEach

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -172,15 +172,15 @@ eventTypes.forEach(({type, events, elementType}) => {
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
-
-    it('fires resize', () => {
-      const node = document.defaultView
-      const spy = jest.fn()
-      node.addEventListener('resize', spy, {once: true})
-      fireEvent.resize(node)
-      expect(spy).toHaveBeenCalledTimes(1)
-    })
   })
+})
+
+it('fires resize', () => {
+  const node = document.defaultView
+  const spy = jest.fn()
+  node.addEventListener('resize', spy, {once: true})
+  fireEvent.resize(node)
+  expect(spy).toHaveBeenCalledTimes(1)
 })
 
 describe(`Bubbling Events`, () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I noticed when running the tests that the `fires resize` test was defined within the `forEach` above, meaning it was running for every `eventType` item.

<!-- Why are these changes necessary? -->

**Why**:

Remove redundant duplicate test runs.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
