### PR TITLE
fix: Revert "feat: Reduce caught exceptions in `prettyDom` (#1321)"

### DIFF
--- a/src/__tests__/pretty-dom.js
+++ b/src/__tests__/pretty-dom.js
@@ -155,6 +155,7 @@ test('prettyDOM can include all elements with a custom filter', () => {
 
 test('prettyDOM supports a COLORS environment variable', () => {
   const {container} = render('<div>Hello World!</div>')
+
   const noColors = prettyDOM(container, undefined, {highlight: false})
   const withColors = prettyDOM(container, undefined, {highlight: true})
 
@@ -164,48 +165,6 @@ test('prettyDOM supports a COLORS environment variable', () => {
 
   process.env.COLORS = 'true'
   expect(prettyDOM(container)).toEqual(withColors)
-})
-
-test('prettyDOM handles a COLORS env variable of unexpected object type by colorizing for node', () => {
-  const {container} = render('<div>Hello World!</div>')
-  const noColors = prettyDOM(container, undefined, {highlight: false})
-  const withColors = prettyDOM(container, undefined, {highlight: true})
-
-  const originalNodeVersion = process.versions.node
-  process.env.COLORS = '{}'
-  delete process.versions.node
-  expect(prettyDOM(container)).toEqual(noColors)
-  process.versions.node = '1.2.3'
-  expect(prettyDOM(container)).toEqual(withColors)
-  process.versions.node = originalNodeVersion
-})
-
-test('prettyDOM handles a COLORS env variable of undefined by colorizing for node', () => {
-  const {container} = render('<div>Hello World!</div>')
-  const noColors = prettyDOM(container, undefined, {highlight: false})
-  const withColors = prettyDOM(container, undefined, {highlight: true})
-
-  const originalNodeVersion = process.versions.node
-  process.env.COLORS = undefined
-  delete process.versions.node
-  expect(prettyDOM(container)).toEqual(noColors)
-  process.versions.node = '1.2.3'
-  expect(prettyDOM(container)).toEqual(withColors)
-  process.versions.node = originalNodeVersion
-})
-
-test('prettyDOM handles a COLORS env variable of empty string by colorizing for node', () => {
-  const {container} = render('<div>Hello World!</div>')
-  const noColors = prettyDOM(container, undefined, {highlight: false})
-  const withColors = prettyDOM(container, undefined, {highlight: true})
-
-  const originalNodeVersion = process.versions.node
-  process.env.COLORS = ''
-  delete process.versions.node
-  expect(prettyDOM(container)).toEqual(noColors)
-  process.versions.node = '1.2.3'
-  expect(prettyDOM(container)).toEqual(withColors)
-  process.versions.node = originalNodeVersion
 })
 
 test('prettyDOM supports named custom elements', () => {

--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -5,20 +5,25 @@ import {getDocument} from './helpers'
 import {getConfig} from './config'
 
 const shouldHighlight = () => {
-  // Try to safely parse env COLORS: We will default behavior if any step fails.
+  let colors
   try {
-    const colors = process?.env?.COLORS
-    if (colors) {
-      const b = JSON.parse(colors)
-      if (typeof b === 'boolean') return b
-    }
-  } catch {
-    // Ignore (non-critical) - Make a defaulting choice below.
+    colors = JSON.parse(process?.env?.COLORS)
+  } catch (e) {
+    // If this throws, process?.env?.COLORS wasn't parsable. Since we only
+    // care about `true` or `false`, we can safely ignore the error.
   }
 
-  // In all other cases, whether COLORS was a weird type, or the attempt threw:
-  // Fall back to colorizing if we are running in node.
-  return !!process?.versions?.node
+  if (typeof colors === 'boolean') {
+    // If `colors` is set explicitly (both `true` and `false`), use that value.
+    return colors
+  } else {
+    // If `colors` is not set, colorize if we're in node.
+    return (
+      typeof process !== 'undefined' &&
+      process.versions !== undefined &&
+      process.versions.node !== undefined
+    )
+  }
 }
 
 const {DOMCollection} = prettyFormat.plugins


### PR DESCRIPTION
This reverts commit 76cb73dec444fca7ae3d160b4dad3b61f7bc8995.
Fixes https://github.com/testing-library/dom-testing-library/issues/1322

Will reland in https://github.com/testing-library/dom-testing-library/pull/1323
