### PR TITLE
chore: pin browserslist deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
+    "browserslist": "4.21.8",
+    "caniuse-lite": "1.0.30001502",
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
     "kcd-scripts": "^13.0.0",
     "typescript": "^4.1.2"
   },
+  "overrides": {
+    "browserslist": "4.21.8",
+    "caniuse-lite": "1.0.30001502"
+  },
   "eslintConfig": {
     "extends": [
       "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Pin `browserslist` and `caniuse-lite` development dependencies.

Fixes #1242

**Why**:

There has been minor release of browserslist packages that remove support of `op_mob 64` which this library currently makes use of. Updates to the support matrix are considered a breaking change, so by pinning dependencies we can unblock minor and patch changes while pending a major release to update these dependencies and the version support for opera mobile.

**How**:

Added `browsers@4.21.8` and `caniuse-lite@1.0.30001502` to the `package.json` `overrides` object (for Node >=16) and `devDependencies` (for Node 14).

Versions chosen to align with those used in the last commit to `main` on 14 June 2023.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

~- [ ] Documentation added to the~
      ~[docs site](https://github.com/testing-library/testing-library-docs)~
~- [ ] Tests~
~- [ ] TypeScript definitions updated~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
