### PR TITLE
feat(ByRole): Allow filter by busy state

### DIFF
--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -36,6 +36,28 @@ test('`expanded` throws on unsupported roles', () => {
   )
 })
 
+test('`busy` throws on unsupported roles', () => {
+  const {getByRole} = render(
+    `<div aria-busy="true" role="none">Hello, Dave!</div>`,
+  )
+  expect(() =>
+    getByRole('none', {busy: true}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-busy" is not supported on role "none".`,
+  )
+})
+
+test('`busy: true|false` matches `busy` regions', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <div role="log" aria-busy="true" />
+      <div role="log" aria-busy="false" />
+    </div>`,
+  )
+  expect(getByRole('log', {busy: true})).toBeInTheDocument()
+  expect(getByRole('log', {busy: false})).toBeInTheDocument()
+})
+
 test('`checked: true|false` matches `checked` checkboxes', () => {
   const {getByRole} = renderIntoDocument(
     `<div>

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -9,6 +9,7 @@ import {
 } from 'aria-query'
 import {
   computeAriaSelected,
+  computeAriaBusy,
   computeAriaChecked,
   computeAriaPressed,
   computeAriaCurrent,
@@ -42,6 +43,7 @@ const queryAllByRole: AllByRole = (
     description,
     queryFallbacks = false,
     selected,
+    busy,
     checked,
     pressed,
     current,
@@ -58,6 +60,16 @@ const queryAllByRole: AllByRole = (
       undefined
     ) {
       throw new Error(`"aria-selected" is not supported on role "${role}".`)
+    }
+  }
+
+  if (busy !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-busy'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-busy" is not supported on role "${role}".`)
     }
   }
 
@@ -151,6 +163,9 @@ const queryAllByRole: AllByRole = (
     .filter(element => {
       if (selected !== undefined) {
         return selected === computeAriaSelected(element)
+      }
+      if (busy !== undefined) {
+        return busy === computeAriaBusy(element)
       }
       if (checked !== undefined) {
         return checked === computeAriaChecked(element)

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -242,6 +242,15 @@ function computeAriaSelected(element) {
 
 /**
  * @param {Element} element -
+ * @returns {boolean} -
+ */
+function computeAriaBusy(element) {
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-busy
+  return element.getAttribute('aria-busy') === 'true'
+}
+
+/**
+ * @param {Element} element -
  * @returns {boolean | undefined} - false/true if (not)checked, undefined if not checked-able
  */
 function computeAriaChecked(element) {
@@ -333,6 +342,7 @@ export {
   prettyRoles,
   isInaccessible,
   computeAriaSelected,
+  computeAriaBusy,
   computeAriaChecked,
   computeAriaPressed,
   computeAriaCurrent,

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -82,6 +82,11 @@ export interface ByRoleOptions {
   selected?: boolean
   /**
    * If true only includes elements in the query set that are marked as
+   * busy in the accessibility tree, i.e., `aria-busy="true"`
+   */
+  busy?: boolean
+  /**
+   * If true only includes elements in the query set that are marked as
    * checked in the accessibility tree, i.e., `aria-checked="true"`
    */
   checked?: boolean


### PR DESCRIPTION
Part of a larger committment to unify APIs for `/react-native` and `/react` (which is just `/react-dom` at the moment)
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Enables `ByRole(role, { busy })`

**Why**:

Makes writing tests for react-native and react-dom easier by removing barriers when changing the target platform that's being tested.

**How**:

Same patterns as for expanded, selected etc

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation: https://github.com/testing-library/testing-library-docs/pull/1232
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
