### PR TITLE
fix: escape square brackets in ID selectors

### DIFF
--- a/src/label-helpers.ts
+++ b/src/label-helpers.ts
@@ -64,7 +64,7 @@ function getLabels(
   return labelsId.length
     ? labelsId.map(labelId => {
         const labellingElement = container.querySelector<HTMLElement>(
-          `[id="${labelId}"]`,
+          `[id="${CSS.escape(labelId)}"]`,
         )
         return labellingElement
           ? {content: getLabelContent(labellingElement), formControl: null}

--- a/src/queries/label-text.ts
+++ b/src/queries/label-text.ts
@@ -173,7 +173,7 @@ function getTagNameOfElementAssociatedWithLabelViaFor(
     return null
   }
 
-  const element = container.querySelector(`[id="${htmlFor}"]`)
+  const element = container.querySelector(`[id="${CSS.escape(htmlFor)}"]`)
   return element ? element.tagName.toLowerCase() : null
 }
 


### PR DESCRIPTION
## Problem

When an element has an ID containing square brackets (e.g. `foo[1].bar`), calling `getByLabelText` (or queries that resolve `aria-labelledby`) throws:

```
SyntaxError: foo[1].bar is not a valid selector
```

This happens because `querySelector("[id=\"foo[1].bar\"]")` interprets `[1]` as a CSS attribute selector, which is invalid.

## Fix

Use `CSS.escape()` to properly escape IDs before interpolating them into attribute selectors. Applied in two locations:

- `src/queries/label-text.ts` — `getTagNameOfElementAssociatedWithLabelViaFor`
- `src/label-helpers.ts` — `getLabels` (aria-labelledby lookup)

`CSS.escape()` is available in all environments supported by dom-testing-library (Node >= 18).

Fixes #1404