### PR TITLE
fix: pin aria-query

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/code-frame": "^7.10.4",
     "@babel/runtime": "^7.12.5",
     "@types/aria-query": "^5.0.1",
-    "aria-query": "^5.0.0",
+    "aria-query": "5.1.3",
     "chalk": "^4.1.0",
     "dom-accessibility-api": "^0.5.9",
     "lz-string": "^1.5.0",


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Temporarily pinning `aria-query` to version 5.1.3.

<!-- Why are these changes necessary? -->

**Why**: The new version of `aria-query`(5.2.1) was released yesterday and caused a few issues on our end.
Affected issues:
Fixes https://github.com/testing-library/dom-testing-library/issues/1235
Fixes https://github.com/testing-library/dom-testing-library/issues/1238

<!-- How were these changes implemented? -->

**How**: Pinning the version in package.json.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] ~~Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~~
- [X] Tests
- [X] ~~TypeScript definitions updated~~
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
