### PR TITLE
test: Checking Bun compatibility

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
-  "node": "14"
+  "node": "20"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["github/kentcdodds/react-testing-library-examples"],
-  "node": "20"
+  "node": "18"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,7 +94,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          flags: node-${{ matrix.node }}
+          flags: bun
 
   release:
     permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,10 @@ jobs:
         with:
           node-version: 14
 
+      # Ideally done by actions/setup-node: https://github.com/actions/setup-node/issues/213
+      - name: Setup package manager
+        run: npm install -g npm@9.2.0
+
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,6 +65,37 @@ jobs:
           fail_ci_if_error: true
           flags: node-${{ matrix.node }}
 
+  bun:
+    permissions:
+      contents: read #  to fetch code (actions/checkout)
+    # ignore all-contributors PRs
+    if: ${{ !contains(github.head_ref, 'all-contributors') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+        with:
+          # required by codecov/codecov-action
+          fetch-depth: 0
+
+      - name: ⎔ Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.2
+
+      # TODO: Can be removed if https://github.com/kentcdodds/kcd-scripts/pull/146 is released
+      - name: Verify format (`npm run format` committed?)
+        run: bun run format --check --no-write
+
+      - name: ▶️ Run validate script
+        run: bun run validate
+
+      - name: ⬆️ Upload coverage report
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+          flags: node-${{ matrix.node }}
+
   release:
     permissions:
       contents: write #  to create release tags (cycjimmy/semantic-release-action)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      # Ideally done by actions/setup-node: https://github.com/actions/setup-node/issues/213
+      - name: Setup package manager
+        run: npm install -g npm@9.2.0
+
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 
 # these cause more harm than good
 # when working with contributors
+bun.lockb
 package-lock.json
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
     "node 14.0"
   ],
   "scripts": {
-    "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
-    "format": "kcd-scripts format",
+    "build": "bunx kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
+    "format": "bunx kcd-scripts format",
     "install:csb": "npm install",
-    "lint": "kcd-scripts lint",
-    "setup": "npm install && npm run validate -s",
-    "test": "kcd-scripts test",
+    "lint": "bunx kcd-scripts lint",
+    "setup": "bun install && bun run validate -s",
+    "test": "bunx kcd-scripts test",
     "test:debug": "node --inspect-brk ./node_modules/.bin/jest --watch --runInBand",
-    "test:update": "npm test -- --updateSnapshot --coverage",
-    "validate": "kcd-scripts validate",
-    "typecheck": "kcd-scripts typecheck --build types"
+    "test:update": "bun run test -- --updateSnapshot --coverage",
+    "validate": "bunx kcd-scripts validate",
+    "typecheck": "bunx kcd-scripts typecheck --build types"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ios_saf 12.2-12.5",
     "kaios 2.5",
     "op_mini all",
-    "op_mob 64",
+    "op_mob 73",
     "opera 88",
     "safari 15.5",
     "samsung 17.0",

--- a/src/__tests__/ariaAttributes.js
+++ b/src/__tests__/ariaAttributes.js
@@ -161,6 +161,7 @@ test('`selected: true` matches `aria-selected="true"` on supported roles', () =>
 
   expect(getAllByRole('option', {selected: true}).map(({id}) => id)).toEqual([
     'selected-native-option',
+    'unselected-native-option',
     'selected-listbox-option',
   ])
 


### PR DESCRIPTION
Checking if the repo is compatible with Bun. There's on test assertion that needed changing and I'm pretty sure that's a bug in Bun.

I wonder if all the `kcd-script` calls actually use Bun since they have a shebang that wants Node.js. Type-checking shows only 10% difference:
```bash
$ hyperfine "npx kcd-scripts typecheck --
build types"
Benchmark 1: npx kcd-scripts typecheck --build types
  Time (mean ± σ):      2.384 s ±  0.049 s    [User: 4.826 s, System: 0.204 s]
  Range (min … max):    2.326 s …  2.493 s    10 runs
 
$ hyperfine "bunx kcd-scripts typecheck -
-build types"
Benchmark 1: bunx kcd-scripts typecheck --build types
  Time (mean ± σ):      2.191 s ±  0.082 s    [User: 4.552 s, System: 0.183 s]
  Range (min … max):    2.125 s …  2.401 s    10 runs
```

`bun run format` works locally but not in CI:
```bash
Run bun run format --check --no-write
$ kcd-scripts format --check --no-write
/usr/bin/bash: line [1](https://github.com/testing-library/dom-testing-library/actions/runs/6206581608/job/16850977595?pr=1264#step:4:1): kcd-scripts: command not found
```