### PR TITLE
fix(role-helpers): refine logRoles fn types

### DIFF
--- a/types/role-helpers.d.ts
+++ b/types/role-helpers.d.ts
@@ -3,7 +3,7 @@ export function logRoles(
   options?: LogRolesOptions,
 ): string
 
-type LogRolesOptions = {
+interface LogRolesOptions {
   hidden?: boolean
 }
 

--- a/types/role-helpers.d.ts
+++ b/types/role-helpers.d.ts
@@ -1,9 +1,19 @@
-export function logRoles(container: HTMLElement): string
+export function logRoles(
+  container: HTMLElement,
+  options?: LogRolesOptions,
+): string
+
+type LogRolesOptions = {
+  hidden?: boolean
+}
+
 export function getRoles(container: HTMLElement): {
   [index: string]: HTMLElement[]
 }
+
 /**
  * https://testing-library.com/docs/dom-testing-library/api-helpers#isinaccessible
  */
 export function isInaccessible(element: Element): boolean
+
 export function computeHeadingLevel(element: Element): number | undefined


### PR DESCRIPTION
**What**:

Increased the TS coverage of the logRoles and prettyRoles functions in the role helpers file,
at the moment cases with `hidden = true` option were not covered.

**Why**:

To further understand the scope of #1201 I've added these defs, I think it's good to have them in the repo.

**Checklist**:
- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged

<!-- feel free to add additional comments -->
