### PR TITLE
feat(ByRole): Allow filter by value state

### DIFF
--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -237,6 +237,101 @@ test('`level` throws on unsupported roles', () => {
   )
 })
 
+test('`value.now` throws on unsupported roles', () => {
+  const {getByRole} = render(`<button aria-valuenow="1">Button</button>`)
+  expect(() =>
+    getByRole('button', {value: {now: 1}}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-valuenow" is not supported on role "button".`,
+  )
+})
+
+test('`value.now: number` matches `aria-valuenow` on widgets', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button role="spinbutton" aria-valuenow="5" />
+      <button role="spinbutton" aria-valuenow="10" />
+    </div>`,
+  )
+  expect(getByRole('spinbutton', {value: {now: 5}})).toBeInTheDocument()
+  expect(getByRole('spinbutton', {value: {now: 10}})).toBeInTheDocument()
+})
+
+test('`value.max` throws on unsupported roles', () => {
+  const {getByRole} = render(`<button aria-valuemax="1">Button</button>`)
+  expect(() =>
+    getByRole('button', {value: {max: 1}}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-valuemax" is not supported on role "button".`,
+  )
+})
+
+test('`value.max: number` matches `aria-valuemax` on widgets', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button role="spinbutton" aria-valuemax="5" />
+      <button role="spinbutton" aria-valuemax="10" />
+    </div>`,
+  )
+  expect(getByRole('spinbutton', {value: {max: 5}})).toBeInTheDocument()
+  expect(getByRole('spinbutton', {value: {max: 10}})).toBeInTheDocument()
+})
+
+test('`value.min` throws on unsupported roles', () => {
+  const {getByRole} = render(`<button aria-valuemin="1">Button</button>`)
+  expect(() =>
+    getByRole('button', {value: {min: 1}}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-valuemin" is not supported on role "button".`,
+  )
+})
+
+test('`value.min: number` matches `aria-valuemin` on widgets', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button role="spinbutton" aria-valuemin="5" />
+      <button role="spinbutton" aria-valuemin="10" />
+    </div>`,
+  )
+  expect(getByRole('spinbutton', {value: {min: 5}})).toBeInTheDocument()
+  expect(getByRole('spinbutton', {value: {min: 10}})).toBeInTheDocument()
+})
+
+test('`value.text` throws on unsupported roles', () => {
+  const {getByRole} = render(`<button aria-valuetext="one">Button</button>`)
+  expect(() =>
+    getByRole('button', {value: {text: 'one'}}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"aria-valuetext" is not supported on role "button".`,
+  )
+})
+
+test('`value.text: Matcher` matches `aria-valuetext` on widgets', () => {
+  const {getAllByRole, getByRole} = renderIntoDocument(
+    `<div>
+      <button role="spinbutton" aria-valuetext="zero" />
+      <button role="spinbutton" aria-valuetext="few" />
+      <button role="spinbutton" aria-valuetext="many" />
+    </div>`,
+  )
+  expect(getByRole('spinbutton', {value: {text: 'zero'}})).toBeInTheDocument()
+  expect(getAllByRole('spinbutton', {value: {text: /few|many/}})).toHaveLength(
+    2,
+  )
+})
+
+test('`value.*` must all match if specified', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button role="spinbutton" aria-valuemin="0" aria-valuenow="1" aria-valuemax="10" aria-valuetext="eins" />
+      <button role="spinbutton" aria-valuemin="0" aria-valuenow="1" aria-valuemax="10" aria-valuetext="one" />
+    </div>`,
+  )
+  expect(
+    getByRole('spinbutton', {value: {now: 1, text: 'one'}}),
+  ).toBeInTheDocument()
+})
+
 test('`expanded: true|false` matches `expanded` buttons', () => {
   const {getByRole} = renderIntoDocument(
     `<div>

--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -249,6 +249,7 @@ test('`value.now` throws on unsupported roles', () => {
 test('`value.now: number` matches `aria-valuenow` on widgets', () => {
   const {getByRole} = renderIntoDocument(
     `<div>
+      <button role="spinbutton" />
       <button role="spinbutton" aria-valuenow="5" />
       <button role="spinbutton" aria-valuenow="10" />
     </div>`,
@@ -269,6 +270,7 @@ test('`value.max` throws on unsupported roles', () => {
 test('`value.max: number` matches `aria-valuemax` on widgets', () => {
   const {getByRole} = renderIntoDocument(
     `<div>
+      <button role="spinbutton" />
       <button role="spinbutton" aria-valuemax="5" />
       <button role="spinbutton" aria-valuemax="10" />
     </div>`,
@@ -289,6 +291,7 @@ test('`value.min` throws on unsupported roles', () => {
 test('`value.min: number` matches `aria-valuemin` on widgets', () => {
   const {getByRole} = renderIntoDocument(
     `<div>
+      <button role="spinbutton" />
       <button role="spinbutton" aria-valuemin="5" />
       <button role="spinbutton" aria-valuemin="10" />
     </div>`,
@@ -309,6 +312,7 @@ test('`value.text` throws on unsupported roles', () => {
 test('`value.text: Matcher` matches `aria-valuetext` on widgets', () => {
   const {getAllByRole, getByRole} = renderIntoDocument(
     `<div>
+      <button role="spinbutton" />
       <button role="spinbutton" aria-valuetext="zero" />
       <button role="spinbutton" aria-valuetext="few" />
       <button role="spinbutton" aria-valuetext="many" />

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import {
   computeAccessibleDescription,
   computeAccessibleName,
@@ -13,6 +14,10 @@ import {
   computeAriaPressed,
   computeAriaCurrent,
   computeAriaExpanded,
+  computeAriaValueNow,
+  computeAriaValueMax,
+  computeAriaValueMin,
+  computeAriaValueText,
   computeHeadingLevel,
   getImplicitAriaRoles,
   prettyRoles,
@@ -47,6 +52,12 @@ const queryAllByRole: AllByRole = (
     current,
     level,
     expanded,
+    value: {
+      now: valueNow,
+      min: valueMin,
+      max: valueMax,
+      text: valueText,
+    } = {} as NonNullable<ByRoleOptions['value']>,
   } = {},
 ) => {
   checkContainerType(container)
@@ -98,6 +109,46 @@ const queryAllByRole: AllByRole = (
     // guard against using `level` option with any role other than `heading`
     if (role !== 'heading') {
       throw new Error(`Role "${role}" cannot have "level" property.`)
+    }
+  }
+
+  if (valueNow !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-valuenow'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-valuenow" is not supported on role "${role}".`)
+    }
+  }
+
+  if (valueMax !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-valuemax'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-valuemax" is not supported on role "${role}".`)
+    }
+  }
+
+  if (valueMin !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-valuemin'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-valuemin" is not supported on role "${role}".`)
+    }
+  }
+
+  if (valueText !== undefined) {
+    // guard against unknown roles
+    if (
+      allRoles.get(role as ARIARoleDefinitionKey)?.props['aria-valuetext'] ===
+      undefined
+    ) {
+      throw new Error(`"aria-valuetext" is not supported on role "${role}".`)
     }
   }
 
@@ -166,6 +217,33 @@ const queryAllByRole: AllByRole = (
       }
       if (level !== undefined) {
         return level === computeHeadingLevel(element)
+      }
+      if (
+        valueNow !== undefined ||
+        valueMax !== undefined ||
+        valueMin !== undefined ||
+        valueText !== undefined
+      ) {
+        let valueMatches = true
+        if (valueNow !== undefined) {
+          valueMatches &&= valueNow === computeAriaValueNow(element)
+        }
+        if (valueMax !== undefined) {
+          valueMatches &&= valueMax === computeAriaValueMax(element)
+        }
+        if (valueMin !== undefined) {
+          valueMatches &&= valueMin === computeAriaValueMin(element)
+        }
+        if (valueText !== undefined) {
+          valueMatches &&= matches(
+            computeAriaValueText(element) ?? null,
+            element,
+            valueText,
+            text => text,
+          )
+        }
+
+        return valueMatches
       }
       // don't care if aria attributes are unspecified
       return true

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -325,6 +325,42 @@ function computeHeadingLevel(element) {
   return ariaLevelAttribute || implicitHeadingLevels[element.tagName]
 }
 
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} -
+ */
+function computeAriaValueNow(element) {
+  const valueNow = element.getAttribute('aria-valuenow')
+  return valueNow === null ? undefined : +valueNow
+}
+
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} -
+ */
+function computeAriaValueMax(element) {
+  const valueMax = element.getAttribute('aria-valuemax')
+  return valueMax === null ? undefined : +valueMax
+}
+
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} -
+ */
+function computeAriaValueMin(element) {
+  const valueMin = element.getAttribute('aria-valuemin')
+  return valueMin === null ? undefined : +valueMin
+}
+
+/**
+ * @param {Element} element -
+ * @returns {string | undefined} -
+ */
+function computeAriaValueText(element) {
+  const valueText = element.getAttribute('aria-valuetext')
+  return valueText === null ? undefined : valueText
+}
+
 export {
   getRoles,
   logRoles,
@@ -337,5 +373,9 @@ export {
   computeAriaPressed,
   computeAriaCurrent,
   computeAriaExpanded,
+  computeAriaValueNow,
+  computeAriaValueMax,
+  computeAriaValueMin,
+  computeAriaValueText,
   computeHeadingLevel,
 }

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -105,6 +105,12 @@ export interface ByRoleOptions {
    * the `aria-level` attribute.
    */
   level?: number
+  value?: {
+    now?: number
+    min?: number
+    max?: number
+    text?: Matcher
+  }
   /**
    * Includes every role used in the `role` attribute
    * For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progressbar">`.


### PR DESCRIPTION
Part of a larger committment to unify APIs for `/react-native` and `/react` (which is just `/react-dom` at the moment)
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Enables `ByRole(role, { value })`

Note that we don't support `valuenow` but rather `value.now` (same pattern for other `aria-value*` attributes). One reason is parity with `@testing-library/react-native`. 

The other reason is that `value.*` works a bit different in that it looks at all `value.*` and combines them with `&&` instead of returning on the first match. Today, `{ pressed: true, selected: true}` has kind of an odd behavior since it only looks at whatever comes first in the implementation. We could combine them with `&&` as well but it's not clear to me yet that this is always good. So by putting them in a single object makes it clear that we look at the whole object which wouldn't be that obvious for `{ name, valuemin, valuemax}`. I don't feel too strongly about this specific rationale. I care more about parity with /react-native.

**Why**:

Makes writing tests for react-native and react-dom easier by removing barriers when changing the target platform that's being tested.

**How**:

Same patterns as for expanded, selected etc

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation: https://github.com/testing-library/testing-library-docs/pull/1230
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
