### PR TITLE
test: add missing test for suggestions

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -7,7 +7,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  configure({testIdAttribute: 'data-testid'})
+  configure({testIdAttribute: 'data-testid', throwSuggestions: true})
   console.warn.mockClear()
 })
 
@@ -110,7 +110,6 @@ test('should suggest when suggest is turned on for a specific query but disabled
   <button data-testid="foot">another</button>`)
 
   expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError()
-  configure({throwSuggestions: true})
 })
 
 test('should suggest getByRole when used with getBy', () => {

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -109,7 +109,7 @@ test('should suggest when suggest is turned on for a specific query but disabled
   <button data-testid="foo">submit</button>
   <button data-testid="foot">another</button>`)
 
-  expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError()
+  expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError("try this:\ngetByRole('button', { name: /submit/i })")
 })
 
 test('should suggest getByRole when used with getBy', () => {

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -103,6 +103,16 @@ test('should not suggest when suggest is turned off for a query', () => {
   ).not.toThrowError()
 })
 
+test('should suggest when suggest is turned on for a specific query but disabled in config', () => {
+  configure({throwSuggestions: false})
+  renderIntoDocument(`
+  <button data-testid="foo">submit</button>
+  <button data-testid="foot">another</button>`)
+
+  expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError()
+  configure({throwSuggestions: true})
+})
+
 test('should suggest getByRole when used with getBy', () => {
   renderIntoDocument(`<button data-testid="foo">submit</button>`)
 

--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -109,7 +109,9 @@ test('should suggest when suggest is turned on for a specific query but disabled
   <button data-testid="foo">submit</button>
   <button data-testid="foot">another</button>`)
 
-  expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError("try this:\ngetByRole('button', { name: /submit/i })")
+  expect(() => screen.getByTestId('foo', {suggest: true})).toThrowError(
+    "try this:\ngetByRole('button', { name: /submit/i })",
+  )
 })
 
 test('should suggest getByRole when used with getBy', () => {


### PR DESCRIPTION
**What**: Add a test that was missing for throwing suggestions

**Why**: While working on the docs requested in the [discussion between](https://github.com/testing-library/testing-library-docs/pull/1214#discussion_r1099027874) @eps1lon and @timdeschryver, I saw that based on the implementation, there's a missing test.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - N/A
- [X] Tests
- [ ] TypeScript definitions updated - N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
