### PR TITLE
feat(byRole): Add description filter

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -572,3 +572,177 @@ test('should find the input using type property instead of attribute', () => {
   const {getByRole} = render('<input type="124">')
   expect(getByRole('textbox')).not.toBeNull()
 })
+
+test('can be filtered by accessible description', () => {
+  const targetedNotificationMessage = 'Your session is about to expire!'
+  const {getByRole} = renderIntoDocument(
+    `
+<ul>
+  <li role="alertdialog" aria-describedby="notification-id-1">
+    <div><button>Close</button></div>
+    <div id="notification-id-1">You have unread emails</div>
+  </li>
+  <li role="alertdialog" aria-describedby="notification-id-2">
+    <div><button>Close</button></div>
+    <div id="notification-id-2">${targetedNotificationMessage}</div>
+  </li>
+</ul>`,
+  )
+
+  const notification = getByRole('alertdialog', {
+    description: targetedNotificationMessage,
+  })
+
+  expect(notification).not.toBeNull()
+  expect(notification).toHaveTextContent(targetedNotificationMessage)
+
+  expect(
+    getQueriesForElement(notification).getByRole('button', {name: 'Close'}),
+  ).not.toBeNull()
+})
+
+test('error should include description when filtering a no results are found', () => {
+  const targetedNotificationMessage = 'Your session is about to expire!'
+  const {getByRole} = renderIntoDocument(
+    `<div role="dialog" aria-describedby="some-id"><div><button>Close</button></div><div id="some-id">${targetedNotificationMessage}</div></div>`,
+  )
+
+  expect(() =>
+    getByRole('alertdialog', {description: targetedNotificationMessage}),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    Unable to find an accessible element with the role "alertdialog" and description "Your session is about to expire!"
+
+    Here are the accessible roles:
+
+      dialog:
+
+      Name "":
+      Description "Your session is about to expire!":
+      <div
+        aria-describedby="some-id"
+        role="dialog"
+      />
+
+      --------------------------------------------------
+      button:
+
+      Name "Close":
+      Description "":
+      <button />
+
+      --------------------------------------------------
+
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      <div
+        aria-describedby="some-id"
+        role="dialog"
+      >
+        <div>
+          <button>
+            Close
+          </button>
+        </div>
+        <div
+          id="some-id"
+        >
+          Your session is about to expire!
+        </div>
+      </div>
+    </body>
+  `)
+})
+
+test('TextMatch serialization for description filter in error message', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div role="alertdialog" aria-describedby="some-id"><div><button>Close</button></div><div id="some-id">Your session is about to expire!</div></div>`,
+  )
+
+  expect(() => getByRole('alertdialog', {description: /unknown description/}))
+    .toThrowErrorMatchingInlineSnapshot(`
+    Unable to find an accessible element with the role "alertdialog" and description \`/unknown description/\`
+
+    Here are the accessible roles:
+
+      alertdialog:
+
+      Name "":
+      Description "Your session is about to expire!":
+      <div
+        aria-describedby="some-id"
+        role="alertdialog"
+      />
+
+      --------------------------------------------------
+      button:
+
+      Name "Close":
+      Description "":
+      <button />
+
+      --------------------------------------------------
+
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      <div
+        aria-describedby="some-id"
+        role="alertdialog"
+      >
+        <div>
+          <button>
+            Close
+          </button>
+        </div>
+        <div
+          id="some-id"
+        >
+          Your session is about to expire!
+        </div>
+      </div>
+    </body>
+  `)
+
+  expect(() => getByRole('alertdialog', {description: () => false}))
+    .toThrowErrorMatchingInlineSnapshot(`
+    Unable to find an accessible element with the role "alertdialog" and description \`() => false\`
+
+    Here are the accessible roles:
+
+      alertdialog:
+
+      Name "":
+      Description "Your session is about to expire!":
+      <div
+        aria-describedby="some-id"
+        role="alertdialog"
+      />
+
+      --------------------------------------------------
+      button:
+
+      Name "Close":
+      Description "":
+      <button />
+
+      --------------------------------------------------
+
+    Ignored nodes: comments, <script />, <style />
+    <body>
+      <div
+        aria-describedby="some-id"
+        role="alertdialog"
+      >
+        <div>
+          <button>
+            Close
+          </button>
+        </div>
+        <div
+          id="some-id"
+        >
+          Your session is about to expire!
+        </div>
+      </div>
+    </body>
+  `)
+})

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -601,7 +601,7 @@ test('can be filtered by accessible description', () => {
   ).not.toBeNull()
 })
 
-test('error should include description when filtering a no results are found', () => {
+test('error should include description when filtering and no results are found', () => {
   const targetedNotificationMessage = 'Your session is about to expire!'
   const {getByRole} = renderIntoDocument(
     `<div role="dialog" aria-describedby="some-id"><div><button>Close</button></div><div id="some-id">${targetedNotificationMessage}</div></div>`,

--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -1,4 +1,7 @@
-import {computeAccessibleName} from 'dom-accessibility-api'
+import {
+  computeAccessibleDescription,
+  computeAccessibleName,
+} from 'dom-accessibility-api'
 import {roles as allRoles, roleElements} from 'aria-query'
 import {
   computeAriaSelected,
@@ -30,6 +33,7 @@ function queryAllByRole(
     collapseWhitespace,
     hidden = getConfig().defaultHidden,
     name,
+    description,
     trim,
     normalizer,
     queryFallbacks = false,
@@ -170,6 +174,22 @@ function queryAllByRole(
       )
     })
     .filter(element => {
+      if (description === undefined) {
+        // Don't care
+        return true
+      }
+
+      return matches(
+        computeAccessibleDescription(element, {
+          computedStyleSupportsPseudoElements:
+            getConfig().computedStyleSupportsPseudoElements,
+        }),
+        element,
+        description,
+        text => text,
+      )
+    })
+    .filter(element => {
       return hidden === false
         ? isInaccessible(element, {
             isSubtreeInaccessible: cachedIsSubtreeInaccessible,
@@ -216,7 +236,7 @@ const getMultipleError = (c, role, {name} = {}) => {
 const getMissingError = (
   container,
   role,
-  {hidden = getConfig().defaultHidden, name} = {},
+  {hidden = getConfig().defaultHidden, name, description} = {},
 ) => {
   if (getConfig()._disableExpensiveErrorDiagnostics) {
     return `Unable to find role="${role}"`
@@ -227,6 +247,7 @@ const getMissingError = (
     roles += prettyRoles(childElement, {
       hidden,
       includeName: name !== undefined,
+      includeDescription: description !== undefined,
     })
   })
   let roleMessage
@@ -257,10 +278,19 @@ Here are the ${hidden === false ? 'accessible' : 'available'} roles:
     nameHint = ` and name \`${name}\``
   }
 
+  let descriptionHint = ''
+  if (description === undefined) {
+    descriptionHint = ''
+  } else if (typeof description === 'string') {
+    descriptionHint = ` and description "${description}"`
+  } else {
+    descriptionHint = ` and description \`${description}\``
+  }
+
   return `
 Unable to find an ${
     hidden === false ? 'accessible ' : ''
-  }element with the role "${role}"${nameHint}
+  }element with the role "${role}"${nameHint}${descriptionHint}
 
 ${roleMessage}`.trim()
 }

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -1,5 +1,8 @@
 import {elementRoles} from 'aria-query'
-import {computeAccessibleName} from 'dom-accessibility-api'
+import {
+  computeAccessibleDescription,
+  computeAccessibleName,
+} from 'dom-accessibility-api'
 import {prettyDOM} from './pretty-dom'
 import {getConfig} from './config'
 
@@ -178,7 +181,7 @@ function getRoles(container, {hidden = false} = {}) {
     }, {})
 }
 
-function prettyRoles(dom, {hidden}) {
+function prettyRoles(dom, {hidden, includeDescription}) {
   const roles = getRoles(dom, {hidden})
   // We prefer to skip generic role, we don't recommend it
   return Object.entries(roles)
@@ -191,7 +194,20 @@ function prettyRoles(dom, {hidden}) {
             computedStyleSupportsPseudoElements:
               getConfig().computedStyleSupportsPseudoElements,
           })}":\n`
+
           const domString = prettyDOM(el.cloneNode(false))
+
+          if (includeDescription) {
+            const descriptionString = `Description "${computeAccessibleDescription(
+              el,
+              {
+                computedStyleSupportsPseudoElements:
+                  getConfig().computedStyleSupportsPseudoElements,
+              },
+            )}":\n`
+            return `${nameString}${descriptionString}${domString}`
+          }
+
           return `${nameString}${domString}`
         })
         .join('\n\n')

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -115,6 +115,13 @@ export interface ByRoleOptions extends MatcherOptions {
     | RegExp
     | string
     | ((accessibleName: string, element: Element) => boolean)
+  /**
+   * Only considers elements with the specified accessible description.
+   */
+  description?:
+    | RegExp
+    | string
+    | ((accessibleDescription: string, element: Element) => boolean)
 }
 
 export type AllByRole<T extends HTMLElement = HTMLElement> = (


### PR DESCRIPTION
**What**:

Add a new `description` option to `ByRole` queries.
This helps finding elements which are aria described.

**Why**:

We were implementing a React component to display the usual popup notifications and, when reading about accessibility considerations, we found we should use `ariadialog` role and we also should use `aria-describedby` to reference the message ([spec documentation](https://www.w3.org/TR/wai-aria-1.1/#alertdialog)).

When writing some tests we wanted to have one where we could close an specific notification when a list of them were rendered in a view.

`ByRole` queries currently support filtering results by accessible name, but no filtering by **accessible description**.

**How**:

Since this project is already using the [dom-accessibility-api](https://github.com/eps1lon/dom-accessibility-api) dependency to resolve the accessible name and that library also expose a function to resolve the accessible description, I would like to introduce this proposal where we implement **filtering by description** when using `ByRole` queries.

Given some HTML markup like this one:
```
<ul>
  <li role="alertdialog" aria-describedby="notification-id-1">
    <div><button>Close</button></div>
    <div id="notification-id-1">You have unread emails</div>
  </li>
  <li role="alertdialog" aria-describedby="notification-id-2">
    <div><button>Close</button></div>
    <div id="notification-id-2">Your session is about to expire!</div>
  </li>
</ul>
```

Now we can find `alertdialog` elements with this kind of query:
```
const notification = getByRole('alertdialog', {
  description: 'Your session is about to expire!',
});
```

I used [this PR](https://github.com/testing-library/dom-testing-library/pull/408) (when `name`filtering was added to `ByRole` queries) to guide my proposed implementation.

I just wanted to create the proposal with some actual code so maybe it's easier to reason about and maybe there are other thing to take into account that we might discuss as a follow-up of this starting point.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

**References**
These are the documents I used as reference for this proposal:
* [RTL docs](https://testing-library.com/docs/queries/byrole)
* [`alertdialog` spec](https://www.w3.org/TR/wai-aria-1.1/#alertdialog)
* [What is an accessible name?](https://www.tpgi.com/what-is-an-accessible-name/)
* [Accessible Name and Description spec](https://www.w3.org/TR/accname-1.1/)

