### PR TITLE
docs: update reproduction link

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -54,7 +54,7 @@ minimal amount of code possible.
 
 Repository template: https://github.com/testing-library/dom-testing-library-template
 
-Or if you can, try to reproduce the issue in Stackblitz. You can fork the one
+Or if you can, try to reproduce the issue in StackBlitz. You can fork the one
 here: https://testing-library.com/new-dtl
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -54,7 +54,7 @@ minimal amount of code possible.
 
 Repository template: https://github.com/testing-library/dom-testing-library-template
 
-Or if you can, try to reproduce the issue in a Stackblitz. You can fork the one
+Or if you can, try to reproduce the issue in Stackblitz. You can fork the one
 here: https://testing-library.com/new-dtl
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -54,7 +54,7 @@ minimal amount of code possible.
 
 Repository template: https://github.com/testing-library/dom-testing-library-template
 
-Or if you can, try to reproduce the issue in a Codesandbox. You can fork the one
+Or if you can, try to reproduce the issue in a Stackblitz. You can fork the one
 here: https://testing-library.com/new-dtl
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -55,7 +55,7 @@ minimal amount of code possible.
 Repository template: https://github.com/testing-library/dom-testing-library-template
 
 Or if you can, try to reproduce the issue in a Codesandbox. You can fork the one
-here: https://codesandbox.io/s/5z6x4r7n0p
+here: https://testing-library.com/new-dtl
 -->
 
 ### Problem description:


### PR DESCRIPTION
This PR updates the repro link in our issue template from our old codesandbox to stackblitz.
Resolves #1303 