### PR TITLE
feat: Allow null type for node on fireEvent and its shortcuts

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -420,6 +420,18 @@ test('throws a useful error message when firing events on non-existent nodes (sh
   )
 })
 
+test('throws a useful error message when firing events on null', () => {
+  expect(() => fireEvent(null, new MouseEvent('click'))).toThrow(
+    'Unable to fire a "click" event - please provide a DOM element.',
+  )
+})
+
+test('throws a useful error message when firing events on null (shortcut)', () => {
+  expect(() => fireEvent.click(null)).toThrow(
+    'Unable to fire a "click" event - please provide a DOM element.',
+  )
+})
+
 test('throws a useful error message when firing non-events', () => {
   expect(() => fireEvent(document.createElement('div'), undefined)).toThrow(
     'Unable to fire an event - please provide an event object.',

--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -213,6 +213,10 @@ export function eventTest() {
   // Custom event
   const customEvent = createEvent('customEvent', element)
   fireEvent(element, customEvent)
+
+  // null returned by Document.getElementById()
+  const button = document.getElementById('my-button')
+  fireEvent.click(button)
 }
 
 export async function testWaitFors() {

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -90,24 +90,24 @@ export type EventType =
   | 'online'
 
 export type FireFunction = (
-  element: Document | Element | Window | Node,
+  element: Document | Element | Window | Node | null,
   event: Event,
 ) => boolean
 export type FireObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Window | Node | null,
     options?: {},
   ) => boolean
 }
 export type CreateFunction = (
   eventName: string,
-  node: Document | Element | Window | Node,
+  node: Document | Element | Window | Node | null,
   init?: {},
   options?: {EventType?: string; defaultInit?: {}},
 ) => Event
 export type CreateObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Window | Node | null,
     options?: {},
   ) => Event
 }


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow the `null` type for `node` argument on fireEvent and its shortcuts.

**Why**:

A common pattern in some testing code is:

```js
const btn = document.getElementById('my-button')
fireEvent.click(btn)
```

However, `document.getElementById()` may return `null` and then TypeScript will report an error:

```
error TS2345: Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Document | Node | Element | Window'.
```

To resolve the TypeScript error, library users can assert or check the returned value with something like:

```js
const btn = document.getElementById('my-button')
if (!btn) {
   throw new Error("Unable to find 'my-button')
}
fireEvent.click(btn)
```

But dom-testing-library is already doing this check, so let fireEvent accept null as a convenience to call sites.

The error already reported by dom-testing-library is:

```
Unable to fire a "click" event - please provide a DOM element.
```

Some might suggest that using `document.getElementById()` should be replaced by a dom-testing-library query method, but that is non-trivial on legacy codebases with many tests trying to adopt and introduce dom-testing-library.

**How**:

Augmented the types of fireEvent & friends to allow `null` for the `node` argument.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
