### PR TITLE
fix: load and error dispatch `Event` instead of `UIEvent`

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -72,6 +72,16 @@ const eventTypes = [
     elementType: 'div',
   },
   {
+    type: '',
+    events: ['load', 'error'],
+    elementType: 'img',
+  },
+  {
+    type: '',
+    events: ['load', 'error'],
+    elementType: 'script',
+  },
+  {
     type: 'Wheel',
     events: ['wheel'],
     elementType: 'div',
@@ -104,11 +114,6 @@ const eventTypes = [
       'waiting',
     ],
     elementType: 'video',
-  },
-  {
-    type: 'Image',
-    events: ['load', 'error'],
-    elementType: 'img',
   },
   {
     type: 'Animation',

--- a/src/event-map.js
+++ b/src/event-map.js
@@ -274,9 +274,13 @@ export const eventMap = {
     EventType: 'Event',
     defaultInit: {bubbles: false, cancelable: false},
   },
-  // Image Events
+  // Events
   load: {
-    EventType: 'UIEvent',
+    // TODO: load events can be UIEvent or Event depending on what generated them
+    // This is were this abstraction breaks down.
+    // But the common targets are <img />, <script /> and window.
+    // Neither of these targets receive a UIEvent
+    EventType: 'Event',
     defaultInit: {bubbles: false, cancelable: false},
   },
   error: {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`fireEvent.load` (et. al.)  dispatches a `Event` now instead of `UIEvent`
Adds a test for https://github.com/testing-library/dom-testing-library/issues/498

**Why**:

I imagine that the most common targets are `<img />` and `<script />` and neither of these receive load events as `UIEvent`: https://codesandbox.io/s/react-script-does-not-work-the-way-you-think-it-does-stc66c

**How**:

Changed event type and added tests for `<script />`. Ieft a note that our abstraction doesn't support firing events with different types.

Also  removed the notion of "Image events" from comments. We refer to DOM interfaces in all other cases. But there is no such thing as `ImageEvent`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
