### PR TITLE
refactor: remove includeName argument

### DIFF
--- a/src/queries/role.js
+++ b/src/queries/role.js
@@ -246,7 +246,6 @@ const getMissingError = (
   Array.from(container.children).forEach(childElement => {
     roles += prettyRoles(childElement, {
       hidden,
-      includeName: name !== undefined,
       includeDescription: description !== undefined,
     })
   })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: remove the passed `includeName` argument to `prettryRoles` (based on a recent "discussion" at https://github.com/testing-library/dom-testing-library/pull/1120#discussion_r841955370)

<!-- Why are these changes necessary? -->

**Why**: `includeName` isn't used `prettyRoles` because we always want to show the role name

<!-- How were these changes implemented? -->

**How**: removed the `includeName`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
