### PR TITLE
fix: Ensure MIT licensed lz-string is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
-    "@types/lz-string": "^1.3.34",
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "aria-query": "^5.0.0",
     "chalk": "^4.1.0",
     "dom-accessibility-api": "^0.5.9",
-    "lz-string": "^1.4.4",
+    "lz-string": "^1.5.0",
     "pretty-format": "^27.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/pieroxy/lz-string/issues/147

**Why**:

Ensures the library as a whole is licensed under MIT.

**How**:

Bump lz-string to include https://github.com/pieroxy/lz-string/issues/147
[Changes to published files of lz-string](https://app.renovatebot.com/package-diff?name=lz-string&from=1.4.4&to=1.5.0)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
