### PR TITLE
feat: Add strictVisibility check option to ByRole queries

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -813,6 +813,37 @@ test('queryAllByRole returns semantic html elements', () => {
   expect(queryAllByRole('listbox')).toHaveLength(1)
 })
 
+test('getAllByRole matchers with strictVisibility enabled and disabled', () => {
+  const {getAllByRole} = render(`
+    <div aria-hidden="true">
+      <button>Aria Hidden Button</button>
+    </div>
+    <div style="display: none;">
+      <button>Display None Button</button>
+    </div>
+    <div style="visibility: hidden;">
+      <button>Visibility Hidden Button</button>
+    </div>
+    <div style="visibility: hidden;">
+      <div>
+        <button>Deep Visibility Hidden Button</button>
+      </div>
+    </div>
+    <div>
+      <button>Visible Button</button>
+    </div>
+  `)
+
+  const defaultResults = getAllByRole('button')
+  expect(defaultResults).toHaveLength(1)
+
+  const strictResults = getAllByRole('button', {strictVisibilityCheck: true})
+  expect(strictResults).toHaveLength(1)
+
+  const looseResults = getAllByRole('button', {strictVisibilityCheck: false})
+  expect(looseResults).toHaveLength(1)
+})
+
 test('getAll* matchers return an array', () => {
   const {
     getAllByAltText,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -24,6 +24,7 @@ import {
   prettyRoles,
   isInaccessible,
   isSubtreeInaccessible,
+  isInaccessibleLoose,
 } from '../role-helpers'
 import {wrapAllByQueryWithSuggestion} from '../query-helpers'
 import {checkContainerType} from '../helpers'
@@ -54,6 +55,7 @@ const queryAllByRole: AllByRole = (
     current,
     level,
     expanded,
+    strictVisibilityCheck = true,
     value: {
       now: valueNow,
       min: valueMin,
@@ -297,9 +299,11 @@ const queryAllByRole: AllByRole = (
     })
     .filter(element => {
       return hidden === false
-        ? isInaccessible(element, {
-            isSubtreeInaccessible: cachedIsSubtreeInaccessible,
-          }) === false
+        ? strictVisibilityCheck
+          ? isInaccessible(element, {
+              isSubtreeInaccessible: cachedIsSubtreeInaccessible,
+            }) === false
+          : isInaccessibleLoose(element) === false
         : true
     })
 }

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -65,6 +65,28 @@ function isInaccessible(element, options = {}) {
   return false
 }
 
+/**
+ * A fast check to see if an element is inaccessible.
+ * @param {Element} element
+ * @returns {boolean} true if exluded, otherwise false
+ */
+function isInaccessibleLoose(element) {
+  do {
+    const explictlyHidden =
+      element.style.visibility === 'hidden' || element.style.display === 'none'
+    if (explictlyHidden) {
+      return true
+    }
+
+    const ariaHidden = element.getAttribute('aria-hidden') === 'true'
+    if (ariaHidden) {
+      return true
+    }
+  } while ((element = element.parentElement))
+
+  return false
+}
+
 function getImplicitAriaRoles(currentNode) {
   // eslint bug here:
   // eslint-disable-next-line no-unused-vars
@@ -382,6 +404,7 @@ export {
   isSubtreeInaccessible,
   prettyRoles,
   isInaccessible,
+  isInaccessibleLoose,
   computeAriaSelected,
   computeAriaBusy,
   computeAriaChecked,

--- a/types/queries.d.ts
+++ b/types/queries.d.ts
@@ -110,6 +110,17 @@ export interface ByRoleOptions {
    * the `aria-level` attribute.
    */
   level?: number
+
+  /**
+   * Whether or not to strictly check the visibliity of the element. Doing so
+   * can cause issues with the performance of tests, because it requires the DOM tree
+   * is traversed, and the `getComputedStyle` function is called on each element.
+   *
+   * If you're finding that your tests are slow, you may want to disable this option.
+   * @default true
+   */
+  strictVisibilityCheck?: boolean
+
   value?: {
     now?: number
     min?: number


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added an option called `strictVisibilityCheck` that defaults to `true` (for now). If `true` it will use the existing code path that does a `getComputedStyle` on each node to check visibility during queries `ByRole`.  If set to `false`, the visibility check settles for a more lose algorithm that doesn't run `getComputedStyle`.

**Why**:

This is being added as a means of improving performance of tests using queries like `getAllByRole` on larger sets of DOM elements, as can be found in many real-world applications. Anecdotally, using this setting fixed one test I had locally from `8000ms` to `500ms` total. (still not great, but miles better).

**How**:

Added an option to the type definition, threaded it through the existing logic, and added a "loose" check for inaccessibility. I added a test with a few checks to make sure the default is still working as expected, and the new setting still works in a similar manner.

It's worth noting that I tried to add a test that checked "indirect" visibility alterations through CSS classes, however, I was unable to get the test harness to recognize the CSS class and trigger layout (I was probably doing something wrong there, happy to follow up).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
