### PR TITLE
chore: Fix failing codesandbox/ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
     "format": "kcd-scripts format",
+    "install:csb": "npm install",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",


### PR DESCRIPTION
Ports https://github.com/testing-library/react-testing-library/pull/1020 to this repository. 

We're experiencing the same issue with codesandbox in https://ci.codesandbox.io/status/testing-library/dom-testing-library/pr/1112/builds/229879