### PR TITLE
fix: Pin supported target environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,25 @@
   "engines": {
     "node": ">=12"
   },
+  "browserslist": [
+    "and_chr 103",
+    "and_ff 101",
+    "and_qq 10.4",
+    "and_uc 12.12",
+    "android 103",
+    "chrome 102",
+    "edge 102",
+    "firefox 91",
+    "ios_saf 12.2-12.5",
+    "kaios 2.5",
+    "op_mini all",
+    "op_mob 64",
+    "opera 88",
+    "safari 15.5",
+    "samsung 17.0",
+    "samsung 16.0",
+    "node 12.0"
+  ],
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
     "format": "kcd-scripts format",


### PR DESCRIPTION

**What**:

Closes https://github.com/testing-library/dom-testing-library/issues/1169

**Why**:

A minor release created a build with that contained syntax that we don't support yet.

**How**:

Run `npx browserslist defaults` with a version of `caniuse-lite` that was used at the time of the latest good release. 
That snapshot is now contained in our manifest and ensures build tools transpile to this target.
Having "defaults" as the target environment is too weak of a contract to have. 
Now it's apparent that changing the target environment is considered a breaking change.
We can decide in the next major release what a good matrix for supported runtimes is. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests `rm -rf node_modules/; npm install; npm run build`, check `dist/@testing-library/dom.esm.js`, no more `??`
- ~[ ]~ TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
