### PR TITLE
fix: support inert attribute and <search> element in role queries

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -197,6 +197,13 @@ test('getImplicitAriaRoles returns expected roles for various dom nodes', () => 
   expect(getImplicitAriaRoles(input)).toEqual(['textbox'])
 })
 
+test('getImplicitAriaRoles returns search role for <search> element', () => {
+  const {container} = render('<search>Search content</search>')
+  expect(getImplicitAriaRoles(container.querySelector('search'))).toEqual([
+    'search',
+  ])
+})
+
 test.each([
   ['<div />', false],
   ['<div aria-hidden="false" />', false],
@@ -205,9 +212,17 @@ test.each([
   ['<div style="display: none;"/>', true],
   ['<div style="visibility: hidden;"/>', true],
   ['<div aria-hidden="true" />', true],
+  ['<div inert />', true],
 ])('shouldExcludeFromA11yTree for %s returns %p', (html, expected) => {
   const {container} = render(html)
   container.firstChild.appendChild(document.createElement('button'))
 
   expect(isInaccessible(container.querySelector('button'))).toBe(expected)
+})
+
+test('elements nested in inert subtree are inaccessible', () => {
+  const {container} = render(
+    '<div inert><span><button>click me</button></span></div>',
+  )
+  expect(isInaccessible(container.querySelector('button'))).toBe(true)
 })

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -21,6 +21,10 @@ function isSubtreeInaccessible(element) {
     return true
   }
 
+  if (element.hasAttribute('inert') || element.closest('[inert]')) {
+    return true
+  }
+
   const window = element.ownerDocument.defaultView
   if (window.getComputedStyle(element).display === 'none') {
     return true
@@ -72,6 +76,15 @@ function getImplicitAriaRoles(currentNode) {
     if (match(currentNode)) {
       return [...roles]
     }
+  }
+
+  // Handle elements not yet in aria-query's elementRoles map
+  // See: https://github.com/testing-library/dom-testing-library/issues/1359
+  // The <search> element has an implicit 'search' role per the HTML-ARIA spec
+  // but aria-query 5.3.0 does not include it in elementRoles.
+  // This can be removed once aria-query includes this mapping.
+  if (currentNode.tagName === 'SEARCH') {
+    return ['search']
   }
 
   return []


### PR DESCRIPTION
## Summary

This PR addresses two related issues in role-based queries:

### 1. `inert` attribute not hiding elements from a11y tree (#1364)

Elements with the [`inert`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert) attribute (and their descendants) should be excluded from the accessibility tree. Per the [HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#inert), `inert` makes the element and all its contents hidden from assistive technologies.

**Fix:** Added a check in `isSubtreeInaccessible` that returns `true` when:
- The element itself has the `inert` attribute, OR
- The element has an ancestor with the `inert` attribute (via `element.closest('[inert]')`)

### 2. `<search>` element not found by `getByRole('search')` (#1359)

The `<search>` HTML element has an implicit ARIA role of `search` per the [HTML-ARIA spec](https://www.w3.org/TR/html-aria/#el-search), but `aria-query@5.3.0` does not include this mapping in its `elementRoles` map.

**Fix:** Added a fallback in `getImplicitAriaRoles` that returns `[search]` for `<search>` elements. This workaround can be removed once `aria-query` publishes a version that includes this mapping (the mapping exists in aria-query's `main` branch but is not yet released).

## Test plan

- Added test case for `<div inert />` to the existing `shouldExcludeFromA11yTree` test matrix
- Added test case for elements nested inside an inert subtree
- Added test case for `<search>` element implicit role
- All 669 existing tests pass
- Full test suite passes: `29 passed, 29 total`

## Related issues

- Fixes #1364
- Fixes #1359