### PR TITLE
fix: propagate hidden flag to computeAccessibleName

### DIFF
--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -197,6 +197,20 @@ test('can include inaccessible roles', () => {
   expect(getByRole('list', {hidden: true})).not.toBeNull()
 })
 
+test('can include inaccessible roles when searching by name', () => {
+  // this behavior deviates from the spec which includes "any descendant"
+  // if visibility is hidden. However, chrome a11y tree and nvda will include
+  // the following markup. This behavior might change depending on how
+  // https://github.com/w3c/aria/issues/1055 is resolved.
+  const {getByRole} = render(
+    '<button>hello <span hidden>hidden</span> world!</button>',
+  )
+
+  expect(
+    getByRole('button', {name: 'hello hidden world!', hidden: true}),
+  ).not.toBeNull()
+})
+
 test('can be filtered by accessible name', () => {
   const {getByRole} = renderIntoDocument(
     `

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -197,11 +197,7 @@ test('can include inaccessible roles', () => {
   expect(getByRole('list', {hidden: true})).not.toBeNull()
 })
 
-test('can include inaccessible roles when searching by name', () => {
-  // this behavior deviates from the spec which includes "any descendant"
-  // if visibility is hidden. However, chrome a11y tree and nvda will include
-  // the following markup. This behavior might change depending on how
-  // https://github.com/w3c/aria/issues/1055 is resolved.
+test('can include hidden elements when searching by accessible name', () => {
   const {getByRole} = render(
     '<button>hello <span hidden>hidden</span> world!</button>',
   )

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -273,6 +273,7 @@ const queryAllByRole: AllByRole = (
         computeAccessibleName(element, {
           computedStyleSupportsPseudoElements:
             getConfig().computedStyleSupportsPseudoElements,
+          hidden,
         }),
         element,
         name as MatcherFunction,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: this PR fixes https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-3434470548

<!-- Why are these changes necessary? -->

**Why**: *ByRole APIs are slow, because the DOM environment relies on `getComputedStyles` to compute elements visibility. This can be mitigated by using the `{ hidden: true }` option. However, when using *ByRole APIs along with the `name` option, the performance toll is still being paid because `computeAccessibleName` is called internally, which does not currently ignore hidden elements.

<!-- How were these changes implemented? -->

**How**: this PR propagates the `hidden` option to `computeAccessibleName`, which avoids paying the performance toll. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
