### PR TITLE
chore: Allow semantic-release to post updates in issues

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,6 +65,7 @@ jobs:
     permissions:
       actions: write #  to cancel/stop running workflows (styfle/cancel-workflow-action)
       contents: write #  to create release tags (cycjimmy/semantic-release-action)
+      issues: write # to post release that resolves an issue
 
     needs: main
     runs-on: ubuntu-latest


### PR DESCRIPTION
semantic-release posts back to the resolved issues.
Fixes https://github.com/testing-library/dom-testing-library/actions/runs/4198704582/jobs/7282710819#step:7:136