### PR TITLE
fix: reset regexg to prevent regexg with global flags to not match every element

### DIFF
--- a/src/__tests__/matches.js
+++ b/src/__tests__/matches.js
@@ -15,6 +15,22 @@ test('matchers accept regex', () => {
   expect(fuzzyMatches('ABC', node, /ABC/, normalizer)).toBe(true)
 })
 
+// https://stackoverflow.com/questions/1520800/why-does-a-regexp-with-global-flag-give-wrong-results
+test('a regex with the global flag consistently (re-)finds a match', () => {
+  const regex = /ABC/g
+  const spy = jest.spyOn(console, 'warn').mockImplementation()
+
+  expect(matches('ABC', node, regex, normalizer)).toBe(true)
+  expect(fuzzyMatches('ABC', node, regex, normalizer)).toBe(true)
+
+  expect(spy).toBeCalledTimes(2)
+  expect(spy).toHaveBeenCalledWith(
+    `To match all elements we had to reset the lastIndex of the RegExp because the global flag is enabled. We encourage to remove the global flag from the RegExp.`,
+  )
+
+  console.warn.mockClear()
+})
+
 test('matchers accept functions', () => {
   expect(matches('ABC', node, text => text === 'ABC', normalizer)).toBe(true)
   expect(fuzzyMatches('ABC', node, text => text === 'ABC', normalizer)).toBe(

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -36,7 +36,7 @@ function fuzzyMatches(
   } else if (typeof matcher === 'function') {
     return matcher(normalizedText, node)
   } else {
-    return matcher.test(normalizedText)
+    return matchRegExp(matcher, normalizedText)
   }
 }
 
@@ -56,7 +56,7 @@ function matches(
   if (matcher instanceof Function) {
     return matcher(normalizedText, node)
   } else if (matcher instanceof RegExp) {
-    return matcher.test(normalizedText)
+    return matchRegExp(matcher, normalizedText)
   } else {
     return normalizedText === String(matcher)
   }
@@ -109,6 +109,17 @@ function makeNormalizer({
   }
 
   return normalizer
+}
+
+function matchRegExp(matcher: RegExp, text: string) {
+  const match = matcher.test(text)
+  if (matcher.global && matcher.lastIndex !== 0) {
+    console.warn(
+      `To match all elements we had to reset the lastIndex of the RegExp because the global flag is enabled. We encourage to remove the global flag from the RegExp.`,
+    )
+    matcher.lastIndex = 0
+  }
+  return match
 }
 
 export {fuzzyMatches, matches, getDefaultNormalizer, makeNormalizer}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Resolves #1115

<!-- Why are these changes necessary? -->

**Why**: 

The instance of a regex that's using the global flag hold a `lastIndex` state.
This might give false positive results.

For example:


```
const g = /foo/g
g.test('foo') // |> true
g.test('foo') // |> false because lastIndex is 3
g.test('foo') // |> true because lastIndex is 0 again
g.test('foo') // |> false because lastIndex is 3
```
<!-- How were these changes implemented? -->

**How**:

Added a reproduction test case.
Recreate a new regex instance from the original regex.

An alternative would be to reset the `lastIndex` to `0` after the check.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
