### PR TITLE
feat(getByRole): Allow filter by disabled

### DIFF
--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -379,3 +379,25 @@ test('`expanded: true|false` matches `expanded` elements with proper role', () =
   expect(getByRole('button', {expanded: true})).toBeInTheDocument()
   expect(getByRole('button', {expanded: false})).toBeInTheDocument()
 })
+
+test('`expected: true|false` matches `disabled` buttons', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button disabled />
+      <button />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+  expect(getByRole('button', {disabled: false})).toBeInTheDocument()
+})
+
+test('`expected: true|false` matches `aria-disabled` buttons', () => {
+  const {getByRole} = renderIntoDocument(
+    `<div>
+      <button aria-disabled="true" />
+      <button aria-disabled="false" />
+    </div>`,
+  )
+  expect(getByRole('button', {disabled: true})).toBeInTheDocument()
+  expect(getByRole('button', {disabled: false})).toBeInTheDocument()
+})

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -20,6 +20,7 @@ import {
   computeAriaValueMin,
   computeAriaValueText,
   computeHeadingLevel,
+  computeDisabled,
   getImplicitAriaRoles,
   prettyRoles,
   isInaccessible,
@@ -53,6 +54,7 @@ const queryAllByRole: AllByRole = (
     pressed,
     current,
     level,
+    disabled,
     expanded,
     value: {
       now: valueNow,
@@ -232,6 +234,9 @@ const queryAllByRole: AllByRole = (
       }
       if (level !== undefined) {
         return level === computeHeadingLevel(element)
+      }
+      if (disabled !== undefined) {
+        return disabled === computeDisabled(element)
       }
       if (
         valueNow !== undefined ||

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -370,6 +370,14 @@ function computeAriaValueText(element) {
   return valueText === null ? undefined : valueText
 }
 
+/**
+ * @param {Element} element
+ * @returns {boolean | undefined}
+ */
+function computeDisabled(element) {
+  return element.disabled || element.getAttribute('aria-disabled') === 'true'
+}
+
 export {
   getRoles,
   logRoles,
@@ -387,5 +395,6 @@ export {
   computeAriaValueMax,
   computeAriaValueMin,
   computeAriaValueText,
+  computeDisabled,
   computeHeadingLevel,
 }

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -135,6 +135,7 @@ export interface ByRoleOptions {
     | RegExp
     | string
     | ((accessibleDescription: string, element: Element) => boolean)
+  disabled?: boolean
 }
 
 export type AllByRole<T extends HTMLElement = HTMLElement> = (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
This PR allows `getByRole()` filter by `disabled` attribute.

We often write tests depending on `disabled` or `aria-disabled` attribute of elements, but `getByRole()` method cannot filter by it.

There are different meaning between `disabled` and `aria-disabled` attribute slightly. `disabled` makes a element be unclickable and unfocusable, but a element setting by `aria-disabled: true` remains clickable and focusable.

https://codepen.io/kemuridama/pen/rNqJKqm

From that differences, I have 2 solutions to filter by `disabled` attribute:

- Filter by both `disabled` and `aria-disabled` attribute
- Filter by `disabled` attribute only

This PR resolves using the former solution, but there are controvertible.

**Why**:

<!-- How were these changes implemented? -->
To write tests depending on `disabled` or `aria-disabled` attribute of elements easily.

**How**:

<!-- Have you done all of these things?  -->

Same patterns as for `expanded`, `selected` etc

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation: https://github.com/testing-library/testing-library-docs/pull/1252
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
