### PR TITLE
In FindAllBy and FindAll query helper types: spread Arguments to support no arguments

### DIFF
--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -132,6 +132,50 @@ export async function testQueryHelpers() {
   screenWithCustomQueries.getByAutomationId(['id', 'automationId'])
   await screenWithCustomQueries.findAllByAutomationId('id', {}, {timeout: 1000})
   await screenWithCustomQueries.findByAutomationId('id', {}, {timeout: 1000})
+
+  // contrived example of a custom query with no arguments beyond container
+  function queryAllByFoo(container: HTMLElement) {
+    return queryAllByText(container, 'Foo')
+  }
+
+  const [
+    queryByTextFoo,
+    getAllByTextFoo,
+    getByTextFoo,
+    findAllByTextFoo,
+    findByTextFoo,
+  ] = buildQueries(
+    queryAllByFoo,
+    createIdRelatedErrorHandler(
+      `Found multiple elements with text Foo`,
+      'Multiple error',
+    ),
+    createIdRelatedErrorHandler(
+      `Unable to find an element with text Foo`,
+      'Missing error',
+    ),
+  )
+
+  queryByTextFoo(element)
+  getAllByTextFoo(element)
+  getByTextFoo(element)
+  await findAllByTextFoo(element)
+  await findByTextFoo(element)
+
+  const screenWithCustomFooQueries = within(document.body, {
+    ...queries,
+    queryByTextFoo,
+    getAllByTextFoo,
+    getByTextFoo,
+    findAllByTextFoo,
+    findByTextFoo,
+  })
+
+  screenWithCustomFooQueries.queryByTextFoo()
+  screenWithCustomFooQueries.getAllByTextFoo()
+  screenWithCustomFooQueries.getByTextFoo()
+  await screenWithCustomFooQueries.findAllByTextFoo()
+  await screenWithCustomFooQueries.findByTextFoo()
 }
 
 export function testBoundFunctions() {

--- a/types/query-helpers.d.ts
+++ b/types/query-helpers.d.ts
@@ -50,12 +50,12 @@ export type GetAllBy<Arguments extends any[]> = QueryMethod<
   HTMLElement[]
 >
 export type FindAllBy<Arguments extends any[]> = QueryMethod<
-  [Arguments[0], Arguments[1]?, waitForOptions?],
+  [...Arguments, waitForOptions?],
   Promise<HTMLElement[]>
 >
 export type GetBy<Arguments extends any[]> = QueryMethod<Arguments, HTMLElement>
 export type FindBy<Arguments extends any[]> = QueryMethod<
-  [Arguments[0], Arguments[1]?, waitForOptions?],
+  [...Arguments, waitForOptions?],
   Promise<HTMLElement>
 >
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Custom queries returned by `buildQueries` whose implementation required no arguments (besides `container`) still required one argument for `find*` and `findAll*` even when used on `screen` or `within`. 

Without the `query-helpers.d.ts` changes introduced by this PR, see these TS errors in the updated `type-tests`:
![Screen Shot 2023-05-05 at 11 48 12 AM](https://user-images.githubusercontent.com/1950438/236513227-15eaf1df-8c20-4a57-9ece-6bde5f0632b3.png)


<!-- Why are these changes necessary? -->

**Why**: There was a lot of great work done on these types [here](https://github.com/testing-library/dom-testing-library/pull/794) and [here](https://github.com/testing-library/dom-testing-library/pull/574), I want to build on that to solve this one additional edge case. 

For context on why we have queries with no arguments: we have a library with UI components that other teams consume. We also provide a few custom queries for things we don't want the consumers to worry about. For example: We provide a `DataGrid` component with the option to select rows. It's possible to find the input to select a row using base testing-library features but consumers shouldn't need to know how the sausage is made, for their convenience we want them to be able to simply say:
`await userEvent.click(within(row).getGridRowSelectionInput())`

This works, however I noticed that for the `find` and `findAll` queries the first arg is always required. It would end up looking like this to make TS happy:
`await within(row).findGridRowSelectionInput(undefined)`

<!-- How were these changes implemented? -->

**How**: Spreading `Arguments` in `FindBy` and `FindAllBy` types would fix this; the resulting queries should better match the types passed into `buildQueries`. If there are no arguments after `container` then the resulting query would have two: `container` and `waitForOptions`. This would also allow for more than two args if needed. Lastly, this doesn't change the fact that `container` is required:

![Screen Shot 2023-05-05 at 11 46 16 AM](https://user-images.githubusercontent.com/1950438/236513706-fc0955e8-3ec8-4298-aa1b-cdb3ae701045.png)


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests (in type-tests.ts, I think this is right based on previous PRs but it failed the pre-commit hook validation)
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
