### PR TITLE
fix(deps): pin @types/node to a TypeScript 4-compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "overrides": {
     "@babel/helper-compilation-targets": "7.24.7",
+    "@types/node": "20.14.0",
     "browserslist": "4.21.8",
     "caniuse-lite": "1.0.30001502"
   },


### PR DESCRIPTION
There's no committed lockfile, so CI installs the latest `@types/node` on every run. Recent `@types/node` ships declaration syntax (e.g. in `ffi.d.ts`) that the pinned `typescript@^4.1.2` can't parse, so `validate` fails the typecheck on PRs for reasons unrelated to the change under test (currently affecting several open PRs, including #1385).

This pins `@types/node` via the existing `overrides` block — alongside the other transitive pins already there — to a version that typechecks under TypeScript 4. Verified: `validate` (typecheck + lint + tests) is green with the pin. It can be dropped once the project moves to TypeScript 5 or commits a lockfile.
