### PR TITLE
Fix getByTitle for nested SVG title elements

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -642,6 +642,23 @@ test('query/get title element of SVG', () => {
   expect(queryByTitle('Close').id).toEqual('svg-title')
 })
 
+test('query/get nested title element of SVG graphics element', () => {
+  const {getByTitle, queryByTitle} = render(`
+    <div>
+        <svg>
+            <g>
+              <path id="svg-path">
+                <title>Close</title>
+              </path>
+            </g>
+        </svg>
+    </div>
+  `)
+
+  expect(getByTitle('Close').id).toEqual('svg-path')
+  expect(queryByTitle('Close').id).toEqual('svg-path')
+})
+
 test('queryByTitle matches case with non-string matcher', () => {
   const {queryByTitle} = render(`<span title="1" />`)
   expect(queryByTitle(1)).toBeTruthy()

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -14,9 +14,21 @@ import {
   buildQueries,
 } from './all-utils'
 
-const isSvgTitle = (node: HTMLElement) =>
-  node.tagName.toLowerCase() === 'title' &&
-  node.parentElement?.tagName.toLowerCase() === 'svg'
+const getSvgTitleOwner = (node: HTMLElement) => {
+  if (
+    node.tagName.toLowerCase() !== 'title' ||
+    node.namespaceURI !== 'http://www.w3.org/2000/svg'
+  ) {
+    return null
+  }
+
+  const parent = node.parentElement
+  if (!parent || parent.tagName.toLowerCase() === 'svg') {
+    return node
+  }
+
+  return parent
+}
 
 const queryAllByTitle: AllByBoundAttribute = (
   container,
@@ -26,14 +38,25 @@ const queryAllByTitle: AllByBoundAttribute = (
   checkContainerType(container)
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
-  return Array.from(
-    container.querySelectorAll<HTMLElement>('[title], svg > title'),
-  ).filter(
-    node =>
-      matcher(node.getAttribute('title'), node, text, matchNormalizer) ||
-      (isSvgTitle(node) &&
-        matcher(getNodeText(node), node, text, matchNormalizer)),
-  )
+  const results = new Set<HTMLElement>()
+
+  Array.from(
+    container.querySelectorAll<HTMLElement>('[title], svg title'),
+  ).forEach(node => {
+    if (matcher(node.getAttribute('title'), node, text, matchNormalizer)) {
+      results.add(node)
+    }
+
+    const svgTitleOwner = getSvgTitleOwner(node)
+    if (
+      svgTitleOwner &&
+      matcher(getNodeText(node), svgTitleOwner, text, matchNormalizer)
+    ) {
+      results.add(svgTitleOwner)
+    }
+  })
+
+  return Array.from(results)
 }
 
 const getMultipleError: GetErrorFunction<[unknown]> = (c, title) =>


### PR DESCRIPTION
**What**:

Fixes #974 by allowing `ByTitle` queries to match SVG `<title>` elements nested under SVG graphics elements.

**Why**:

`getByTitle('Close')` currently only finds direct `svg > title` elements, so an SVG like `<path><title>Close</title></path>` cannot be queried by title even though the title labels the graphics element.

**How**:

The title query now scans SVG title descendants and resolves a matched nested SVG title to the element it labels. The existing direct `svg > title` behavior is preserved. A regression test covers the nested `<path><title>...</title></path>` case.

**Checklist**:

- [x] Documentation added to the docs site: N/A, bug fix covered by tests
- [x] Tests
- [x] TypeScript definitions updated: N/A, no type changes
- [x] Ready to be merged