### PR TITLE
fix(title): find nested SVG title elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "typescript": "^4.1.2"
   },
   "overrides": {
+    "@types/node": "18.19.0",
     "@babel/helper-compilation-targets": "7.24.7",
     "browserslist": "4.21.8",
     "caniuse-lite": "1.0.30001502"

--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -642,6 +642,23 @@ test('query/get title element of SVG', () => {
   expect(queryByTitle('Close').id).toEqual('svg-title')
 })
 
+test('query/get nested title element of SVG', () => {
+  const {getByTitle, queryByTitle} = render(`
+    <div>
+        <svg>
+            <g>
+              <path>
+                <title id="svg-path-title">Close</title>
+              </path>
+            </g>
+        </svg>
+    </div>
+  `)
+
+  expect(getByTitle('Close').id).toEqual('svg-path-title')
+  expect(queryByTitle('Close').id).toEqual('svg-path-title')
+})
+
 test('queryByTitle matches case with non-string matcher', () => {
   const {queryByTitle} = render(`<span title="1" />`)
   expect(queryByTitle(1)).toBeTruthy()

--- a/src/queries/title.ts
+++ b/src/queries/title.ts
@@ -15,8 +15,7 @@ import {
 } from './all-utils'
 
 const isSvgTitle = (node: HTMLElement) =>
-  node.tagName.toLowerCase() === 'title' &&
-  node.parentElement?.tagName.toLowerCase() === 'svg'
+  node.tagName.toLowerCase() === 'title' && node.closest('svg') !== null
 
 const queryAllByTitle: AllByBoundAttribute = (
   container,
@@ -27,7 +26,7 @@ const queryAllByTitle: AllByBoundAttribute = (
   const matcher = exact ? matches : fuzzyMatches
   const matchNormalizer = makeNormalizer({collapseWhitespace, trim, normalizer})
   return Array.from(
-    container.querySelectorAll<HTMLElement>('[title], svg > title'),
+    container.querySelectorAll<HTMLElement>('[title], svg title'),
   ).filter(
     node =>
       matcher(node.getAttribute('title'), node, text, matchNormalizer) ||


### PR DESCRIPTION
## What changed

Allow `ByTitle` queries to match SVG `<title>` elements nested below SVG graphics/container elements, not only direct `svg > title` children.

## Why

SVG titles can be attached to nested graphics elements such as `<path><title>...</title></path>`. The previous selector only considered direct children of `<svg>`, so `getByTitle` could not find those valid nested title elements.

Fixes #974

## Validation

- `npm test -- --runTestsByPath src/__tests__/element-queries.js --runInBand --watch=false`

Note: the full local `validate` step is currently blocked in this checkout by `@types/node/ffi.d.ts` syntax errors from the repository's dependency/TypeScript version combination, before this PR's code is involved.
