### PR TITLE
chore: Convert `helpers.js` to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
       "plugin:import/typescript"
     ],
     "rules": {
+      "@typescript-eslint/prefer-optional-chain": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/prefer-includes": "off",
       "import/prefer-default-export": "off",
       "import/no-unassigned-import": "off",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,7 +7,7 @@ function jestFakeTimersAreEnabled() {
   if (typeof jest !== 'undefined' && jest !== null) {
     return (
       // legacy timers
-      setTimeout._isMockFunction === true ||
+      (setTimeout as any)._isMockFunction === true ||
       // modern timers
       Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
     )
@@ -23,7 +23,7 @@ function getDocument() {
   }
   return window.document
 }
-function getWindowFromNode(node) {
+function getWindowFromNode(node: any) {
   if (node.defaultView) {
     // node is document
     return node.defaultView
@@ -60,11 +60,11 @@ function getWindowFromNode(node) {
   }
 }
 
-function checkContainerType(container) {
+function checkContainerType(container: unknown) {
   if (
     !container ||
-    !(typeof container.querySelector === 'function') ||
-    !(typeof container.querySelectorAll === 'function')
+    !(typeof (container as any).querySelector === 'function') ||
+    !(typeof (container as any).querySelectorAll === 'function')
   ) {
     throw new TypeError(
       `Expected container to be an Element, a Document or a DocumentFragment but got ${getTypeName(
@@ -73,7 +73,7 @@ function checkContainerType(container) {
     )
   }
 
-  function getTypeName(object) {
+  function getTypeName(object: unknown) {
     if (typeof object === 'object') {
       return object === null ? 'null' : object.constructor.name
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,6 +4,7 @@ const TEXT_NODE = 3
 
 function jestFakeTimersAreEnabled() {
   /* istanbul ignore else */
+  // eslint-disable-next-line
   if (typeof jest !== 'undefined' && jest !== null) {
     return (
       // legacy timers


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Part of #494

**Why**:

To use generated TypeScript declaration files eventually

**How**:

Fairly low level helpers where most types are `unknown`. Uses `any` for pragmatic reasons.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
