### PR TITLE
feat: Drop support for Node.js 12.x

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
-  "node": "12"
+  "node": "14"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,7 @@ jobs:
       # Otherwise we would not know if the problem is tied to the Node.js version
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "browserslist": [
     "and_chr 103",
@@ -40,7 +40,7 @@
     "safari 15.5",
     "samsung 17.0",
     "samsung 16.0",
-    "node 12.0"
+    "node 14.0"
   ],
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",


### PR DESCRIPTION
BREAKING CHANGE: Minimum supported Node.js version is now 14.x

**What**:

Drop support for Node.js 12.x

**Why**:

Reached EOL in April 2022. Tooling is starting to drop Node.js 12.x (see JSDOM) as well so it's time to upgrade to be able to test compat with latest test frameworks (e.g. Jest).

**How**:

Targetting alpha for now. Want to batch this with https://github.com/testing-library/dom-testing-library/issues/1202
Look for occurence of "12" and update where appropriate. Also introducing Node.js 18.x into test matrix since that is now in Active LTS

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
