### PR TITLE
fix: safer read of DEBUG_PRINT_LIMIT

### DIFF
--- a/src/pretty-dom.js
+++ b/src/pretty-dom.js
@@ -47,7 +47,10 @@ function prettyDOM(dom, maxLength, options = {}) {
   }
   if (typeof maxLength !== 'number') {
     maxLength =
-      (typeof process !== 'undefined' && process.env.DEBUG_PRINT_LIMIT) || 7000
+      (typeof process !== 'undefined' &&
+        typeof process.env !== 'undefined' &&
+        process.env.DEBUG_PRINT_LIMIT) ||
+      7000
   }
 
   if (maxLength === 0) {


### PR DESCRIPTION
**What**:

We encountered some issues on our CI. We use Azure DevOps with this image: `using docker/cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1`. This was the log produces when a test failed (for a different reason):
```
  2) (Site Management) Manage capacity
       Permissions
         Should show the page when user has correct permissions:
     AssertionError: Timed out retrying after 4000ms: Cannot read properties of undefined (reading 'DEBUG_PRINT_LIMIT')
      at Context.eval (webpack:///./src/ui/support/page-permissions.helper.ts:25:0)
```

Apparently process was defined, while process.env was not. I don't see the harm to do this extra check.

**Why**:
To have proper error logging when a test fails.

**How**:
I first used patch-package to patch this library on our codebase with the same change. This unblocked our ci and gave us proper logging of this failing test.

I ran the tests after my changes on this repo and no tests were failing. 

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
