### PR TITLE
fix: wrap filterNode in arrow function to ignore extra callback args

### DIFF
--- a/src/DOMElementFilter.ts
+++ b/src/DOMElementFilter.ts
@@ -253,7 +253,7 @@ export default function createDOMElementFilter(
         printChildren(
           Array.prototype.slice
             .call(node.childNodes || node.children)
-            .filter(filterNode),
+            .filter(node => filterNode(node)),
           config,
           indentation + config.indent,
           depth,


### PR DESCRIPTION
Fixes #1360

When printing filtered DOM nodes, Array.prototype.filter passes three arguments (element, index, array) to the callback, but filterNode expects only (node: Node). While this works in JS due to ignored extra arguments, wrapping with an explicit arrow function `.filter(node => filterNode(node))` ensures only the element is passed, matching the type signature.