### PR TITLE
chore: Pin NPM version

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
-  "node": "14"
+  "node": "20"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
-  "node": "20"
+  "node": "18"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,10 @@ jobs:
         with:
           node-version: 14
 
+      # Ideally done by actions/setup-node: https://github.com/actions/setup-node/issues/213
+      - name: Setup package manager
+        run: npm install -g npm@9.2.0
+
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      # Ideally done by actions/setup-node: https://github.com/actions/setup-node/issues/213
+      - name: Setup package manager
+        run: npm install -g npm@9.2.0
+
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:


### PR DESCRIPTION
Closes https://github.com/testing-library/dom-testing-library/issues/1242

`overrides` is not available in NPM bundled with Node.js 14. But we can hopefully use later NPM versions in older Node.js version.

That way we can keep CI alive without having to make breaking changes.