### PR TITLE
feat: add a return value from logTestingPlaygroundURL

### DIFF
--- a/src/__tests__/screen.js
+++ b/src/__tests__/screen.js
@@ -64,6 +64,15 @@ test('logs Playground URL that are passed as element', () => {
   `)
 })
 
+test('returns Playground URL that are passed as element', () => {
+  const playGroundUrl = screen.logTestingPlaygroundURL(
+    render(`<h1>Sign <em>up</em></h1>`).container,
+  )
+  expect(playGroundUrl).toMatchInlineSnapshot(
+    'https://testing-playground.com/#markup=DwCwjAfAyglg5gOwATAKYFsIFcAOwD0GEB4EQA',
+  )
+})
+
 test('exposes debug method', () => {
   renderIntoDocument(
     `<button>test</button><span>multi-test</span><div>multi-test</div>`,

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -42,6 +42,7 @@ const logTestingPlaygroundURL = (element = getDocument().body) => {
   console.log(
     `Open this URL in your browser\n\n${getPlaygroundUrl(element.innerHTML)}`,
   )
+  return getPlaygroundUrl(element.innerHTML)
 }
 
 const initialValue = {debug, logTestingPlaygroundURL}

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -39,10 +39,9 @@ const logTestingPlaygroundURL = (element = getDocument().body) => {
     console.log(`The provided element doesn't have any children.`)
     return
   }
-  console.log(
-    `Open this URL in your browser\n\n${getPlaygroundUrl(element.innerHTML)}`,
-  )
-  return getPlaygroundUrl(element.innerHTML)
+  const playgroundUrl = getPlaygroundUrl(element.innerHTML)
+  console.log(`Open this URL in your browser\n\n${playgroundUrl}`)
+  return playgroundUrl
 }
 
 const initialValue = {debug, logTestingPlaygroundURL}

--- a/types/screen.d.ts
+++ b/types/screen.d.ts
@@ -13,7 +13,7 @@ export type Screen<Q extends Queries = typeof queries> = BoundFunctions<Q> & {
     options?: OptionsReceived,
   ) => void
   /**
-   * Convenience function for `Testing Playground` which logs URL that
+   * Convenience function for `Testing Playground` which logs & return URL that
    * can be opened in a browser
    */
   logTestingPlaygroundURL: (element?: Element | HTMLDocument) => void

--- a/types/screen.d.ts
+++ b/types/screen.d.ts
@@ -16,7 +16,7 @@ export type Screen<Q extends Queries = typeof queries> = BoundFunctions<Q> & {
    * Convenience function for `Testing Playground` which logs and returns the URL that
    * can be opened in a browser
    */
-  logTestingPlaygroundURL: (element?: Element | HTMLDocument) => void
+  logTestingPlaygroundURL: (element?: Element | HTMLDocument) => string
 }
 
 export const screen: Screen

--- a/types/screen.d.ts
+++ b/types/screen.d.ts
@@ -13,7 +13,7 @@ export type Screen<Q extends Queries = typeof queries> = BoundFunctions<Q> & {
     options?: OptionsReceived,
   ) => void
   /**
-   * Convenience function for `Testing Playground` which logs & return URL that
+   * Convenience function for `Testing Playground` which logs and returns the URL that
    * can be opened in a browser
    */
   logTestingPlaygroundURL: (element?: Element | HTMLDocument) => void


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Adding a return value to logTestingPlaygroundURL function besides the log - Resolves #1125

<!-- Why are these changes necessary? -->

logTestingPlaygroundURL() used to prints the value directly to the stdout of the running process, 
The values was hidden in the log window

<!-- How were these changes implemented? -->

Adding a return statement to the logTestingPlaygroundURL function

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [X] Tests
- [X] TypeScript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Will add documentation to testing-library-docs after the PR will be completed.
