### PR TITLE
fix: mock brower event about https://github.com/testing-library/dom-testing-library/issues/1327 

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "aria-query": "5.3.0",
     "chalk": "^4.1.0",
     "dom-accessibility-api": "^0.5.9",
+    "lodash": "^4.17.21",
     "lz-string": "^1.5.0",
     "pretty-format": "^27.0.2"
   },

--- a/src/event-map.js
+++ b/src/event-map.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import _ from 'lodash'
+import {valiateByAttr} from './life-cycle'
 export const eventMap = {
   // Clipboard Events
   copy: {
@@ -112,10 +115,24 @@ export const eventMap = {
   dragOver: {
     EventType: 'DragEvent',
     defaultInit: {bubbles: true, cancelable: true, composed: true},
+    cond: conditionObj => {
+      const shouldTrueAttrArr = ['dragover']
+      const shouldFalseAttrArr = ['defaultprevented']
+      if (valiateByAttr(conditionObj, [], shouldFalseAttrArr)) {
+        return true
+      }
+      if (valiateByAttr(conditionObj, shouldTrueAttrArr, [])) {
+        return true
+      }
+      return false
+    },
   },
   dragStart: {
     EventType: 'DragEvent',
     defaultInit: {bubbles: true, cancelable: true, composed: true},
+    before: (config = {}) => {
+      return _.pick(config, ['dragstart', 'defaultprevented'])
+    },
   },
   drop: {
     EventType: 'DragEvent',

--- a/src/life-cycle.js
+++ b/src/life-cycle.js
@@ -1,0 +1,53 @@
+/**
+ * @description before->cond->dispatch
+ */
+
+export const beforeFn = (
+  initValue,
+  event,
+  before = config => {
+    return config
+  },
+) => {
+  let ConditionValue = initValue
+  if (before && typeof before == 'function') {
+    ConditionValue = before(ConditionValue)
+  }
+  if (!ConditionValue) {
+    ConditionValue = {
+      [`${event.type}`]: true,
+    }
+  }
+  if (ConditionValue) {
+    ConditionValue = {
+      ...ConditionValue,
+      [`${event.type}`]: true,
+    }
+  }
+  return ConditionValue
+}
+
+/**
+ * @description judge attr exist about condition
+ * @param {*} element
+ * @param {*} AttrObj
+ * @returns
+ */
+export function valiateByAttr(element, AttrTrueObj, AttrFalseObj) {
+  if (!element) {
+    return false
+  }
+  let trueFlag = true
+  for (const i in AttrTrueObj) {
+    if (element[`${AttrTrueObj[i]}`]) {
+      trueFlag = false
+    }
+  }
+  let falseFlag = true
+  for (const i in AttrFalseObj) {
+    if (element[`${AttrFalseObj[i]}`]) {
+      falseFlag = false
+    }
+  }
+  return trueFlag && falseFlag
+}


### PR DESCRIPTION
fix https://github.com/testing-library/dom-testing-library/issues/1327   

this pr is about mock brower event



**What**:
This PR adds two new lifecycle methods, `before` and `cond`, developers only need to control these two lifecycles to simulate most browser behaviors..   on top of the existing ones to simulate browser events. This is just a draft; please do not merge.

**Why**:

The events in dom-testing-library are encapsulated based on the native Event class. However, when there are conflicts between this Event and native DOM events, it may not fully replicate the behavior.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->





before this pr, it will trigger `dragstar` and `dragover` event ,it is error because dragstart is prevent，it should only trigger `dragstart` event
after this pr ,when i test this case ,it 'll be as expect

```

test('assigns dataTransfer properties', () => {
  const node = document.createElement('div')
  node.addEventListener('dragstart', (e)=>{
    e.preventDefault()
  })
  node.addEventListener('dragover', (e)=>{
    console.log("dragOver:-------------")
  })
  fireEvent.dragStart(node, {dataTransfer: {dropEffect: 'move'}})
  fireEvent.dragOver(node, {dataTransfer: {dropEffect: 'move'}})
})

```







