### PR TITLE
feat: add support for globalThis in event handling functions

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -434,6 +434,35 @@ test('fires events on Document', () => {
   document.removeEventListener('keydown', keyDownSpy)
 })
 
+test('fires events on globalThis', () => {
+  /* eslint-disable no-undef */
+  const clickSpy = jest.fn()
+  globalThis.addEventListener('click', clickSpy)
+  fireEvent.click(globalThis)
+  expect(clickSpy).toHaveBeenCalledTimes(1)
+  globalThis.removeEventListener('click', clickSpy)
+  /* eslint-enable no-undef */
+})
+
+test('fires created events on globalThis', () => {
+  /* eslint-disable no-undef */
+  const spy = jest.fn()
+  globalThis.addEventListener('click', spy)
+  const event = createEvent.click(globalThis)
+  fireEvent(globalThis, event)
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(spy).toHaveBeenCalledWith(event)
+  globalThis.removeEventListener('click', spy)
+  /* eslint-enable no-undef */
+})
+
+test('creates events for globalThis', () => {
+  /* eslint-disable no-undef */
+  const event = createEvent.click(globalThis)
+  expect(event).toBeInstanceOf(MouseEvent)
+  /* eslint-enable no-undef */
+})
+
 test('can create generic events', () => {
   const el = document.createElement('div')
   const eventName = 'my-custom-event'

--- a/types/__tests__/type-tests.ts
+++ b/types/__tests__/type-tests.ts
@@ -210,6 +210,11 @@ export function eventTest() {
   }
   fireEvent.click(element.firstChild)
 
+  // GlobalThis
+  fireEvent.click(globalThis)
+  const globalThisEvent = createEvent('customEvent', globalThis)
+  fireEvent(globalThis, globalThisEvent)
+
   // Custom event
   const customEvent = createEvent('customEvent', element)
   fireEvent(element, customEvent)

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -92,24 +92,24 @@ export type EventType =
   | 'pageShow'
 
 export type FireFunction = (
-  element: Document | Element | Window | Node,
+  element: Document | Element | Window | Node | GlobalThis,
   event: Event,
 ) => boolean
 export type FireObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Window | Node | GlobalThis,
     options?: {},
   ) => boolean
 }
 export type CreateFunction = (
   eventName: string,
-  node: Document | Element | Window | Node,
+  node: Document | Element | Window | Node | GlobalThis,
   init?: {},
   options?: {EventType?: string; defaultInit?: {}},
 ) => Event
 export type CreateObject = {
   [K in EventType]: (
-    element: Document | Element | Window | Node,
+    element: Document | Element | Window | Node | GlobalThis,
     options?: {},
   ) => Event
 }


### PR DESCRIPTION
**What**: Add `GlobalThis` to the event type definitions for `fireEvent` and `createEvent`.

**Why**: `globalThis` is a valid event target (it references `window` in browser environments), but the current type definitions don't accept it. This causes false type errors when firing or creating events on `globalThis`.

**How**: 
- Added `GlobalThis` to the union types in `FireFunction`, `FireObject`, `CreateFunction`, and `CreateObject` in `types/events.d.ts`.
- Added type tests in `types/__tests__/type-tests.ts` to validate `globalThis` is accepted by `fireEvent` and `createEvent`.

**Checklist**:

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged