### PR TITLE
fix: support the <search> element in role queries

### DIFF
--- a/src/__tests__/role-helpers.js
+++ b/src/__tests__/role-helpers.js
@@ -197,6 +197,14 @@ test('getImplicitAriaRoles returns expected roles for various dom nodes', () => 
   expect(getImplicitAriaRoles(input)).toEqual(['textbox'])
 })
 
+test('getImplicitAriaRoles returns search role for a <search> element', () => {
+  const {container} = render('<search>content</search>')
+
+  expect(getImplicitAriaRoles(container.querySelector('search'))).toEqual([
+    'search',
+  ])
+})
+
 test.each([
   ['<div />', false],
   ['<div aria-hidden="false" />', false],

--- a/src/__tests__/role.js
+++ b/src/__tests__/role.js
@@ -56,6 +56,13 @@ test('when hidden: true logs available roles when it fails', () => {
   `)
 })
 
+test('can be found by its implicit role when using a <search> element', () => {
+  const {getByRole, container} = render(
+    '<search><input type="search" /></search>',
+  )
+  expect(getByRole('search')).toBe(container.querySelector('search'))
+})
+
 test('logs error when there are no accessible roles', () => {
   const {getByRole} = render('<div />')
   expect(() => getByRole('article')).toThrowErrorMatchingInlineSnapshot(`

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -313,6 +313,15 @@ function makeRoleSelector(role: ByRoleMatcher) {
     Array.from(roleRelations).map(({name}) => name),
   )
 
+  // aria-query 5.3.0 does not map the `<search>` element to its implicit
+  // `search` role, so it is missing from `roleElements`. Add it here to keep
+  // the candidate selector in sync with `getImplicitAriaRoles`. This can be
+  // removed once aria-query maps `<search>`.
+  // https://github.com/testing-library/dom-testing-library/issues/1359
+  if (role === 'search') {
+    implicitRoleSelectors.add('search')
+  }
+
   // Current transpilation config sometimes assumes `...` is always applied to arrays.
   // `...` is equivalent to `Array.prototype.concat` for arrays.
   // If you replace this code with `[explicitRoleSelector, ...implicitRoleSelectors]`, make sure every transpilation target retains the `...` in favor of `Array.prototype.concat`.

--- a/src/role-helpers.js
+++ b/src/role-helpers.js
@@ -74,6 +74,14 @@ function getImplicitAriaRoles(currentNode) {
     }
   }
 
+  // The `<search>` element has an implicit `search` role per the HTML-ARIA
+  // spec, but aria-query 5.3.0 does not include it in `elementRoles`, so it
+  // never matches above. This can be removed once aria-query maps `<search>`.
+  // https://github.com/testing-library/dom-testing-library/issues/1359
+  if (currentNode.tagName === 'SEARCH') {
+    return ['search']
+  }
+
   return []
 }
 


### PR DESCRIPTION
Closes #1359

The `<search>` element has an implicit ARIA role of `search` per the HTML-AAM spec, but `aria-query@5.3.0` doesn't map it. As a result `getByRole('search')` can't find a `<search>` element, and `getImplicitAriaRoles` returns `[]` for it.

The fix adds `<search>` in the **two** places that consume aria-query's maps:
- `getImplicitAriaRoles` (computes an element's implicit role)
- `makeRoleSelector` (builds the candidate set for a role query)

Both are gated behind a comment noting they can be removed once aria-query maps `<search>`. I found that patching only `getImplicitAriaRoles` (as in the earlier #1376) isn't enough — `makeRoleSelector` filters the candidate elements first, so `<search>` never reaches the role check. The added integration test (`getByRole('search')`) covers that path; there's also a unit test for `getImplicitAriaRoles`.

Full suite green (668 tests). #1376's contentious `inert` change is intentionally left out — this is only the uncontroversial `<search>` support.
