### PR TITLE
fix: use defineProperty on the error object instead of setting the message directly 

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -148,6 +148,31 @@ test('timeout logs a pretty DOM', async () => {
   `)
 })
 
+test("timeout doesn't error on DOMExceptions", async () => {
+  renderIntoDocument(`<div id="pretty">how pretty</div>`)
+  const error = await waitFor(
+    () => {
+      throw new DOMException('nooooooo!')
+    },
+    {timeout: 1},
+  ).catch(e => e)
+  expect(error.message).toMatchInlineSnapshot(`
+    nooooooo!
+
+    Ignored nodes: comments, script, style
+    <html>
+      <head />
+      <body>
+        <div
+          id="pretty"
+        >
+          how pretty
+        </div>
+      </body>
+    </html>
+  `)
+})
+
 test('should delegate to config.getElementError', async () => {
   const elementError = new Error('Custom element error')
   const getElementError = jest.fn().mockImplementation(() => elementError)

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -24,10 +24,9 @@ function waitFor(
     stackTraceError,
     interval = 50,
     onTimeout = error => {
-      error.message = getConfig().getElementError(
-        error.message,
-        container,
-      ).message
+      Object.defineProperty(error, 'message', {
+        value: getConfig().getElementError(error.message, container).message,
+      })
       return error
     },
     mutationObserverOptions = {


### PR DESCRIPTION
Cherry-picking https://github.com/testing-library/dom-testing-library/pull/1261 into alpha