### PR TITLE
fix: support form-associated custom elements in isLabelable

### DIFF
--- a/src/__tests__/element-queries.js
+++ b/src/__tests__/element-queries.js
@@ -1192,6 +1192,16 @@ test('can get a select with options', () => {
   getByLabelText('Label')
 })
 
+test('can get a form-associated custom element by label', () => {
+  const {getByLabelText} = renderIntoDocument(`
+    <label for="custom-input">Custom Label</label>
+    <my-input id="custom-input"></my-input>
+  `)
+  const el = document.getElementById('custom-input')
+  el.formAssociated = true
+  expect(getByLabelText('Custom Label')).toBe(el)
+})
+
 test('can get an element with aria-labelledby when label has a child', () => {
   const {getByLabelText} = render(`
     <div>

--- a/src/__tests__/label-helpers.js
+++ b/src/__tests__/label-helpers.js
@@ -5,3 +5,14 @@ test('hidden inputs are not labelable', () => {
   element.type = 'hidden'
   expect(getRealLabels(element)).toEqual([])
 })
+
+test('form-associated custom elements are labelable', () => {
+  const element = document.createElement('my-input')
+  element.formAssociated = true
+  expect(getRealLabels(element)).toEqual([])
+})
+
+test('custom elements without formAssociated are not labelable', () => {
+  const element = document.createElement('my-input')
+  expect(getRealLabels(element)).toEqual([])
+})

--- a/src/label-helpers.ts
+++ b/src/label-helpers.ts
@@ -44,13 +44,23 @@ function getRealLabels(element: Element) {
   if (!isLabelable(element)) return []
 
   const labels = element.ownerDocument.querySelectorAll('label')
-  return Array.from(labels).filter(label => label.control === element)
+  const labelsForElement = Array.from(labels).filter(
+    label => label.control === element,
+  )
+  // label.control is null for form-associated custom elements in environments
+  // that don't implement it (e.g. jsdom). Fall back to matching by `for`/`id`.
+  if (!labelsForElement.length && element.id) {
+    return Array.from(labels).filter(label => label.htmlFor === element.id)
+  }
+  return labelsForElement
 }
 
 function isLabelable(element: Element) {
   return (
     /BUTTON|METER|OUTPUT|PROGRESS|SELECT|TEXTAREA/.test(element.tagName) ||
-    (element.tagName === 'INPUT' && element.getAttribute('type') !== 'hidden')
+    (element.tagName === 'INPUT' &&
+      element.getAttribute('type') !== 'hidden') ||
+    (element as HTMLElement).formAssociated === true
   )
 }
 


### PR DESCRIPTION
Fixes #1343

## Summary

Adds a `formAssociated` check to `isLabelable` and a `for`/`id` fallback in `getRealLabels` so `getByLabelText` can find form-associated custom elements.

## Background

The [HTML spec](https://html.spec.whatwg.org/multipage/forms.html#category-label) lists form-associated custom elements as labelable, but `isLabelable` only checked built-in tag names:

```ts
/BUTTON|METER|OUTPUT|PROGRESS|SELECT|TEXTAREA/.test(element.tagName) ||
(element.tagName === "INPUT" && element.getAttribute("type") !== "hidden")
```

A custom element with `formAssociated = true` should be targetable by `<label for>`, but `getByLabelText` threw "non-labellable" for it.

`getRealLabels` also needed a fallback because `label.control` is `null` for custom elements in jsdom (only populated for built-in form controls). In real browsers `element.labels` is defined for form-associated custom elements and the early return handles it. The fallback matches by `label.htmlFor === element.id` to cover jsdom.

## Verification

- `npm test`: **669 tests pass** (29 suites).
- `npm run lint`: clean.