### PR TITLE
fix(ByRole): Constrain API 

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -788,33 +788,26 @@ test('queryAllByRole returns semantic html elements', () => {
     </form>
   `)
 
-  expect(queryAllByRole(/table/i)).toHaveLength(1)
-  expect(queryAllByRole(/tabl/i, {exact: false})).toHaveLength(1)
-  expect(queryAllByRole(/columnheader/i)).toHaveLength(1)
-  expect(queryAllByRole(/rowheader/i)).toHaveLength(1)
-  expect(queryAllByRole(/grid/i)).toHaveLength(1)
-  expect(queryAllByRole(/form/i)).toHaveLength(0)
-  expect(queryAllByRole(/button/i)).toHaveLength(1)
-  expect(queryAllByRole(/heading/i)).toHaveLength(6)
+  expect(queryAllByRole('table')).toHaveLength(1)
+  expect(queryAllByRole('columnheader')).toHaveLength(1)
+  expect(queryAllByRole('rowheader')).toHaveLength(1)
+  expect(queryAllByRole('grid')).toHaveLength(1)
+  expect(queryAllByRole('form')).toHaveLength(0)
+  expect(queryAllByRole('button')).toHaveLength(1)
+  expect(queryAllByRole('heading')).toHaveLength(6)
   expect(queryAllByRole('list')).toHaveLength(2)
-  expect(queryAllByRole(/listitem/i)).toHaveLength(3)
-  expect(queryAllByRole(/textbox/i)).toHaveLength(2)
-  expect(queryAllByRole(/checkbox/i)).toHaveLength(1)
-  expect(queryAllByRole(/radio/i)).toHaveLength(1)
+  expect(queryAllByRole('listitem')).toHaveLength(3)
+  expect(queryAllByRole('textbox')).toHaveLength(2)
+  expect(queryAllByRole('checkbox')).toHaveLength(1)
+  expect(queryAllByRole('radio')).toHaveLength(1)
   expect(queryAllByRole('row')).toHaveLength(3)
-  expect(queryAllByRole(/rowgroup/i)).toHaveLength(2)
-  expect(queryAllByRole(/(table)|(textbox)/i)).toHaveLength(3)
-  expect(queryAllByRole(/img/i)).toHaveLength(1)
+  expect(queryAllByRole('rowgroup')).toHaveLength(2)
+  expect(queryAllByRole('img')).toHaveLength(1)
   expect(queryAllByRole('meter')).toHaveLength(1)
   expect(queryAllByRole('progressbar')).toHaveLength(0)
   expect(queryAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
   expect(queryAllByRole('combobox')).toHaveLength(1)
   expect(queryAllByRole('listbox')).toHaveLength(1)
-})
-
-test('queryByRole matches case with non-string matcher', () => {
-  const {queryByRole} = render(`<span role="1" />`)
-  expect(queryByRole(1)).toBeTruthy()
 })
 
 test('getAll* matchers return an array', () => {
@@ -827,7 +820,7 @@ test('getAll* matchers return an array', () => {
     getAllByText,
     getAllByRole,
   } = render(`
-    <div role="container">
+    <div role="section">
       <img
         data-testid="poster"
         alt="finding nemo poster"
@@ -864,7 +857,7 @@ test('getAll* matchers return an array', () => {
   expect(getAllByDisplayValue('Japanese cars')).toHaveLength(1)
   expect(getAllByDisplayValue(/cars$/)).toHaveLength(2)
   expect(getAllByText(/^where/i)).toHaveLength(1)
-  expect(getAllByRole(/container/i)).toHaveLength(1)
+  expect(getAllByRole('section')).toHaveLength(1)
   expect(getAllByRole('meter')).toHaveLength(1)
   expect(getAllByRole('progressbar', {queryFallbacks: true})).toHaveLength(1)
 })
@@ -879,7 +872,7 @@ test('getAll* matchers throw for 0 matches', () => {
     getAllByText,
     getAllByRole,
   } = render(`
-    <div role="container">
+    <div role="section">
       <label>No Matches Please</label>
     </div>,
   `)

--- a/src/__tests__/get-by-errors.js
+++ b/src/__tests__/get-by-errors.js
@@ -35,6 +35,10 @@ cases(
       query: /his/,
       html: `<div title="his"></div><div title="history"></div>`,
     },
+    getByRole: {
+      query: 'button',
+      html: `<button>one</button><div role="button">two</button>`,
+    },
     getByTestId: {
       query: /his/,
       html: `<div data-testid="his"></div><div data-testid="history"></div>`,
@@ -81,6 +85,10 @@ cases(
     queryByTitle: {
       query: /his/,
       html: `<div title="his"></div><div title="history"></div>`,
+    },
+    queryByRole: {
+      query: 'button',
+      html: `<button>one</button><div role="button">two</button>`,
     },
     queryByTestId: {
       query: /his/,

--- a/src/__tests__/get-by-errors.js
+++ b/src/__tests__/get-by-errors.js
@@ -35,10 +35,6 @@ cases(
       query: /his/,
       html: `<div title="his"></div><div title="history"></div>`,
     },
-    getByRole: {
-      query: /his/,
-      html: `<div role="his"></div><div role="history"></div>`,
-    },
     getByTestId: {
       query: /his/,
       html: `<div data-testid="his"></div><div data-testid="history"></div>`,
@@ -85,10 +81,6 @@ cases(
     queryByTitle: {
       query: /his/,
       html: `<div title="his"></div><div title="history"></div>`,
-    },
-    queryByRole: {
-      query: /his/,
-      html: `<div role="his"></div><div role="history"></div>`,
     },
     queryByTestId: {
       query: /his/,

--- a/src/__tests__/text-matchers.js
+++ b/src/__tests__/text-matchers.js
@@ -291,10 +291,6 @@ cases(
       dom: `<input value="User ${LRM}name" />`,
       queryFn: 'queryAllByDisplayValue',
     },
-    queryAllByRole: {
-      dom: `<input role="User ${LRM}name" />`,
-      queryFn: 'queryAllByRole',
-    },
   },
 )
 

--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -183,9 +183,7 @@ export async function testByRole() {
   )
 
   console.assert(queryByRole(element, 'foo') === null)
-  console.assert(queryByRole(element, /foo/) === null)
   console.assert(screen.queryByRole('foo') === null)
-  console.assert(screen.queryByRole(/foo/) === null)
 }
 
 export function testA11yHelper() {

--- a/types/matches.d.ts
+++ b/types/matches.d.ts
@@ -7,8 +7,8 @@ export type MatcherFunction = (
 export type Matcher = MatcherFunction | RegExp | number | string
 
 // Get autocomplete for ARIARole union types, while still supporting another string
-// Ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
-export type ByRoleMatcher = ARIARole | MatcherFunction | {}
+// Ref: https://github.com/microsoft/TypeScript/issues/29729#issuecomment-567871939
+export type ByRoleMatcher = ARIARole | (string & {})
 
 export type NormalizerFn = (text: string) => string
 

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -66,7 +66,9 @@ export type FindByText<T extends HTMLElement = HTMLElement> = (
   waitForElementOptions?: waitForOptions,
 ) => Promise<T>
 
-export interface ByRoleOptions extends MatcherOptions {
+export interface ByRoleOptions {
+  /** suppress suggestions for a specific query */
+  suggest?: boolean
   /**
    * If true includes elements in the query set that are usually excluded from
    * the accessibility tree. `role="none"` or `role="presentation"` are included


### PR DESCRIPTION
BREAKING CHANGE: Only allow `string` as a `role`.
Drop support for `exact`, `trim`, `collapseWhitespace`, and `normalizer` options.


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/dom-testing-library/issues/1202

**Why**:

Options are not needed as far as I can tell. From the tests we have, it seems to me this encourages rather bad queries. Will ship this soon-ish (since it's just an alpha) to test.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/1214
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
