### PR TITLE
Disable callToJSON option used by pretty-format

### DIFF
--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -79,6 +79,7 @@ function prettyDOM(dom, maxLength, options = {}) {
     plugins: [createDOMElementFilter(filterNode), DOMCollection],
     printFunctionName: false,
     highlight: shouldHighlight(),
+    callToJSON: false,
     ...prettyFormatOptions,
   })
   return maxLength !== undefined && dom.outerHTML.length > maxLength


### PR DESCRIPTION
**What**:

This PR disable the `callToJSON` option used by the [pretty-format](https://www.npmjs.com/package/pretty-format#usage-with-options) dependency.

**Why**:

These changes are needed to fix a conflict that happens when trying to add E2E tests to a project that uses [Symfony's](https://github.com/symfony/symfony) [live components](https://github.com/symfony/ux-live-component).

The issue is caused by the process of building the "pretty printed" [DOM debug data](https://testing-library.com/docs/dom-testing-library/api-debugging/).
This process is handled by the `pretty-format` dependency, which will by default call a `toJSON` method on any object that defines it.

See the relevant from `pretty-format`:

![image](https://github.com/testing-library/dom-testing-library/assets/42734840/04cf5eab-9412-4b7c-910b-8fd08dc054f9)

This seems harmless most of the time but conflict with symfony's live component because the component DOM node is a proxied object which support any method being called on it (which will be interpreted as an "action").

For more context, here is the relevant code used by the proxy:

![image](https://github.com/testing-library/dom-testing-library/assets/42734840/5b458557-21d3-4c1d-97b8-b0a584226888)

With this in mind, the `typeof val.toJSON === 'function'` check of `pretty-format` will be validated and it will call `toJSON` on symfony DOM items, which will trigger a backend request for a `toJSON` action, which does not exist, thus breaking all tests.

**How**:

Luckily `pretty-format` has a option which can be used to disable the whole `toJSON` logic.

The testing library use only uses `pretty-format` to display DOM items which will never support this special method unless they are weirdly proxied.
Disabling the option should thus be fairly safe and have no negative impact (the test suite seems to confirm it as all tests passes without issues).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A (not sure how this could be properly tested as it relies on an external framework internal behavior. I tried adding a case with a custom proxy to simulate the issue but it didn't really make sense in the end.)
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
