### PR TITLE
feat: support `checkVisibility` API

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -214,17 +214,8 @@ test.each([
 })
 
 describe('checkVisibility API integration', () => {
-  let originalCheckVisibility
-
   beforeEach(() => {
-    // This may not exist depending on the environment
-    originalCheckVisibility = Element.prototype.checkVisibility
-  })
-
-  afterEach(() => {
-    if (originalCheckVisibility) {
-      Element.prototype.checkVisibility = originalCheckVisibility
-    } else {
+    if (Element.prototype.checkVisibility) {
       delete Element.prototype.checkVisibility
     }
   })
@@ -246,9 +237,6 @@ describe('checkVisibility API integration', () => {
   })
 
   test('falls back to getComputedStyle when checkVisibility unavailable', () => {
-    // Remove checkVisibility to test fallback
-    delete Element.prototype.checkVisibility
-
     const {container} = render('<button style="display: none;">Test</button>')
     const button = container.querySelector('button')
 
@@ -276,10 +264,6 @@ describe('checkVisibility API integration', () => {
       const resultWithoutAPI = isInaccessible(button2)
 
       expect(resultWithAPI).toBe(resultWithoutAPI)
-
-      if (originalCheckVisibility) {
-        Element.prototype.checkVisibility = originalCheckVisibility
-      }
     })
   })
 })


### PR DESCRIPTION
## Background

I work on a test suite that runs exclusively in the browser so I was interested in exploring whether the new-ish `checkVisibility` [API](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) could help speed up `ByRole` queries. I did some not-super-scientific profiling and the key takeaways were:

- Currently, `ByRole` queries are roughly ~2.3x slower than `ByText` queries
- `checkVisibility` is reliably ~30% faster than the equivalent `getComputedStyle` check
- Switching to `checkVisibility` has virtually no impact on the overall query time (put another way, visibility checking isn't the bottleneck in the browser - computing accessible name is)

I don't know that this should necessarily get merged in its current state, but wanted to at least start the discussion and see if my implementation is on the right track. Relatedly, JSDOM has a [PR](https://github.com/jsdom/jsdom/pull/3828) to add `checkVisibility` support, but I have no idea how likely it is to land.

Related to https://github.com/testing-library/dom-testing-library/issues/698
Related to https://github.com/testing-library/dom-testing-library/issues/820
Related to https://github.com/eps1lon/dom-accessibility-api/issues/1060

---

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add (environment-dependent) support for the `checkVisibility` API when calculating element visibility.

<!-- Why are these changes necessary? -->

**Why**: Use modern platform APIs, marginal perf improvement

<!-- How were these changes implemented? -->

**How**: Short-circuit `getComputedStyle` calls with `checkVisibility` calls

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
