### PR TITLE
feat(ByRole): Allow filter by disabled state

### DIFF
--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -258,3 +258,57 @@ test('`expanded: true|false` matches `expanded` elements with proper role', () =
   expect(getByRole('button', {expanded: true})).toBeInTheDocument()
   expect(getByRole('button', {expanded: false})).toBeInTheDocument()
 })
+
+test('`disabled` throws on unsupported roles', () => {
+  const {getByRole} = render(
+    `<div role="alert" aria-disabled="true">Hello, Dave!</div>`,
+  )
+  expect(() =>
+    getByRole('alert', {disabled: true}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-disabled" is not supported on role "alert".`,
+  )
+})
+
+test('`disabled: true|false` matches `disabled` buttons', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button disabled="true" />
+      <button />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+  expect(getByRole('button', {disabled: false})).toBeInTheDocument()
+})
+
+test('`disabled: true|false` matches `aria-disabled` buttons', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button aria-disabled="true" />
+      <button aria-disabled="false" />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+  expect(getByRole('button', {disabled: false})).toBeInTheDocument()
+})
+
+test('`disabled` attributes overrides `aria-dsiabled`', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button disabled="true" aria-disabled="false" />
+      <button />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+})
+
+test('consider `disabled` attribute only if supported', () => {
+  const {getByRole, queryByRole} = renderIntoDocument(
+    `<div>
+      <button disabled="true" />
+      <div role="slider" disabled="true" />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+  expect(queryByRole('slider', {disabled: true})).toBe(null)
+})

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -12,6 +12,7 @@ import {
   computeAriaChecked,
   computeAriaPressed,
   computeAriaCurrent,
+  computeAriaDisabled,
   computeAriaExpanded,
   computeHeadingLevel,
   getImplicitAriaRoles,
@@ -45,6 +46,7 @@ const queryAllByRole: AllByRole = (
     checked,
     pressed,
     current,
+    disabled,
     level,
     expanded,
   } = {},
@@ -111,6 +113,16 @@ const queryAllByRole: AllByRole = (
     }
   }
 
+  if (disabled !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-disabled'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-disabled" is not supported on role "${role}".`)
+    }
+  }
+
   const subtreeIsInaccessibleCache = new WeakMap<Element, Boolean>()
   function cachedIsSubtreeInaccessible(element: Element) {
     if (!subtreeIsInaccessibleCache.has(element)) {
@@ -160,6 +172,9 @@ const queryAllByRole: AllByRole = (
       }
       if (current !== undefined) {
         return current === computeAriaCurrent(element)
+      }
+      if (disabled !== undefined) {
+        return disabled === computeAriaDisabled(element)
       }
       if (expanded !== undefined) {
         return expanded === computeAriaExpanded(element)

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -281,6 +281,29 @@ function computeAriaCurrent(element) {
   )
 }
 
+const elementsSupportingDisabledAttribute = new Set([
+  'button',
+  'fieldset',
+  'input',
+  'optgroup',
+  'option',
+  'select',
+  'textarea',
+])
+
+/**
+ * @param {Element} element -
+ * @returns {boolean} -
+ */
+function computeAriaDisabled(element) {
+  return elementsSupportingDisabledAttribute.has(element.localName) &&
+    element.hasAttribute('disabled')
+    ? // https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings
+      true
+    : // https://www.w3.org/TR/wai-aria-1.1/#aria-disabled
+      element.getAttribute('aria-disabled') === 'true'
+}
+
 /**
  * @param {Element} element -
  * @returns {boolean | undefined} - false/true if (not)expanded, undefined if not expand-able
@@ -336,6 +359,7 @@ export {
   computeAriaChecked,
   computeAriaPressed,
   computeAriaCurrent,
+  computeAriaDisabled,
   computeAriaExpanded,
   computeHeadingLevel,
 }

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -95,6 +95,11 @@ export interface ByRoleOptions {
    */
   current?: boolean | string
   /**
+   * If true only includes elements in the query set that are marked as 
+   * disabled in the accessibility tree, i.e., `aria-disabled="true"` or `disabled="true"`.
+   */
+  disabled?: boolean
+  /**
    * If true only includes elements in the query set that are marked as
    * expanded in the accessibility tree, i.e., `aria-expanded="true"`
    */


### PR DESCRIPTION
Part of a larger committment to unify APIs for `/react-native` and `/react` (which is just `/react-dom` at the moment)
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Enables `ByRole(role, { disabled })`

**Why**:

Makes writing tests for react-native and react-dom easier by removing barriers when changing the target platform that's being tested.

**How**:

Same patterns as for expanded, selected etc

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) PENDING
- [x] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
