### PR TITLE
feat(ByRole): Treat inert subtrees as hidden in role queries

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -205,6 +205,7 @@ test.each([
   ['<div style="display: none;"/>', true],
   ['<div style="visibility: hidden;"/>', true],
   ['<div aria-hidden="true" />', true],
+  ['<div inert />', true],
 ])('shouldExcludeFromA11yTree for %s returns %p', (html, expected) => {
   const {container} = render(html)
   container.firstChild.appendChild(document.createElement('button'))

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -175,6 +175,25 @@ test('by default excludes elements which have aria-hidden="true" or any of their
   `)
 })
 
+test('by default excludes elements which have inert attribute or any of their parents', () => {
+  const {getByRole} = render('<div inert><ul /></div>')
+
+  expect(() => getByRole('list')).toThrowErrorMatchingInlineSnapshot(`
+    Unable to find an accessible element with the role "list"
+
+    There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the \`hidden\` option to \`true\`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+
+    Ignored nodes: comments, script, style
+    <div>
+      <div
+        inert=""
+      >
+        <ul />
+      </div>
+    </div>
+  `)
+})
+
 test('considers the computed visibility style not the parent', () => {
   // this behavior deviates from the spec which includes "any descendant"
   // if visibility is hidden. However, chrome a11y tree and nvda will include

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -21,6 +21,10 @@ function isSubtreeInaccessible(element) {
     return true
   }
 
+  if (element.hasAttribute('inert')) {
+    return true
+  }
+
   const window = element.ownerDocument.defaultView
   if (window.getComputedStyle(element).display === 'none') {
     return true


### PR DESCRIPTION
**What**:

Exclude inert elements in role queries by default.

**Why**:

Align behavior with what is described here https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees:

>  Inert nodes generally cannot be focused, and user agents do not expose the inert nodes to accessibility APIs or assistive technologies.

**How**:

Check presence of `inert` attribute. Since jsdom [does not yet fully support the `inert` attribute](https://github.com/jsdom/jsdom/issues/3605), we use `element.hasAttribute('inert')` instead of `element.inert`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added (https://github.com/testing-library/testing-library-docs/pull/1504)
- [x] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged

fixes #1364