### PR TITLE
fix: Don't assume named exports interop

### DIFF
--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,4 +1,6 @@
-import {compressToEncodedURIComponent} from 'lz-string'
+// WARNING: `lz-string` only has a default export but statically we assume named exports are allowd
+// TODO: Statically verify we don't rely on NodeJS implicit named imports.
+import lzString from 'lz-string'
 import type {OptionsReceived} from 'pretty-format'
 import {getQueriesForElement} from './get-queries-for-element'
 import {getDocument} from './helpers'
@@ -12,7 +14,7 @@ function unindent(string: string) {
 }
 
 function encode(value: string) {
-  return compressToEncodedURIComponent(unindent(value))
+  return lzString.compressToEncodedURIComponent(unindent(value))
 }
 
 function getPlaygroundUrl(markup: string) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes #995

**Why**:

The ecosystem is annoying

**How**:

Follow advise of error message:
```
SyntaxError: Named export 'compressToEncodedURIComponent' not found. The requested module 'lz-string' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'lz-string';
const { compressToEncodedURIComponent } = pkg;
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
