### PR TITLE
chore: replace chalk with picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "@babel/runtime": "^7.12.5",
     "@types/aria-query": "^5.0.1",
     "aria-query": "5.3.0",
-    "chalk": "^4.1.0",
     "dom-accessibility-api": "^0.5.9",
     "lz-string": "^1.5.0",
+    "picocolors": "^1.1.1",
     "pretty-format": "^27.0.2"
   },
   "devDependencies": {

--- a/src/get-user-code-frame.js
+++ b/src/get-user-code-frame.js
@@ -1,17 +1,17 @@
 // We try to load node dependencies
-let chalk = null
+let picocolors = null
 let readFileSync = null
 let codeFrameColumns = null
 
 try {
   const nodeRequire = module && module.require
 
+  picocolors = nodeRequire.call(module, 'picocolors')
   readFileSync = nodeRequire.call(module, 'fs').readFileSync
   codeFrameColumns = nodeRequire.call(
     module,
     '@babel/code-frame',
   ).codeFrameColumns
-  chalk = nodeRequire.call(module, 'chalk')
 } catch {
   // We're in a browser environment
 }
@@ -46,7 +46,7 @@ function getCodeFrame(frame) {
       linesBelow: 0,
     },
   )
-  return `${chalk.dim(frameLocation)}\n${codeFrame}\n`
+  return `${picocolors.dim(frameLocation)}\n${codeFrame}\n`
 }
 
 function getUserCodeFrame() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Replaces chalk and its dependencies, 94 KB of unpacked size in total, with picocolors, doing the same thing, but under 1 KB.

**Why**:

Part of the [e18e initiative](https://e18e.dev/).

**How**:

Drop-in replacement, in this particular case. Yay!

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
