### PR TITLE
feat: Allow disabling colorized debug output

### DIFF
--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -152,3 +152,17 @@ test('prettyDOM can include all elements with a custom filter', () => {
     </body>
   `)
 })
+
+test('prettyDOM supports a COLORS environment variable', () => {
+  const {container} = render('<div>Hello World!</div>')
+
+  const noColors = prettyDOM(container, undefined, {highlight: false})
+  const withColors = prettyDOM(container, undefined, {highlight: true})
+
+  // process.env.COLORS is a string, so make sure we test it as such
+  process.env.COLORS = 'false'
+  expect(prettyDOM(container)).toEqual(noColors)
+
+  process.env.COLORS = 'true'
+  expect(prettyDOM(container)).toEqual(withColors)
+})

--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -4,10 +4,27 @@ import {getUserCodeFrame} from './get-user-code-frame'
 import {getDocument} from './helpers'
 import {getConfig} from './config'
 
-const inNode = () =>
-  typeof process !== 'undefined' &&
-  process.versions !== undefined &&
-  process.versions.node !== undefined
+const shouldHighlight = () => {
+  let colors
+  try {
+    colors = JSON.parse(process?.env?.COLORS)
+  } catch (e) {
+    // If this throws, process?.env?.COLORS wasn't parsable. Since we only
+    // care about `true` or `false`, we can safely ignore the error.
+  }
+
+  if (typeof colors === 'boolean') {
+    // If `colors` is set explicitly (both `true` and `false`), use that value.
+    return colors
+  } else {
+    // If `colors` is not set, colorize if we're in node.
+    return (
+      typeof process !== 'undefined' &&
+      process.versions !== undefined &&
+      process.versions.node !== undefined
+    )
+  }
+}
 
 const {DOMCollection} = prettyFormat.plugins
 
@@ -61,7 +78,7 @@ function prettyDOM(dom, maxLength, options = {}) {
   const debugContent = prettyFormat.format(dom, {
     plugins: [createDOMElementFilter(filterNode), DOMCollection],
     printFunctionName: false,
-    highlight: inNode(),
+    highlight: shouldHighlight(),
     ...prettyFormatOptions,
   })
   return maxLength !== undefined && dom.outerHTML.length > maxLength


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 

Add an environment flag that allows turning off of colors from the command line.

<!-- Why are these changes necessary? -->

**Why**: 

Some environments current flag as "node", but print logs in formats that don't handle colorization which makes reading the logs hard to read.

More details here: https://github.com/testing-library/dom-testing-library/issues/1153

<!-- How were these changes implemented? -->

**How**: 

Changed the `isNode` function to `shouldHighlight`, and check for the environment variable before checking for the

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated - **N/A**
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
