### PR TITLE
Bump kcd-scripts to 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
       "./node_modules/kcd-scripts/eslint.js",
       "plugin:import/typescript"
     ],
+    "parserOptions": {
+      "ecmaVersion": 2020
+    },
     "rules": {
       "@typescript-eslint/prefer-optional-chain": "off",
       "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",
-    "jsdom": "^16.4.0",
-    "kcd-scripts": "^11.0.0",
+    "jsdom": "19.0.0",
+    "kcd-scripts": "^12.3.0",
     "typescript": "^4.1.2"
   },
   "eslintConfig": {

--- a/src/__tests__/config.js
+++ b/src/__tests__/config.js
@@ -11,12 +11,13 @@ describe('configuration API', () => {
       return {}
     })
   })
-  afterEach(() => {
-    configure(originalConfig)
-  })
 
   beforeEach(() => {
     configure({other: 123})
+  })
+
+  afterEach(() => {
+    configure(originalConfig)
   })
 
   describe('getConfig', () => {

--- a/src/__tests__/fake-timers.js
+++ b/src/__tests__/fake-timers.js
@@ -70,6 +70,7 @@ test('recursive timers do not cause issues', async () => {
   let recurse = true
   function startTimer() {
     setTimeout(() => {
+      // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
       if (recurse) startTimer()
     }, 1)
   }

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -564,11 +564,11 @@ describe('configuration', () => {
       queryByRole('button', {name: 'Hello, Dave!'})
 
       expect(console.error).toHaveBeenCalledTimes(2)
-      expect(console.error.mock.calls[0][0]).toMatch(
-        'Error: Not implemented: window.computedStyle(elt, pseudoElt)',
+      expect(console.error.mock.calls[0][0].message).toMatch(
+        'Not implemented: window.computedStyle(elt, pseudoElt)',
       )
-      expect(console.error.mock.calls[1][0]).toMatch(
-        'Error: Not implemented: window.computedStyle(elt, pseudoElt)',
+      expect(console.error.mock.calls[1][0].message).toMatch(
+        'Not implemented: window.computedStyle(elt, pseudoElt)',
       )
     } finally {
       jest.restoreAllMocks()

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -274,6 +274,7 @@ test('accessible name filter implements TextMatch', () => {
   expect(
     getByRole('heading', {
       name: (name, element) => {
+        // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
         return element.nodeName === 'H2' && name === 'Your Signature'
       },
     }),

--- a/src/__tests__/wait-for-element-to-be-removed.js
+++ b/src/__tests__/wait-for-element-to-be-removed.js
@@ -98,6 +98,7 @@ test('rethrows non-testing-lib errors', () => {
   const error = new Error('my own error')
   return expect(
     waitForElementToBeRemoved(() => {
+      // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
       if (throwIt) {
         throw error
       }

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -275,7 +275,7 @@ test('does not work after it resolves', async () => {
       context = 'act'
       try {
         const result = callback()
-        // eslint-disable-next-line jest/no-if
+        // eslint-disable-next-line jest/no-if, jest/no-conditional-in-test -- false-positive
         if (typeof result?.then === 'function') {
           const thenable = result
           return {
@@ -319,6 +319,7 @@ test('does not work after it resolves', async () => {
 
   await waitFor(
     () => {
+      // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
       if (data === null) {
         throw new Error('not found')
       }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,7 @@ function jestFakeTimersAreEnabled() {
       // legacy timers
       (setTimeout as any)._isMockFunction === true ||
       // modern timers
+      // eslint-disable-next-line prefer-object-has-own -- not supported by our support matrix
       Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
     )
   }

--- a/src/queries/label-text.ts
+++ b/src/queries/label-text.ts
@@ -71,20 +71,23 @@ const queryAllByLabelText: AllByText = (
           if (
             matcher(label.content, label.formControl, text, matchNormalizer) &&
             label.formControl
-          )
+          ) {
             labelledElements.push(label.formControl)
+          }
         })
       const labelsValue = labelList
         .filter(label => Boolean(label.content))
         .map(label => label.content)
       if (
         matcher(labelsValue.join(' '), labelledElement, text, matchNormalizer)
-      )
+      ) {
         labelledElements.push(labelledElement)
+      }
       if (labelsValue.length > 1) {
         labelsValue.forEach((labelValue, index) => {
-          if (matcher(labelValue, labelledElement, text, matchNormalizer))
+          if (matcher(labelValue, labelledElement, text, matchNormalizer)) {
             labelledElements.push(labelledElement)
+          }
 
           const labelsFiltered = [...labelsValue]
           labelsFiltered.splice(index, 1)
@@ -97,8 +100,9 @@ const queryAllByLabelText: AllByText = (
                 text,
                 matchNormalizer,
               )
-            )
+            ) {
               labelledElements.push(labelledElement)
+            }
           }
         })
       }

--- a/src/query-helpers.ts
+++ b/src/query-helpers.ts
@@ -1,11 +1,11 @@
-import type {
-  GetErrorFunction,
-  Matcher,
-  MatcherOptions,
-  QueryMethod,
-  Variant,
-  waitForOptions as WaitForOptions,
-  WithSuggest,
+import {
+  type GetErrorFunction,
+  type Matcher,
+  type MatcherOptions,
+  type QueryMethod,
+  type Variant,
+  type waitForOptions as WaitForOptions,
+  type WithSuggest,
 } from '../types'
 import {getSuggestedQuery} from './suggestions'
 import {fuzzyMatches, matches, makeNormalizer} from './matches'

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -1,7 +1,7 @@
 // WARNING: `lz-string` only has a default export but statically we assume named exports are allowd
 // TODO: Statically verify we don't rely on NodeJS implicit named imports.
 import lzString from 'lz-string'
-import type {OptionsReceived} from 'pretty-format'
+import {type OptionsReceived} from 'pretty-format'
 import {getQueriesForElement} from './get-queries-for-element'
 import {getDocument} from './helpers'
 import {logDOM} from './pretty-dom'


### PR DESCRIPTION
Blocked by https://github.com/testing-library/dom-testing-library/pull/1207
Stacked on [#1207](https://github.com/testing-library/dom-testing-library/pull/1207) ([Diff against #1207](https://github.com/testing-library/dom-testing-library/compare/eps1lon:feat/drop-node-12...eps1lon:test/kcd-scripts-bump))

**What**:

Bump kcd-scripts to 9.x

**Why**:

Get newer versions of JSDOM

**How**:

Bump kcd-scripts to 9.x

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
