### PR TITLE
fix: Match declared types of `waitFor` with runtime behavior

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -25,7 +25,7 @@ function getDocument() {
   }
   return window.document
 }
-function getWindowFromNode(node: any) {
+function getWindowFromNode(node: any): typeof window {
   if (node.defaultView) {
     // node is document
     return node.defaultView

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -4,7 +4,9 @@ export interface Config {
    * WARNING: `unstable` prefix means this API may change in patch and minor releases.
    * @param cb
    */
-  unstable_advanceTimersWrapper(cb: (...args: unknown[]) => unknown): unknown
+  unstable_advanceTimersWrapper: (
+    cb: (...args: unknown[]) => unknown,
+  ) => unknown
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   asyncWrapper(cb: (...args: any[]) => any): Promise<any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -16,7 +18,10 @@ export interface Config {
   defaultIgnore: string
   showOriginalStackTrace: boolean
   throwSuggestions: boolean
-  getElementError: (message: string | null, container: Element) => Error
+  getElementError: (
+    message: string | null,
+    container: Element | Document,
+  ) => Error
 }
 
 export interface ConfigFn {

--- a/types/wait-for.d.ts
+++ b/types/wait-for.d.ts
@@ -1,9 +1,10 @@
 export interface waitForOptions {
-  container?: HTMLElement
+  container?: Element | Document
   timeout?: number
   interval?: number
   onTimeout?: (error: Error) => Error
   mutationObserverOptions?: MutationObserverInit
+  showOriginalStackTrace?: boolean
 }
 
 export function waitFor<T>(


### PR DESCRIPTION
- `waitFor#options.container` can be `Document | Element` not just `HTMLElement`
- added `waitFor#options.showOriginalStackTrace`
- `config.getElementError` accepts `Document | Element` not just `Element`
- `config.unstable_advanceTimersWrapper` has no bound `this`