### PR TITLE
Fix 'TypeError: _browserslist.findConfigFile is not a function'

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,16 +51,12 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
-    "caniuse-lite": "1.0.30001502",
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "20.0.0",
     "kcd-scripts": "^13.0.0",
     "typescript": "^4.1.2"
-  },
-  "overrides": {
-    "caniuse-lite": "1.0.30001502"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -23,25 +23,6 @@
   "engines": {
     "node": ">=18"
   },
-  "browserslist": [
-    "and_chr 103",
-    "and_ff 101",
-    "and_qq 10.4",
-    "and_uc 12.12",
-    "android 103",
-    "chrome 102",
-    "edge 102",
-    "firefox 91",
-    "ios_saf 12.2-12.5",
-    "kaios 2.5",
-    "op_mini all",
-    "op_mob 64",
-    "opera 88",
-    "safari 15.5",
-    "samsung 17.0",
-    "samsung 16.0",
-    "node 18.0"
-  ],
   "scripts": {
     "build": "kcd-scripts build  --no-ts-defs --ignore \"**/__tests__/**,**/__node_tests__/**,**/__mocks__/**\" && kcd-scripts build --no-ts-defs --bundle --no-clean",
     "format": "kcd-scripts format",
@@ -70,7 +51,6 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
-    "browserslist": "4.21.8",
     "caniuse-lite": "1.0.30001502",
     "jest-in-case": "^1.0.2",
     "jest-snapshot-serializer-ansi": "^1.0.0",
@@ -80,7 +60,6 @@
     "typescript": "^4.1.2"
   },
   "overrides": {
-    "browserslist": "4.21.8",
     "caniuse-lite": "1.0.30001502"
   },
   "eslintConfig": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I remove browserslist override which was causing errors on: npm run setup -s

<!-- Why are these changes necessary? -->

**Why**:

Have to build.

<!-- How were these changes implemented? -->

**How**:

removed pin in package.json

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- N/A [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- N/A [ ] Tests
- N/A [ ] TypeScript definitions updated
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
