### PR TITLE
feat: Use new `waitForWrapper` around `waitFor` scope 

### DIFF
--- a/src/__tests__/wait-for.js
+++ b/src/__tests__/wait-for.js
@@ -328,7 +328,7 @@ test('does not work after it resolves', async () => {
         return undefined
       }
     },
-    asyncWrapper: async callback => {
+    waitForWrapper: async callback => {
       contextStack.push('no-act:start')
       try {
         await callback()

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,16 @@ let config: InternalConfig = {
   // so we have this config option that's really only intended for
   // react-testing-library to use. For that reason, this feature will remain
   // undocumented.
-  asyncWrapper: cb => cb(),
+  // Turns out other libraries did use that (user-event).
+  // Not actually used by DTL but rather by user-event which uses act() from RTL
+  /* istanbul ignore next */
+  asyncWrapper: /* istanbul ignore next */ cb =>
+    /* istanbul ignore next */ cb(),
+  // For compat with libraries that used asyncWrapper, we add a more specific
+  // "waitForWrapper" that makes it more clear that this is only meant for waitFor.
+  // RTL will use this instead to disable act() during that scope while user-event
+  // can keep relying on the semantics for asyncWrapper.
+  waitForWrapper: cb => cb(),
   unstable_advanceTimersWrapper: cb => cb(),
   eventWrapper: cb => cb(),
   // default value for the `hidden` option in `ByRole` queries

--- a/src/wait-for.js
+++ b/src/wait-for.js
@@ -184,8 +184,8 @@ function waitForWrapper(callback, options) {
   // create the error here so its stack trace is as close to the
   // calling code as possible
   const stackTraceError = new Error('STACK_TRACE_MESSAGE')
-  return getConfig().asyncWrapper(() =>
-    waitFor(callback, {stackTraceError, ...options}),
+  return getConfig().waitForWrapper(
+    waitFor.bind(null, callback, {stackTraceError, ...options}),
   )
 }
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -9,6 +9,8 @@ export interface Config {
   asyncWrapper(cb: (...args: any[]) => any): Promise<any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   eventWrapper(cb: (...args: any[]) => any): void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  waitForWrapper(cb: (...args: any[]) => any): Promise<any>
   asyncUtilTimeout: number
   computedStyleSupportsPseudoElements: boolean
   defaultHidden: boolean


### PR DESCRIPTION
BREAKING CHANGE: `asyncWrapper` is no longer used around `waitFor` scope

`user-event` has started using `asyncWrapper` around small async steps. RTL needs to disable the act environment around `waitFor`. We're resolving this conflict with a new wrapper specific to `waitFor`.

RTL will use `waitFor` to disable act environment and configure `asyncWrapper` to use `act`.  All user-event has to do is ensure it awaits the `fireEvent` since these are now async.