### PR TITLE
fix: getQueriesForElement types

### DIFF
--- a/types/get-queries-for-element.d.ts
+++ b/types/get-queries-for-element.d.ts
@@ -179,4 +179,9 @@ export function getQueriesForElement<
   QueriesToBind extends Queries = typeof queries,
   // Extra type parameter required for reassignment.
   T extends QueriesToBind = QueriesToBind,
->(element: HTMLElement, queriesToBind?: T): BoundFunctions<T>
+  I extends Object = {},
+>(
+  element: HTMLElement,
+  queriesToBind?: T,
+  initialValue?: I,
+): BoundFunctions<T> & I


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix `getQueriesForElement` type.

<!-- Why are these changes necessary? -->

**Why**:

Type definition for `getQueriesForElement` doesn't match the [JS implementation](https://github.com/testing-library/dom-testing-library/blob/a86c54ccda5242ad8dfc1c70d31980bdbf96af7f/src/get-queries-for-element.js#L13).

<!-- How were these changes implemented? -->

**How**:

Add `initialValue` third parameter to the function signature.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
