### PR TITLE
Bump kcd-scripts to 13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",
-    "jsdom": "19.0.0",
-    "kcd-scripts": "^12.3.0",
+    "jsdom": "20.0.0",
+    "kcd-scripts": "^13.0.0",
     "typescript": "^4.1.2"
   },
   "eslintConfig": {

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -612,8 +612,8 @@ test('should suggest hidden option if element is not in the accessibility tree',
   suggestion.toString()
 
   expect(console.warn.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
+    [
+      [
         Element is inaccessible. This means that the element and all its children are invisible to screen readers.
         If you are using the aria-hidden prop, make sure this is the right choice for your case.
         ,
@@ -649,9 +649,9 @@ test('should find label text using the aria-labelledby', () => {
       warning: '',
     },
     `
-    Object {
-      queryArgs: Array [
-        Object {},
+    {
+      queryArgs: [
+        {},
       ],
       queryMethod: getByLabelText,
       queryName: LabelText,

--- a/tests/jest.config.dom.js
+++ b/tests/jest.config.dom.js
@@ -1,7 +1,12 @@
 const path = require('path')
-const baseConfig = require('kcd-scripts/jest')
+const {
+  // global config options that would trigger warnings in project configs
+  collectCoverageFrom,
+  watchPlugins,
+  ...baseConfig
+} = require('kcd-scripts/jest')
 
-module.exports = {
+const projectConfig = {
   ...baseConfig,
   rootDir: path.join(__dirname, '..'),
   displayName: 'dom',
@@ -12,3 +17,5 @@ module.exports = {
   ],
   testEnvironment: 'jest-environment-jsdom',
 }
+
+module.exports = projectConfig

--- a/tests/jest.config.node.js
+++ b/tests/jest.config.node.js
@@ -1,7 +1,12 @@
 const path = require('path')
-const baseConfig = require('kcd-scripts/jest')
+const {
+  // global config options that would trigger warnings in project configs
+  collectCoverageFrom,
+  watchPlugins,
+  ...baseConfig
+} = require('kcd-scripts/jest')
 
-module.exports = {
+const projectConfig = {
   ...baseConfig,
   rootDir: path.join(__dirname, '..'),
   displayName: 'node',
@@ -13,3 +18,5 @@ module.exports = {
   ],
   testMatch: ['**/__node_tests__/**.js'],
 }
+
+module.exports = projectConfig


### PR DESCRIPTION
**What**:

Bump kcd-scripts to 13.0.0

**Why**:

Get newer versions of JSDOM

**How**:

Bump kcd-scripts to 13.0.0

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
