### PR TITLE
fix: Stop calling `waitFor` callback after timeout

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -431,24 +431,19 @@ test(`when fake timer is installed, on waitFor timeout, it doesn't call the call
     },
   })
 
-  let waitForHasResolved = false
-  let callbackCalledAfterWaitForResolved = false
+  const callback = jest.fn(() => {
+    throw new Error('We want to timeout')
+  })
+  const interval = 50
 
   await expect(() =>
-    waitFor(
-      () => {
-        // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
-        if (waitForHasResolved) {
-          callbackCalledAfterWaitForResolved = true
-        }
-        throw new Error('We want to timeout')
-      },
-      {interval: 50, timeout: 100},
-    ),
+    waitFor(callback, {interval, timeout: 100}),
   ).rejects.toThrow()
-  waitForHasResolved = true
+  expect(callback).toHaveBeenCalledWith()
 
-  await Promise.resolve()
+  callback.mockClear()
 
-  expect(callbackCalledAfterWaitForResolved).toBe(false)
+  await jest.advanceTimersByTimeAsync(interval)
+
+  expect(callback).not.toHaveBeenCalledWith()
 })

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -337,12 +337,14 @@ test('does not work after it resolves', async () => {
 
   let data = null
   setTimeout(() => {
+    contextStack.push('timeout')
     data = 'resolved'
   }, 100)
 
   contextStack.push('waitFor:start')
   await waitFor(
     () => {
+      contextStack.push('callback')
       // eslint-disable-next-line jest/no-conditional-in-test -- false-positive
       if (data === null) {
         throw new Error('not found')
@@ -352,27 +354,39 @@ test('does not work after it resolves', async () => {
   )
   contextStack.push('waitFor:end')
 
-  expect(contextStack).toEqual([
-    'waitFor:start',
-    'no-act:start',
-    'act:start',
-    'act:end',
-    'act:start',
-    'act:end',
-    'no-act:end',
-    'waitFor:end',
-  ])
+  expect(contextStack).toMatchInlineSnapshot(`
+    [
+      waitFor:start,
+      no-act:start,
+      callback,
+      act:start,
+      act:end,
+      callback,
+      act:start,
+      timeout,
+      act:end,
+      callback,
+      no-act:end,
+      waitFor:end,
+    ]
+  `)
 
   await Promise.resolve()
 
-  expect(contextStack).toEqual([
-    'waitFor:start',
-    'no-act:start',
-    'act:start',
-    'act:end',
-    'act:start',
-    'act:end',
-    'no-act:end',
-    'waitFor:end',
-  ])
+  expect(contextStack).toMatchInlineSnapshot(`
+    [
+      waitFor:start,
+      no-act:start,
+      callback,
+      act:start,
+      act:end,
+      callback,
+      act:start,
+      timeout,
+      act:end,
+      callback,
+      no-act:end,
+      waitFor:end,
+    ]
+  `)
 })

--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -373,6 +373,7 @@ test('does not work after it resolves', async () => {
 
   await Promise.resolve()
 
+  // The context call stack should not change
   expect(contextStack).toMatchInlineSnapshot(`
     [
       waitFor:start,

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -106,6 +106,9 @@ function waitFor(
     }
 
     function onDone(error, result) {
+      if (finished) {
+        return
+      }
       finished = true
       clearTimeout(overallTimeoutTimer)
 
@@ -134,7 +137,7 @@ function waitFor(
     }
 
     function checkCallback() {
-      if (promiseStatus === 'pending') return
+      if (finished || promiseStatus === 'pending') return
       try {
         const result = runWithExpensiveErrorDiagnosticsDisabled(callback)
         if (typeof result?.then === 'function') {
@@ -160,6 +163,9 @@ function waitFor(
     }
 
     function handleTimeout() {
+      if (finished) {
+        return
+      }
       let error
       if (lastError) {
         error = lastError

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -81,15 +81,15 @@ function waitFor(
           jest.advanceTimersByTime(interval)
         })
 
+        // Could have timed-out
+        if (finished) {
+          break
+        }
         // It's really important that checkCallback is run *before* we flush
         // in-flight promises. To be honest, I'm not sure why, and I can't quite
         // think of a way to reproduce the problem in a test, but I spent
         // an entire day banging my head against a wall on this.
         checkCallback()
-
-        if (finished) {
-          break
-        }
       }
     } else {
       try {
@@ -106,9 +106,6 @@ function waitFor(
     }
 
     function onDone(error, result) {
-      if (finished) {
-        return
-      }
       finished = true
       clearTimeout(overallTimeoutTimer)
 
@@ -137,7 +134,7 @@ function waitFor(
     }
 
     function checkCallback() {
-      if (finished || promiseStatus === 'pending') return
+      if (promiseStatus === 'pending') return
       try {
         const result = runWithExpensiveErrorDiagnosticsDisabled(callback)
         if (typeof result?.then === 'function') {
@@ -163,9 +160,6 @@ function waitFor(
     }
 
     function handleTimeout() {
-      if (finished) {
-        return
-      }
       let error
       if (lastError) {
         error = lastError


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Prevent `waitFor` callback from being invoked even after it resolved, on `waitFor` timeout.
<!-- Why are these changes necessary? -->

**Why**:

More context can be found [in this issue](https://github.com/testing-library/dom-testing-library/issues/1270), but with that context in mind, it's preventing test side-effects:

`afterEach` should be enough to "clean" the previous test from any side-effect.  However, because of the callback leak issue, `window.variable` will remain to be `123` even after being set back to `1` for a short period of time. 

```js
afterEach(() => {
 window.variable = 1;
})
it('my test', () => {
  return waitFor(() => {
    window.variable = 123;
    throw new Error('I want it to timeout');
  })
})
```


<!-- How were these changes implemented? -->

**How**:

When the clock is mocked, only call `checkCallback` when `finished` is `false` 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs): N/A
- [x] Tests
- [ ] TypeScript definitions updated: N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

resolves https://github.com/testing-library/dom-testing-library/issues/1270
