### PR TITLE
Use defineProperty on the error object instead of setting the message…

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -148,6 +148,31 @@ test('timeout logs a pretty DOM', async () => {
   `)
 })
 
+test("timeout doesn't error on DOMExceptions", async () => {
+  renderIntoDocument(`<div id="pretty">how pretty</div>`)
+  const error = await waitFor(
+    () => {
+      throw new DOMException('nooooooo!')
+    },
+    {timeout: 1},
+  ).catch(e => e)
+  expect(error.message).toMatchInlineSnapshot(`
+    nooooooo!
+
+    Ignored nodes: comments, script, style
+    <html>
+      <head />
+      <body>
+        <div
+          id="pretty"
+        >
+          how pretty
+        </div>
+      </body>
+    </html>
+  `)
+})
+
 test('should delegate to config.getElementError', async () => {
   const elementError = new Error('Custom element error')
   const getElementError = jest.fn().mockImplementation(() => elementError)

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -24,10 +24,9 @@ function waitFor(
     stackTraceError,
     interval = 50,
     onTimeout = error => {
-      error.message = getConfig().getElementError(
-        error.message,
-        container,
-      ).message
+      Object.defineProperty(error, 'message', {
+        value: getConfig().getElementError(error.message, container).message,
+      })
       return error
     },
     mutationObserverOptions = {


### PR DESCRIPTION
… directly

Fixes #1259

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Use defineProperty on the error object instead of setting the message directly (Fixes #1259)

<!-- Why are these changes necessary? -->

**Why**: With a DOMException, the error isn't propagated properly without this fix.

<!-- How were these changes implemented? -->

**How**: I used defineProperty instead of setting the message property directly.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] ~~Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs)~~ unneeded
- [X] Tests
- [x] ~~TypeScript definitions updated~~ unneeded
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
