### PR TITLE
test: Improve test perf for suggestion tests

### DIFF
--- a/src/__tests__/suggestions.js
+++ b/src/__tests__/suggestions.js
@@ -6,7 +6,14 @@ beforeAll(() => {
   configure({throwSuggestions: true})
 })
 
+beforeEach(() => {
+  // We're testing suggestions of find* queries but we're not interested in their time-related behavior.
+  // Real timers would make the test suite slower for no reason.
+  jest.useFakeTimers()
+})
+
 afterEach(() => {
+  jest.useRealTimers()
   configure({testIdAttribute: 'data-testid'})
   console.warn.mockClear()
 })


### PR DESCRIPTION
Brings down the duration of `suggestions.js` tests from ~9s to <1s.

Was always bugging me how sluggish `suggestions.js` tests were. Revisited them during https://github.com/testing-library/dom-testing-library/pull/1215/files and it turns out they're only slow because of real timers. 

However, the test is not concerned with time but the suggesions themselves. I originally just set the timeout to 1 for `find*` queries but this felt noisy and means we might regress in the future. 